### PR TITLE
Use struct for Ctx

### DIFF
--- a/lang/core/src/ctx.rs
+++ b/lang/core/src/ctx.rs
@@ -6,13 +6,35 @@ use std::rc::Rc;
 
 use syntax::common::*;
 use syntax::ctx::values::TypeCtx;
+use syntax::ctx::{Context, HasContext};
 use syntax::ust;
 
 use crate::eval::Eval;
 use crate::read_back::ReadBack;
 use crate::TypeError;
 
-pub type Ctx = TypeCtx;
+//pub type Ctx = TypeCtx;
+
+pub struct Ctx {
+    pub vars: TypeCtx,
+}
+
+impl Ctx {
+    pub fn empty() -> Self {
+        Self { vars: TypeCtx::empty() }
+    }
+    pub fn new(vars: TypeCtx) -> Self {
+        Self { vars }
+    }
+}
+
+impl HasContext for Ctx {
+    type Ctx = TypeCtx;
+
+    fn ctx_mut(&mut self) -> &mut Self::Ctx {
+        &mut self.vars
+    }
+}
 
 pub trait ContextSubstExt: Sized {
     fn subst<S: Substitution<Rc<ust::Exp>>>(
@@ -22,7 +44,7 @@ pub trait ContextSubstExt: Sized {
     ) -> Result<Self, TypeError>;
 }
 
-impl ContextSubstExt for Ctx {
+impl ContextSubstExt for TypeCtx {
     fn subst<S: Substitution<Rc<ust::Exp>>>(
         &self,
         prg: &ust::Prg,


### PR DESCRIPTION
In order to add a name generator for (co)matches, we need to extend the Ctx data type.
This is preliminary work to enable that
