### PR TITLE
Simplify typechecker

### DIFF
--- a/lang/printer/src/ust.rs
+++ b/lang/printer/src/ust.rs
@@ -647,7 +647,7 @@ fn print_lambda_sugar<'a>(e: &'a Comatch, cfg: &PrintCfg, alloc: &'a Alloc<'a>) 
 }
 
 fn print_comma_separated<'a, T: Print<'a>>(
-    vec: &'a Vec<T>,
+    vec: &'a [T],
     cfg: &PrintCfg,
     alloc: &'a Alloc<'a>,
 ) -> Builder<'a> {


### PR DESCRIPTION
Removed some trait indirection. This is necessary since I want to unify "Match" with "Comatch" and "Case" with "Cocase", but the polymorphism in the typechecker makes this difficult since we need to invoke two functions `check_case` and `check_cocase` on the same argument.