### PR TITLE
Remove HoleKind

### DIFF
--- a/examples/typedhole.xfn
+++ b/examples/typedhole.xfn
@@ -14,7 +14,7 @@ data Vec(n: Nat) {
 }
 
 def Vec(S(n)).head(n: Nat) : Nat {
-    Cons(n', x, xs) => ...,
+    Cons(n', x, xs) => ?,
     Nil absurd,
 }
 

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -323,7 +323,7 @@ impl Lift for tst::Exp {
                 ust::Exp::Anno { info: info.forget(), exp: exp.lift(ctx), typ: typ.lift(ctx) }
             }
             tst::Exp::Type { info } => ust::Exp::Type { info: info.forget() },
-            tst::Exp::Hole { info, kind } => ust::Exp::Hole { info: info.forget(), kind: *kind },
+            tst::Exp::Hole { info } => ust::Exp::Hole { info: info.forget() },
             tst::Exp::Match { info, ctx: type_ctx, name, on_exp, motive, ret_typ, body } => {
                 ctx.lift_match(info, type_ctx, name, on_exp, motive, ret_typ, body)
             }

--- a/lang/lowering/src/imp.rs
+++ b/lang/lowering/src/imp.rs
@@ -448,7 +448,7 @@ impl Lower for cst::Exp {
                 is_lambda_sugar: *is_lambda_sugar,
                 body: body.lower(ctx)?,
             }),
-            cst::Exp::Hole { span, kind } => Ok(ust::Exp::Hole { info: Some(*span), kind: *kind }),
+            cst::Exp::Hole { span } => Ok(ust::Exp::Hole { info: Some(*span) }),
             cst::Exp::NatLit { span, val } => {
                 let mut out = ust::Exp::Ctor {
                     info: Some(*span),

--- a/lang/normalizer/src/eval.rs
+++ b/lang/normalizer/src/eval.rs
@@ -52,9 +52,7 @@ impl Eval for Exp {
                 is_lambda_sugar: *is_lambda_sugar,
                 body: body.eval(prg, env)?,
             }),
-            Exp::Hole { info, kind } => {
-                Rc::new(Val::Neu { exp: Neu::Hole { info: *info, kind: *kind } })
-            }
+            Exp::Hole { info } => Rc::new(Val::Neu { exp: Neu::Hole { info: *info } }),
         };
         Ok(res)
     }

--- a/lang/normalizer/src/read_back.rs
+++ b/lang/normalizer/src/read_back.rs
@@ -62,7 +62,7 @@ impl ReadBack for val::Neu {
                 on_exp: on_exp.read_back(prg)?,
                 body: body.read_back(prg)?,
             },
-            val::Neu::Hole { info, kind } => nf::Neu::Hole { info: *info, kind: *kind },
+            val::Neu::Hole { info } => nf::Neu::Hole { info: *info },
         };
         Ok(res)
     }

--- a/lang/normalizer/src/val.rs
+++ b/lang/normalizer/src/val.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 
 use derivative::Derivative;
-use parser::cst::HoleKind;
 use parser::cst::Ident;
 
 use crate::env::*;
@@ -76,8 +75,6 @@ pub enum Neu {
     Hole {
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         info: Option<Span>,
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
-        kind: HoleKind,
     },
 }
 
@@ -160,7 +157,7 @@ impl ShiftInRange for Neu {
                 on_exp: on_exp.shift_in_range(range.clone(), by),
                 body: body.shift_in_range(range, by),
             },
-            Neu::Hole { info, kind } => Neu::Hole { info: *info, kind: *kind },
+            Neu::Hole { info } => Neu::Hole { info: *info },
         }
     }
 }
@@ -234,10 +231,7 @@ impl<'a> Print<'a> for Neu {
                 .append(alloc.text(name.to_string()))
                 .append(alloc.space())
                 .append(body.print(cfg, alloc)),
-            Neu::Hole { info: _, kind } => match kind {
-                HoleKind::Todo => alloc.keyword(HOLE_TODO),
-                HoleKind::Omitted => alloc.keyword(HOLE_OMITTED),
-            },
+            Neu::Hole { .. } => alloc.keyword(HOLE),
         }
     }
 }

