### PR TITLE
Slight refactoring of cst types and lowering

### DIFF
--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -161,20 +161,37 @@ pub enum DeclKind {
     Dtor { self_typ: Ident },
 }
 
-impl From<&cst::TypDecl> for DeclKind {
-    fn from(decl: &cst::TypDecl) -> Self {
-        match decl {
-            cst::TypDecl::Data(data) => Self::Data { arity: data.params.len() },
-            cst::TypDecl::Codata(codata) => Self::Codata { arity: codata.params.len() },
-        }
+impl From<&cst::Data> for DeclKind {
+    fn from(data: &cst::Data) -> Self {
+        Self::Data { arity: data.params.len() }
     }
 }
 
-impl From<&cst::DefDecl> for DeclKind {
-    fn from(decl: &cst::DefDecl) -> Self {
+impl From<&cst::Codata> for DeclKind {
+    fn from(codata: &cst::Codata) -> Self {
+        Self::Codata { arity: codata.params.len() }
+    }
+}
+
+impl From<&cst::Def> for DeclKind {
+    fn from(_def: &cst::Def) -> Self {
+        Self::Def
+    }
+}
+
+impl From<&cst::Codef> for DeclKind {
+    fn from(_codef: &cst::Codef) -> Self {
+        Self::Codef
+    }
+}
+
+impl From<&cst::Item> for DeclKind {
+    fn from(decl: &cst::Item) -> Self {
         match decl {
-            cst::DefDecl::Def(_) => Self::Def,
-            cst::DefDecl::Codef(_) => Self::Codef,
+            cst::Item::Data(data) => DeclKind::from(data),
+            cst::Item::Codata(codata) => DeclKind::from(codata),
+            cst::Item::Def(_def) => Self::Def,
+            cst::Item::Codef(_codef) => Self::Codef,
         }
     }
 }

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -84,18 +84,10 @@ pub Prg: Prg = {
 }
 
 pub Item: Item = {
-    <decl: TypDecl> => Item::Type(decl),
-    <decl: DefDecl> => Item::Def(decl),
-}
-
-pub TypDecl: TypDecl = {
-    <l: @L> <doc: DocComment?> <hidden: Hidden> "data" <name: UpperIdent> <params: OptTelescope> "{" <ctors: Comma<Ctor>> "}" <r: @R> => TypDecl::Data(Data { info: span(l, r), doc, name, hidden, params, ctors }),
-    <l: @L> <doc: DocComment?> <hidden: Hidden> "codata" <name: UpperIdent> <params: OptTelescope> "{" <dtors: Comma<Dtor>> "}" <r: @R> => TypDecl::Codata(Codata { info: span(l, r), doc, name, hidden, params, dtors }),
-}
-
-pub DefDecl: DefDecl = {
-    <l: @L> <doc: DocComment?> <hidden: Hidden> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <body: Match> "}" <r: @R> => DefDecl::Def(Def { info: span(l, r), doc, name, hidden, params, scrutinee, ret_typ, body }),
-    <l: @L> <doc: DocComment?> <hidden: Hidden> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <body: Comatch> "}" <r: @R> => DefDecl::Codef(Codef { info: span(l, r), doc, name, hidden, params, typ, body }),
+    <l: @L> <doc: DocComment?> <hidden: Hidden> "data" <name: UpperIdent> <params: OptTelescope> "{" <ctors: Comma<Ctor>> "}" <r: @R> => Item::Data(Data { info: span(l, r), doc, name, hidden, params, ctors }),
+    <l: @L> <doc: DocComment?> <hidden: Hidden> "codata" <name: UpperIdent> <params: OptTelescope> "{" <dtors: Comma<Dtor>> "}" <r: @R> => Item::Codata(Codata { info: span(l, r), doc, name, hidden, params, dtors }),
+    <l: @L> <doc: DocComment?> <hidden: Hidden> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <body: Match> "}" <r: @R> => Item::Def(Def { info: span(l, r), doc, name, hidden, params, scrutinee, ret_typ, body }),
+    <l: @L> <doc: DocComment?> <hidden: Hidden> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <body: Comatch> "}" <r: @R> => Item::Codef(Codef { info: span(l, r), doc, name, hidden, params, typ, body }),
 }
 
 Ctor: Ctor = {

--- a/lang/syntax/src/common/named.rs
+++ b/lang/syntax/src/common/named.rs
@@ -9,26 +9,10 @@ pub trait Named {
 impl Named for cst::Item {
     fn name(&self) -> &Ident {
         match self {
-            cst::Item::Type(typ_decl) => typ_decl.name(),
-            cst::Item::Def(def_decl) => def_decl.name(),
-        }
-    }
-}
-
-impl Named for cst::TypDecl {
-    fn name(&self) -> &Ident {
-        match self {
-            cst::TypDecl::Data(cst::Data { name, .. }) => name,
-            cst::TypDecl::Codata(cst::Codata { name, .. }) => name,
-        }
-    }
-}
-
-impl Named for cst::DefDecl {
-    fn name(&self) -> &Ident {
-        match self {
-            cst::DefDecl::Def(cst::Def { name, .. }) => name,
-            cst::DefDecl::Codef(cst::Codef { name, .. }) => name,
+            cst::Item::Data(cst::Data { name, .. }) => name,
+            cst::Item::Codata(cst::Codata { name, .. }) => name,
+            cst::Item::Def(cst::Def { name, .. }) => name,
+            cst::Item::Codef(cst::Codef { name, .. }) => name,
         }
     }
 }

--- a/lang/syntax/src/trees/cst.rs
+++ b/lang/syntax/src/trees/cst.rs
@@ -15,14 +15,10 @@ pub struct Prg {
 
 #[derive(Debug, Clone)]
 pub enum Item {
-    Type(TypDecl),
-    Def(DefDecl),
-}
-
-#[derive(Debug, Clone)]
-pub enum TypDecl {
     Data(Data),
     Codata(Codata),
+    Def(Def),
+    Codef(Codef),
 }
 
 #[derive(Debug, Clone)]
@@ -66,12 +62,6 @@ pub struct Dtor {
     pub params: Telescope,
     pub destructee: Destructee,
     pub ret_typ: Rc<Exp>,
-}
-
-#[derive(Debug, Clone)]
-pub enum DefDecl {
-    Def(Def),
-    Codef(Codef),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
In the CST representation there was the following indirection:
``` 
Item -> TypDecl -> Data
Item -> TypDecl -> Codata
Item -> DefDecl -> Def
Item -> DefDecl -> Codef
```
This is now flattened to:
```
Item -> Data
Item -> Codata
Item -> Def
Item -> Codef
```