### PR TITLE
Improve texify and fmt subcommands

### DIFF
--- a/app/src/cli/texify.rs
+++ b/app/src/cli/texify.rs
@@ -55,7 +55,7 @@ pub struct Args {
     output: Option<PathBuf>,
 }
 
-/// Compute the output stream for the "texify" command.
+/// Compute the output stream for the "texify" subcommand.
 /// If an output filepath is specified, then that filepath is used.
 /// Otherwise, the file extension is replaced by the `.tex` file extension.
 fn compute_output_stream(cmd: &Args) -> Box<dyn io::Write> {
@@ -77,7 +77,6 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
 
     let prg = view.ust().map_err(|err| view.pretty_error(err))?;
 
-    // Write to file or to stdout
     let mut stream: Box<dyn io::Write> = compute_output_stream(&cmd);
 
     let cfg =


### PR DESCRIPTION
Change the behaviour of `xfunc fmt` and `xfunc texify`.

- The default behaviour of `xfunc texify`, i.e. if an output file is not specified, is to replace the extension by `.tex` and print to that file. Previously, the output was to the commandline.
- The `xfunc fmt` subcommand has an `--inplace` flag which sets the output to the input file and formats the file inplace.