--- a/lang/parser/src/cst.rs
+++ b/lang/parser/src/cst.rs
@@ -159,12 +159,6 @@ impl TypApp {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub enum HoleKind {
-    Todo,
-    Omitted,
-}
-
 #[derive(Debug, Clone)]
 pub enum Exp {
     Call { span: Span, name: Ident, args: Args },
@@ -173,7 +167,7 @@ pub enum Exp {
     Type { span: Span },
     Match { span: Span, name: Option<Ident>, on_exp: Rc<Exp>, motive: Option<Motive>, body: Match },
     Comatch { span: Span, name: Option<Ident>, is_lambda_sugar: bool, body: Match },
-    Hole { span: Span, kind: HoleKind },
+    Hole { span: Span },
     NatLit { span: Span, val: BigUint },
     Fun { span: Span, from: Rc<Exp>, to: Rc<Exp> },
     Lam { span: Span, var: ParamInst, body: Rc<Exp> },

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -12,7 +12,7 @@ grammar;
 // Tokens
 match {
     // Symbols
-    "(", ")", "{", "}", ";", ":=", "=>", ",", ":", ".", "?", "...",
+    "(", ")", "{", "}", ";", ":=", "=>", ",", ":", ".", "?",
     "->", "\\",
     // Names
     "_",
@@ -153,8 +153,7 @@ pub Builtins: Rc<Exp> = {
 }
 
 pub Hole: Rc<Exp> = {
-    <l: @L> "?" <r: @R> => Rc::new(Exp::Hole { span: span(l, r), kind: HoleKind::Todo }),
-    <l: @L> "..." <r: @R> => Rc::new(Exp::Hole { span: span(l, r), kind: HoleKind::Omitted }),
+    <l: @L> "?" <r: @R> => Rc::new(Exp::Hole { span: span(l, r) }),
     Atom,
 }
 

--- a/lang/printer/src/nf.rs
+++ b/lang/printer/src/nf.rs
@@ -49,7 +49,7 @@ impl<'a> Print<'a> for Neu {
                 .append(alloc.text(name.to_string()))
                 .append(alloc.space())
                 .append(body.print(cfg, alloc)),
-            Neu::Hole { .. } => alloc.keyword(HOLE_TODO),
+            Neu::Hole { .. } => alloc.keyword(HOLE),
         }
     }
 }

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -6,8 +6,7 @@ pub const COMMA: &str = ",";
 pub const COLON: &str = ":";
 pub const DOT: &str = ".";
 pub const AT: &str = "@";
-pub const HOLE_TODO: &str = "?";
-pub const HOLE_OMITTED: &str = "...";
+pub const HOLE: &str = "?";
 
 // Keywords
 

--- a/lang/printer/src/ust.rs
+++ b/lang/printer/src/ust.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use pretty::DocAllocator;
 
-use parser::cst::{DocComment, HoleKind};
+use parser::cst::DocComment;
 use syntax::common::*;
 use syntax::generic::Item;
 use syntax::ust::*;
@@ -497,10 +497,7 @@ impl<'a> Print<'a> for Exp {
                         .append(body.print(cfg, alloc))
                 }
             }
-            Exp::Hole { info: _, kind } => match kind {
-                HoleKind::Todo => alloc.keyword(HOLE_TODO),
-                HoleKind::Omitted => alloc.keyword(HOLE_OMITTED),
-            },
+            Exp::Hole { .. } => alloc.keyword(HOLE),
         }
     }
 }

--- a/lang/syntax/src/trees/forget/tst.rs
+++ b/lang/syntax/src/trees/forget/tst.rs
@@ -240,7 +240,7 @@ impl Forget for tst::Exp {
                 is_lambda_sugar: *is_lambda_sugar,
                 body: body.forget(),
             },
