### PR TITLE
Omit whitespace before colon in prettyprinter

### DIFF
--- a/lang/printer/src/ast.rs
+++ b/lang/printer/src/ast.rs
@@ -211,7 +211,6 @@ where
             .append(DOT)
             .append(alloc.dtor(name))
             .append(params.print(cfg, alloc))
-            .append(alloc.space())
             .append(COLON)
             .append(alloc.space())
             .append(ret_typ.print(cfg, alloc));
@@ -238,7 +237,6 @@ where
             .append(alloc.space())
             .append(alloc.ctor(name))
             .append(params.print(cfg, alloc))
-            .append(alloc.space())
             .append(COLON)
             .append(alloc.space())
             .append(typ.print(cfg, alloc));
@@ -261,10 +259,7 @@ where
         if typ.is_simple() {
             head
         } else {
-            head.append(alloc.space())
-                .append(COLON)
-                .append(alloc.space())
-                .append(typ.print(cfg, alloc))
+            head.append(COLON).append(alloc.space()).append(typ.print(cfg, alloc))
         }
     }
 }
@@ -283,7 +278,6 @@ where
         };
         head.append(alloc.dtor(name))
             .append(params.print(cfg, alloc))
-            .append(alloc.space())
             .append(COLON)
             .append(alloc.space())
             .append(ret_typ.print(cfg, alloc))


### PR DESCRIPTION
Fixes #54

```
-- | The non-dependent function type.
codata Fun(a b: Type) { Fun(a, b).ap(a b: Type, x: a): b }

-- | The dependent function type.
codata Π(a: Type, p: Fun(a, Type)) { Π(a, p).pi_elim(a: Type, p: Fun(a, Type), x: a): p.ap(a, Type, x) }

-- | The dependent sum type.
data Σ(a: Type, p: Fun(a, Type)) { Exists(a: Type, p: Fun(a, Type), x: a, prf: p.ap(a, Type, x)): Σ(a, p) }

data Sum(a b: Type) {
    -- | The left injection into a sum.
    Inl(a b: Type, x: a): Sum(a, b),
    -- | The right injection into a sum.
    Inr(a b: Type, x: b): Sum(a, b)
}

```