### PR TITLE
Fix some clippy hints which appeared in newer version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ members = [
     "app",
     "test/test-runner",
 ]
+resolver = "2"
 default-members = ["app"]

--- a/app/src/cli/texify.rs
+++ b/app/src/cli/texify.rs
@@ -9,8 +9,8 @@ use syntax::ust;
 
 use crate::result::IOError;
 
-const LATEX_END: &str = r#"\end{alltt}
-"#;
+const LATEX_END: &str = r"\end{alltt}
+";
 
 fn latex_start(fontsize: &FontSize) -> String {
     use FontSize::*;

--- a/lang/lifting/src/fv.rs
+++ b/lang/lifting/src/fv.rs
@@ -72,7 +72,7 @@ impl FreeVars {
     pub fn union(self, other: FreeVars) -> FreeVars {
         assert_eq!(self.cutoff, other.cutoff);
         let mut fvs = self.fvs;
-        fvs.extend(other.fvs.into_iter());
+        fvs.extend(other.fvs);
         Self { fvs, cutoff: self.cutoff }
     }
 

--- a/lang/query/src/lib.rs
+++ b/lang/query/src/lib.rs
@@ -6,7 +6,6 @@ use codespan::{FileId, Files};
 
 use data::HashMap;
 
-use info::collect_info;
 pub use result::Error;
 
 mod asserts;


### PR DESCRIPTION
Recent version of clippy apparently introduced new lints. This is why CI on main is currently red.