### PR TITLE
Merge EvalError, ReadBackError and NormalizeError

### DIFF
--- a/lang/core/src/normalize.rs
+++ b/lang/core/src/normalize.rs
@@ -8,7 +8,7 @@ use super::result::*;
 pub trait Normalize {
     type Nf;
 
-    fn normalize(&self, prg: &ust::Prg, env: &mut Env) -> Result<Self::Nf, NormalizeError>;
+    fn normalize(&self, prg: &ust::Prg, env: &mut Env) -> Result<Self::Nf, EvalError>;
 }
 
 impl<T> Normalize for T
@@ -18,8 +18,8 @@ where
 {
     type Nf = <<T as Eval>::Val as ReadBack>::Nf;
 
-    fn normalize(&self, prg: &ust::Prg, env: &mut Env) -> Result<Self::Nf, NormalizeError> {
-        let val = self.eval(prg, env).map_err(NormalizeError::Eval)?;
-        val.read_back(prg).map_err(NormalizeError::ReadBack)
+    fn normalize(&self, prg: &ust::Prg, env: &mut Env) -> Result<Self::Nf, EvalError> {
+        let val = self.eval(prg, env)?;
+        val.read_back(prg)
     }
 }

--- a/lang/core/src/read_back.rs
+++ b/lang/core/src/read_back.rs
@@ -14,14 +14,14 @@ use super::result::*;
 pub trait ReadBack {
     type Nf;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError>;
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError>;
 }
 
 impl ReadBack for val::Val {
     type Nf = nf::Nf;
 
     #[trace("↓{:P} ~> {return:P}", self, data::id)]
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let res = match self {
             val::Val::TypCtor { info, name, args } => nf::Nf::TypCtor {
                 info: info.clone(),
@@ -46,7 +46,7 @@ impl ReadBack for val::Val {
 impl ReadBack for val::Neu {
     type Nf = nf::Neu;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let res = match self {
             val::Neu::Var { info, name, idx } => {
                 nf::Neu::Var { info: info.clone(), name: name.clone(), idx: *idx }
@@ -72,7 +72,7 @@ impl ReadBack for val::Neu {
 impl ReadBack for val::Match {
     type Nf = nf::Match;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let val::Match { info, cases } = self;
         Ok(nf::Match { info: info.clone(), cases: cases.read_back(prg)? })
     }
@@ -81,7 +81,7 @@ impl ReadBack for val::Match {
 impl ReadBack for val::Comatch {
     type Nf = nf::Comatch;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let val::Comatch { info, cases } = self;
         Ok(nf::Comatch { info: info.clone(), cases: cases.read_back(prg)? })
     }
@@ -90,7 +90,7 @@ impl ReadBack for val::Comatch {
 impl ReadBack for val::Case {
     type Nf = nf::Case;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let val::Case { info, name, args, body } = self;
 
         Ok(nf::Case {
@@ -105,7 +105,7 @@ impl ReadBack for val::Case {
 impl ReadBack for val::Cocase {
     type Nf = nf::Cocase;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let val::Cocase { info, name, args, body } = self;
 
         Ok(nf::Cocase {
@@ -120,7 +120,7 @@ impl ReadBack for val::Cocase {
 impl ReadBack for val::TypApp {
     type Nf = nf::TypApp;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let val::TypApp { info, name, args } = self;
 
         Ok(nf::TypApp { info: info.clone(), name: name.clone(), args: args.read_back(prg)? })
@@ -130,7 +130,7 @@ impl ReadBack for val::TypApp {
 impl ReadBack for val::Closure {
     type Nf = Rc<nf::Nf>;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         let args: Vec<Rc<val::Val>> = (0..self.n_args)
             .rev()
             .map(|snd| val::Val::Neu {
@@ -152,7 +152,7 @@ impl ReadBack for val::Closure {
 impl<T: ReadBack> ReadBack for Vec<T> {
     type Nf = Vec<T::Nf>;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         self.iter().map(|x| x.read_back(prg)).collect()
     }
 }
@@ -160,7 +160,7 @@ impl<T: ReadBack> ReadBack for Vec<T> {
 impl<T: ReadBack> ReadBack for Rc<T> {
     type Nf = Rc<T::Nf>;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         (**self).read_back(prg).map(Rc::new)
     }
 }
@@ -168,7 +168,7 @@ impl<T: ReadBack> ReadBack for Rc<T> {
 impl<T: ReadBack> ReadBack for Option<T> {
     type Nf = Option<T::Nf>;
 
-    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, ReadBackError> {
+    fn read_back(&self, prg: &Prg) -> Result<Self::Nf, EvalError> {
         self.as_ref().map(|x| x.read_back(prg)).transpose()
     }
 }

--- a/lang/core/src/result.rs
+++ b/lang/core/src/result.rs
@@ -109,7 +109,7 @@ pub enum TypeError {
     Unify(#[from] UnifyError),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Normalize(#[from] NormalizeError),
+    Eval(#[from] EvalError),
 }
 
 impl TypeError {
@@ -148,26 +148,6 @@ impl TypeError {
     }
 }
 
-impl From<EvalError> for TypeError {
-    fn from(err: EvalError) -> Self {
-        Self::Normalize(err.into())
-    }
-}
-
-impl From<ReadBackError> for TypeError {
-    fn from(err: ReadBackError) -> Self {
-        Self::Normalize(err.into())
-    }
-}
-
-#[derive(Error, Diagnostic, Debug)]
-#[error(transparent)]
-#[diagnostic(transparent)]
-pub enum NormalizeError {
-    Eval(#[from] EvalError),
-    ReadBack(#[from] ReadBackError),
-}
-
 #[derive(Error, Diagnostic, Debug)]
 pub enum EvalError {
     #[error("The impossible happened: {message}")]
@@ -179,13 +159,6 @@ pub enum EvalError {
         #[label]
         span: Option<SourceSpan>,
     },
-}
-
-#[derive(Error, Diagnostic, Debug)]
-#[diagnostic(transparent)]
-#[error(transparent)]
-pub enum ReadBackError {
-    Eval(#[from] EvalError),
 }
 
 #[derive(Error, Diagnostic, Debug)]


### PR DESCRIPTION
A small simpification by merging the three different kinds of errors. Most of them are empty anyway, so there is no point in having the complicated relationship between the different kinds of errors.