### PR TITLE
Fix 119

### DIFF
--- a/lang/printer/src/ust.rs
+++ b/lang/printer/src/ust.rs
@@ -260,17 +260,25 @@ impl<'a> Print<'a> for Dtor {
 impl<'a> Print<'a> for Comatch {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Comatch { info: _, cases } = self;
-        if cases.is_empty() {
-            empty_braces(alloc)
-        } else {
-            let sep = alloc.text(COMMA).append(alloc.hardline());
-
-            alloc
-                .hardline()
-                .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+        match cases.len() {
+            0 => empty_braces(alloc),
+            1 => alloc
+                .line()
+                .append(cases[0].print(cfg, alloc))
                 .nest(cfg.indent)
-                .append(alloc.hardline())
+                .append(alloc.line())
                 .braces_anno()
+                .group(),
+            _ => {
+                let sep = alloc.text(COMMA).append(alloc.hardline());
+
+                alloc
+                    .hardline()
+                    .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+                    .nest(cfg.indent)
+                    .append(alloc.hardline())
+                    .braces_anno()
+            }
         }
     }
 }
@@ -278,16 +286,24 @@ impl<'a> Print<'a> for Comatch {
 impl<'a> Print<'a> for Match {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Match { info: _, cases } = self;
-        if cases.is_empty() {
-            empty_braces(alloc)
-        } else {
-            let sep = alloc.text(COMMA).append(alloc.hardline());
-            alloc
-                .hardline()
-                .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+        match cases.len() {
+            0 => empty_braces(alloc),
+            1 => alloc
+                .line()
+                .append(cases[0].print(cfg, alloc))
                 .nest(cfg.indent)
-                .append(alloc.hardline())
+                .append(alloc.line())
                 .braces_anno()
+                .group(),
+            _ => {
+                let sep = alloc.text(COMMA).append(alloc.hardline());
+                alloc
+                    .hardline()
+                    .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+                    .nest(cfg.indent)
+                    .append(alloc.hardline())
+                    .braces_anno()
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #119

The formatter produces the following code now, for example:

```
codata Bool { neg: Bool }

codef True: Bool { neg => False }

codef False: Bool { neg => True }

data Pair { MkPair(x y: Bool) }

def Pair.fst: Bool { MkPair(x, _) => x }
```