-            tst::Exp::Hole { info, kind } => ust::Exp::Hole { info: info.forget(), kind: *kind },
+            tst::Exp::Hole { info } => ust::Exp::Hole { info: info.forget() },
         }
     }
 }

--- a/lang/syntax/src/trees/generic/def.rs
+++ b/lang/syntax/src/trees/generic/def.rs
@@ -7,7 +7,7 @@ use data::HashMap;
 use derivative::Derivative;
 
 use crate::common::*;
-use parser::cst::{DocComment, HoleKind, Ident};
+use parser::cst::{DocComment, Ident};
 
 use super::lookup_table::{DeclKind, LookupTable};
 
@@ -307,8 +307,6 @@ pub enum Exp<P: Phase> {
     Hole {
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         info: P::TypeInfo,
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
-        kind: HoleKind,
     },
 }
 

--- a/lang/syntax/src/trees/generic/fold.rs
+++ b/lang/syntax/src/trees/generic/fold.rs
@@ -5,7 +5,7 @@ use codespan::Span;
 use data::HashMap;
 
 use crate::common::*;
-use parser::cst::{DocComment, HoleKind, Ident};
+use parser::cst::{DocComment, Ident};
 
 use super::def::*;
 use super::lookup_table::LookupTable;
@@ -47,7 +47,7 @@ pub trait Folder<P: Phase, O: Out> {
     fn fold_exp_type(&mut self, info: O::TypeInfo) -> O::Exp;
     fn fold_exp_match(&mut self, info: O::TypeAppInfo, ctx: O::Ctx, name: Label, on_exp: O::Exp, motive: Option<O::Motive>, ret_typ: O::Typ, body: O::Match) -> O::Exp;
     fn fold_exp_comatch(&mut self, info: O::TypeAppInfo, ctx: O::Ctx, name: Label, is_lambda_sugar: bool, body: O::Match) -> O::Exp;
-    fn fold_exp_hole(&mut self, info: O::TypeInfo, kind: HoleKind) -> O::Exp;
+    fn fold_exp_hole(&mut self, info: O::TypeInfo) -> O::Exp;
     fn fold_motive(&mut self, info: Option<Span>, param: O::ParamInst, ret_typ: O::Exp) -> O::Motive;
     // FIXME: Unifier binder handling into one method
     fn fold_motive_param<X, F>(&mut self, param: O::ParamInst, f_inner: F) -> X
@@ -514,9 +514,9 @@ impl<P: Phase, O: Out> Fold<P, O> for Exp<P> {
                 let body = body.fold(f);
                 f.fold_exp_comatch(info, ctx, name, is_lambda_sugar, body)
             }
-            Exp::Hole { info, kind } => {
+            Exp::Hole { info } => {
                 let info = f.fold_type_info(info);
-                f.fold_exp_hole(info, kind)
+                f.fold_exp_hole(info)
             }
         }
     }

--- a/lang/syntax/src/trees/generic/map.rs
+++ b/lang/syntax/src/trees/generic/map.rs
@@ -4,7 +4,7 @@ use codespan::Span;
 use data::HashMap;
 
 use crate::common::*;
-use parser::cst::{DocComment, HoleKind, Ident};
+use parser::cst::{DocComment, Ident};
 
 use super::def::*;
 use super::fold::*;
