### PR TITLE
Add information about contributing and releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-We use the `DD.MM.YYYY` date format.
+We use the `YYYY-MM-DD` date format.
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+We use the `DD.MM.YYYY` date format.
+
+## [Unreleased]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Please check that you observe the following guidelines:
 
 - If your PR changes the observable behaviour of the binary, then you have to add an entry to the `CHANGELOG.md` file with your PR under the `Unreleased` section of the changelog.
 - Every PR needs to have at least 1 approval before it can be merged.
+- We enforce a linear history on the `main` branch, so every PR must either be rebased or rebased and squashed before it is merged into `main`.
 
 ### Release workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing Guidelines
+
+Pull requests, bug reports and feature requests are highly welcomed and encouraged!
+
+### Contents
+
+- [Pull Request Workflow](#pull-request-workflow)
+- [Release Workflow](#release-workflow)
+
+### Pull request workflow
+
+All changes to the codebase should go through pull-requests.
+We do not allow commits directly on the `main` branch of the repository.
+Furthermore, all pull requests should be associated with at least one specific issue unless the PR fixes a minor problem.
+Please check that you observe the following guidelines:
+
+- If your PR changes the observable behaviour of the binary, then you have to add an entry to the `CHANGELOG.md` file with your PR under the `Unreleased` section of the changelog.
+- Every PR needs to have at least 1 approval before it can be merged.
+
+### Release workflow
+
+We use the following workflow for generating a new release for version `x.x.x`:
+
+- Open a branch with the name `prepare-release-x.x.x` and create a corresponding PR.
+- Change the versions in all the `Cargo.toml` files to the new version `x.x.x`, build the project, and also commit the generated `Cargo.lock` file.
+- Move everything under the section `Unreleased` in the `CHANGELOG.md` into a new section `[x.x.x] YYYY-MM-DD` with the current date.
+- Merge the Pull request into `main`.
+- In the main branch, use `git tag -a x.x.x -m "Version x.x.x` to create a tag, and `git push origin x.x.x` to publish the tag.


### PR DESCRIPTION
We should get a little bit more careful about versioning and releasing now.
Here is what I think are some minimal first steps:

- Add an (empty) changelog.
- Add some information about the PR and release workflow.

Should we specify a merge strategy for PRs (rebase / squash / merge etc?)