### PR TITLE
Omit type signature of constructor if it is trivial

### DIFF
--- a/lang/printer/src/ast.rs
+++ b/lang/printer/src/ast.rs
@@ -263,10 +263,12 @@ where
 {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Dtor { info: _, name, params, self_param, ret_typ } = self;
-        self_param
-            .print(cfg, alloc)
-            .append(DOT)
-            .append(alloc.dtor(name))
+        let head = if self_param.is_simple() {
+            alloc.nil()
+        } else {
+            self_param.print(cfg, alloc).append(DOT)
+        };
+        head.append(alloc.dtor(name))
             .append(params.print(cfg, alloc))
             .append(alloc.space())
             .append(COLON)

--- a/lang/syntax/src/trees/ast/generic/def.rs
+++ b/lang/syntax/src/trees/ast/generic/def.rs
@@ -326,6 +326,12 @@ impl<P: Phase> SelfParam<P> {
             }],
         }
     }
+
+    /// A self parameter is simple if the list of arguments to the type is empty, and the name is None.
+    /// If the self parameter is simple, we can omit it during prettyprinting.
+    pub fn is_simple(&self) -> bool {
+        self.typ.is_simple() && self.name.is_none()
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Example output:
```
data Ctx {
    Nil,
    Cons(t: Typ, ts: Ctx)
}
```