@@ -97,8 +97,8 @@ pub trait Mapper<P: Phase> {
     fn map_exp_comatch(&mut self, info: P::TypeAppInfo, ctx: P::Ctx, name: Label, is_lambda_sugar: bool, body: Match<P>) -> Exp<P> {
         Exp::Comatch { info, ctx, name, is_lambda_sugar, body }
     }
-    fn map_exp_hole(&mut self, info: P::TypeInfo, kind: HoleKind) -> Exp<P> {
-        Exp::Hole { info, kind }
+    fn map_exp_hole(&mut self, info: P::TypeInfo) -> Exp<P> {
+        Exp::Hole { info }
     }
     fn map_motive(&mut self, info: Option<Span>, param: ParamInst<P>, ret_typ: Rc<Exp<P>>) -> Motive<P> {
         Motive { info, param, ret_typ }
@@ -292,8 +292,8 @@ impl<P: Phase, T: Mapper<P>> Folder<P, Id<P>> for T {
         Rc::new(self.map_exp_comatch(info, ctx, name, is_lambda_sugar, body))
     }
 
-    fn fold_exp_hole(&mut self, info: <Id<P> as Out>::TypeInfo, kind: HoleKind) -> <Id<P> as Out>::Exp {
-        Rc::new(self.map_exp_hole(info, kind))
+    fn fold_exp_hole(&mut self, info: <Id<P> as Out>::TypeInfo) -> <Id<P> as Out>::Exp {
+        Rc::new(self.map_exp_hole(info))
     }
 
     fn fold_motive(&mut self, info: Option<Span>, param: <Id<P> as Out>::ParamInst, ret_typ: <Id<P> as Out>::Exp) -> <Id<P> as Out>::Motive {

--- a/lang/syntax/src/trees/generic/visit.rs
+++ b/lang/syntax/src/trees/generic/visit.rs
@@ -4,7 +4,7 @@ use codespan::Span;
 use data::HashMap;
 
 use crate::common::*;
-use parser::cst::{DocComment, HoleKind, Ident};
+use parser::cst::{DocComment, Ident};
 
 use super::def::*;
 use super::lookup_table::LookupTable;
@@ -40,7 +40,7 @@ pub trait Visitor<P: Phase> {
     fn visit_exp_type(&mut self, info: &P::TypeInfo) {}
     fn visit_exp_match(&mut self, info: &P::TypeAppInfo, ctx: &P::Ctx, name: &Label, on_exp: &Rc<Exp<P>>, ret_typ: &P::InfTyp, body: &Match<P>) {}
     fn visit_exp_comatch(&mut self, info: &P::TypeAppInfo, ctx: &P::Ctx, name: &Label, is_lambda_sugar: &bool, body: &Match<P>) {}
-    fn visit_exp_hole(&mut self, info: &P::TypeInfo, kind: HoleKind) {}
+    fn visit_exp_hole(&mut self, info: &P::TypeInfo) {}
     fn visit_motive(&mut self, info: &Option<Span>, param: &ParamInst<P>, ret_typ: &Rc<Exp<P>>) {}
     fn visit_motive_param<X, F>(&mut self, param: &ParamInst<P>, f_inner: F) -> X
     where
@@ -388,9 +388,9 @@ impl<P: Phase> Visit<P> for Exp<P> {
                 body.visit(v);
                 v.visit_exp_comatch(info, ctx, name, is_lambda_sugar, body)
             }
-            Exp::Hole { info, kind } => {
+            Exp::Hole { info } => {
                 v.visit_type_info(info);
-                v.visit_exp_hole(info, *kind)
+                v.visit_exp_hole(info)
             }
         }
     }

--- a/lang/syntax/src/trees/nf/def.rs
+++ b/lang/syntax/src/trees/nf/def.rs
@@ -4,7 +4,7 @@ use crate::common::*;
 use crate::ust;
 use codespan::Span;
 use derivative::Derivative;
-use parser::cst::{HoleKind, Ident};
+use parser::cst::Ident;
 
 /// The syntax of normal forms
 #[derive(Debug, Clone, Derivative)]
@@ -84,8 +84,6 @@ pub enum Neu {
     Hole {
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         info: Option<Span>,
-        #[derivative(PartialEq = "ignore", Hash = "ignore")]
-        kind: HoleKind,
     },
 }
 

--- a/lang/syntax/src/trees/nf/forget.rs
+++ b/lang/syntax/src/trees/nf/forget.rs
@@ -54,7 +54,7 @@ impl Forget for Neu {
                 ret_typ: (),
                 body: body.forget(),
             },
-            Neu::Hole { info, kind } => ust::Exp::Hole { info: *info, kind: *kind },
+            Neu::Hole { info } => ust::Exp::Hole { info: *info },
         }
     }
 }

--- a/lang/syntax/src/trees/nf/shift.rs
+++ b/lang/syntax/src/trees/nf/shift.rs
@@ -43,7 +43,7 @@ impl ShiftInRange for Neu {
                 on_exp: on_exp.shift_in_range(range.clone(), by),
                 body: body.shift_in_range(range, by),
             },
-            Neu::Hole { info, kind } => Neu::Hole { info: *info, kind: *kind },
+            Neu::Hole { info } => Neu::Hole { info: *info },
         }
     }
 }

