### PR TITLE
Optimize prettyprinting of data and codata declarations

### DIFF
--- a/lang/printer/src/ast.rs
+++ b/lang/printer/src/ast.rs
@@ -141,8 +141,10 @@ where
                 .nest(cfg.indent)
                 .append(alloc.line())
                 .braces_from(cfg)
-                .group()
         };
+
+        let body = if typ.params.is_empty() { body.group() } else { body };
+
         head.append(body)
     }
 }
@@ -186,8 +188,9 @@ where
                 .nest(cfg.indent)
                 .append(alloc.line())
                 .braces_from(cfg)
-                .group()
         };
+
+        let body = if typ.params.is_empty() { body.group() } else { body };
 
         head.append(body)
     }


### PR DESCRIPTION
We discussed this in person: We only want to put data/codata declarations on one line if the type is not parameterized.