### PR TITLE
Add version subcommand; rename module from app to polarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,26 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "async-std",
- "clap",
- "futures",
- "lsp-server",
- "miette",
- "normalizer",
- "printer",
- "query",
- "syntax",
- "termsize",
- "thiserror",
- "tokio",
- "tower-lsp",
- "typechecker",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1543,26 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polarity"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "clap",
+ "futures",
+ "lsp-server",
+ "miette",
+ "normalizer",
+ "printer",
+ "query",
+ "syntax",
+ "termsize",
+ "thiserror",
+ "tokio",
+ "tower-lsp",
+ "typechecker",
+]
 
 [[package]]
 name = "polling"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "polarity"
 version = "0.1.0"
 edition = "2021"
 

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -23,7 +23,7 @@ pub fn exec() -> miette::Result<()> {
 }
 
 #[derive(Parser)]
-#[clap(author, about, long_about = None)]
+#[clap(version, author, about, long_about = None)]
 struct Cli {
     #[clap(subcommand)]
     command: Command,


### PR DESCRIPTION
Fixes #149 
I had to rename the module from "app" to "polarity", since `clap` uses the name of the module to generate the output.

```console
>pol --version
polarity 0.1.0
>pol --help
Usage: pol [OPTIONS] <COMMAND>

Commands:
  run     Run a source code file
  fmt     Format a code file
  texify  Render a code file as a latex document
  xfunc   De-/Refunctionalize a type in a code file
  lsp     Start an LSP server
  lift    Lift local (co)matches of a type to the top-level
  help    Print this message or the help of the given subcommand(s)

Options:
      --trace    Enable internal debug output
  -h, --help     Print help
  -V, --version  Print version
```