--- a/lang/syntax/src/trees/ust/shift.rs
+++ b/lang/syntax/src/trees/ust/shift.rs
@@ -47,7 +47,7 @@ impl ShiftInRange for Exp {
                 is_lambda_sugar: *is_lambda_sugar,
                 body: body.shift_in_range(range, by),
             },
-            Exp::Hole { info, kind } => Exp::Hole { info: *info, kind: *kind },
+            Exp::Hole { info } => Exp::Hole { info: *info },
         }
     }
 }

--- a/lang/syntax/src/trees/ust/subst.rs
+++ b/lang/syntax/src/trees/ust/subst.rs
@@ -49,7 +49,7 @@ impl Substitutable<Rc<Exp>> for Rc<Exp> {
                 is_lambda_sugar: *is_lambda_sugar,
                 body: body.subst(ctx, by),
             }),
-            Exp::Hole { info, kind } => Rc::new(Exp::Hole { info: *info, kind: *kind }),
+            Exp::Hole { info } => Rc::new(Exp::Hole { info: *info }),
         }
     }
 }

--- a/lang/typechecker/src/typecheck.rs
+++ b/lang/typechecker/src/typecheck.rs
@@ -8,7 +8,7 @@ use data::HashSet;
 use miette_util::ToMiette;
 use normalizer::env::ToEnv;
 use normalizer::normalize::Normalize;
-use parser::cst::{HoleKind, Ident};
+use parser::cst::Ident;
 use syntax::common::*;
 use syntax::ctx::values::Binder;
 use syntax::ctx::{BindContext, BindElem, LevelCtx};
@@ -761,10 +761,9 @@ impl Check for ust::Exp {
                     body: body_out,
                 })
             }
-            ust::Exp::Hole { info, kind } => Ok(tst::Exp::Hole {
-                info: info.with_type_and_ctx(t.clone(), ctx.vars.clone()),
-                kind: *kind,
-            }),
+            ust::Exp::Hole { info } => {
+                Ok(tst::Exp::Hole { info: info.with_type_and_ctx(t.clone(), ctx.vars.clone()) })
+            }
             _ => {
                 let actual = self.infer(prg, ctx)?;
                 convert(actual.typ(), &t)?;
@@ -852,9 +851,7 @@ impl Infer for ust::Exp {
                 })
             }
             ust::Exp::Type { info } => Ok(tst::Exp::Type { info: info.with_type(type_univ()) }),
-            ust::Exp::Hole { info, kind } => {
-                Ok(tst::Exp::Hole { info: info.with_type(type_hole()), kind: *kind })
-            }
+            ust::Exp::Hole { info } => Ok(tst::Exp::Hole { info: info.with_type(type_hole()) }),
             ust::Exp::Match { .. } => {
                 Err(TypeError::CannotInferMatch { span: self.span().to_miette() })
             }
@@ -1085,7 +1082,7 @@ fn type_univ() -> Rc<nf::Nf> {
 }
 
 fn type_hole() -> Rc<nf::Nf> {
-    Rc::new(nf::Nf::Neu { exp: nf::Neu::Hole { info: None, kind: HoleKind::Todo } })
+    Rc::new(nf::Nf::Neu { exp: nf::Neu::Hole { info: None } })
 }
 
 // Checks whether the codata type contains destructors with a self parameter


### PR DESCRIPTION
We had `...` and `?` for holes. The duplication will no longer be necessary, I think we added it for the paper. I remove it because it is one of the small things which forces everything to depend on the CST.