### PR TITLE
Remove toplevel expression

### DIFF
--- a/examples/boolrep.pol
+++ b/examples/boolrep.pol
@@ -27,5 +27,3 @@ def Top.flipRep(x: Bool, rep: BoolRep(x)): BoolRep(x.not) {
 def Top.example: Bool {
     Unit => Unit.flipRep(True, TrueRep).extract(False)
 }
-
-Unit.example

--- a/examples/colist.pol
+++ b/examples/colist.pol
@@ -30,4 +30,3 @@ codef TakeN(n: CoNat, s: CoList(Omega)) : CoList(n) {
     tail(n') => TakeN(n.pred, s.tail(Omega)),
 }
 
-TakeN(3, CountUp(1)).tail(3).tail(2).head(1, SNotZero(0))

--- a/examples/covect.pol
+++ b/examples/covect.pol
@@ -33,4 +33,3 @@ def Top.example2: Vec(4) {
     Unit => Unit.example1.append(2, 2, Unit.example1)
 }
 
-Unit.example2

--- a/examples/example.pol
+++ b/examples/example.pol
@@ -22,4 +22,3 @@ codata NatToNat {
     ap(x: Nat) : Nat
 }
 
-S(S(Z)).add(S(S(Z)))

--- a/examples/simple.pol
+++ b/examples/simple.pol
@@ -17,5 +17,3 @@ def List(a).head(a: Type) : Option(a) {
     Nil(a) => None(a),
     Cons(a, x, xs) => Some(a, x)
 }
-
-Cons(Nat, Z, Cons(Nat, Z, Nil(Nat)))

--- a/examples/typedhole.pol
+++ b/examples/typedhole.pol
@@ -73,4 +73,3 @@ codef Alternate(choose: Bool) : Stream {
     sTail() => Alternate(choose.not())
 }
 
-Unit.example2

--- a/examples/vect.pol
+++ b/examples/vect.pol
@@ -38,4 +38,3 @@ def Top.example2: Vec(4) {
     Unit => Unit.example1.append(2, 2, Unit.example1)
 }
 
-Unit.example2

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -76,9 +76,9 @@ impl Lift for tst::Prg {
     type Target = ust::Prg;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let tst::Prg { decls, exp } = self;
+        let tst::Prg { decls } = self;
 
-        ust::Prg { decls: decls.lift(ctx), exp: exp.lift(ctx) }
+        ust::Prg { decls: decls.lift(ctx) }
     }
 }
 

--- a/lang/lowering/src/imp.rs
+++ b/lang/lowering/src/imp.rs
@@ -24,7 +24,7 @@ pub trait Lower {
 }
 
 pub fn lower_prg(prg: &cst::Prg) -> Result<ust::Prg, LoweringError> {
-    let cst::Prg { items, exp } = prg;
+    let cst::Prg { items } = prg;
 
     let (top_level_map, lookup_table) = build_lookup_table(items)?;
 
@@ -34,9 +34,7 @@ pub fn lower_prg(prg: &cst::Prg) -> Result<ust::Prg, LoweringError> {
         item.lower(&mut ctx)?;
     }
 
-    let exp = exp.lower(&mut ctx)?;
-
-    Ok(ust::Prg { decls: ust::Decls { map: ctx.decls_map, lookup_table }, exp })
+    Ok(ust::Prg { decls: ust::Decls { map: ctx.decls_map, lookup_table } })
 }
 
 /// Build the structure tracking the declaration order in the source code

--- a/lang/parser/src/cst.rs
+++ b/lang/parser/src/cst.rs
@@ -20,7 +20,6 @@ pub enum BindingSite {
 #[derive(Debug, Clone)]
 pub struct Prg {
     pub items: Vec<Decl>,
-    pub exp: Option<Rc<Exp>>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -81,7 +81,7 @@ DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 // Program
 
 pub Prg: Prg = {
-    <items: Decl*> <exp: Exp?> => Prg { items, exp },
+    <items: Decl*> => Prg { items,  },
 }
 
 pub Decl: Decl = {

--- a/lang/printer/src/ust.rs
+++ b/lang/printer/src/ust.rs
@@ -14,24 +14,8 @@ use super::util::*;
 
 impl<'a> Print<'a> for Prg {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let Prg { decls, exp } = self;
-
-        match exp {
-            Some(exp) => {
-                let top = if decls.is_empty() {
-                    alloc.nil()
-                } else {
-                    let sep = if cfg.omit_decl_sep {
-                        alloc.hardline()
-                    } else {
-                        alloc.hardline().append(alloc.hardline())
-                    };
-                    decls.print(cfg, alloc).append(sep)
-                };
-                top.append(exp.print(cfg, alloc))
-            }
-            None => decls.print(cfg, alloc),
-        }
+        let Prg { decls } = self;
+        decls.print(cfg, alloc)
     }
 }
 

--- a/lang/query/src/view/rt.rs
+++ b/lang/query/src/view/rt.rs
@@ -2,9 +2,7 @@ use std::rc::Rc;
 
 use super::DatabaseView;
 
-use normalizer::normalize::Normalize;
 use parser::cst;
-use syntax::common::Forget;
 use syntax::{nf, tst, ust};
 
 use crate::*;
@@ -35,17 +33,7 @@ impl<'a> DatabaseView<'a> {
     }
 
     pub fn run(&self) -> Result<Option<Rc<nf::Nf>>, Error> {
-        let tst = self.tst()?;
-        let ust = tst.forget();
-        match ust.exp.clone() {
-            None => Ok(None),
-            Some(exp) => {
-                let nf = exp
-                    .normalize_in_empty_env(&ust)
-                    .map_err(|err| Error::Type(typechecker::TypeError::Eval(err)))?;
-                Ok(Some(nf))
-            }
-        }
+        Ok(None)
     }
 
     pub fn pretty_error(&self, err: Error) -> miette::Report {

--- a/lang/syntax/src/trees/forget/tst.rs
+++ b/lang/syntax/src/trees/forget/tst.rs
@@ -10,9 +10,9 @@ impl Forget for tst::Prg {
     type Target = ust::Prg;
 
     fn forget(&self) -> Self::Target {
-        let tst::Prg { decls, exp } = self;
+        let tst::Prg { decls } = self;
 
-        ust::Prg { decls: decls.forget(), exp: exp.forget() }
+        ust::Prg { decls: decls.forget() }
     }
 }
 

--- a/lang/syntax/src/trees/generic/def.rs
+++ b/lang/syntax/src/trees/generic/def.rs
@@ -36,7 +36,6 @@ pub struct DocComment {
 #[derive(Debug, Clone)]
 pub struct Prg<P: Phase> {
     pub decls: Decls<P>,
-    pub exp: Option<Rc<Exp<P>>>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/syntax/src/trees/generic/fold.rs
+++ b/lang/syntax/src/trees/generic/fold.rs
@@ -18,7 +18,7 @@ pub trait Folder<P: Phase, O: Out> {
     /// Run just before a declaration is entered
     fn enter_decl(&mut self, decl: &Decl<P>) { let _ = decl; }
 
-    fn fold_prg(&mut self, decls: O::Decls, exp: Option<O::Exp>) -> O::Prg;
+    fn fold_prg(&mut self, decls: O::Decls) -> O::Prg;
     fn fold_decls(&mut self, map: HashMap<Ident, O::Decl>, order: LookupTable) -> O::Decls;
     fn fold_decl(&mut self, decl: O::Decl) -> O::Decl;
     fn fold_decl_data(&mut self, data: O::Data) -> O::Decl;
@@ -226,10 +226,9 @@ where
     where
         F: Folder<P, O>,
     {
-        let Prg { decls, exp } = self;
+        let Prg { decls } = self;
         let decls = decls.fold(f);
-        let exp = exp.fold(f);
-        f.fold_prg(decls, exp)
+        f.fold_prg(decls)
     }
 }
 

--- a/lang/syntax/src/trees/generic/map.rs
+++ b/lang/syntax/src/trees/generic/map.rs
@@ -14,8 +14,8 @@ pub trait Mapper<P: Phase> {
     /// Run just before a declaration is entered
     fn enter_decl(&mut self, decl: &Decl<P>) { let _ = decl; }
 
-    fn map_prg(&mut self, decls: Decls<P>, exp: Option<Rc<Exp<P>>>) -> Prg<P> {
-        Prg { decls, exp }
+    fn map_prg(&mut self, decls: Decls<P>) -> Prg<P> {
+        Prg { decls }
     }
     fn map_decls(&mut self, map: HashMap<Ident, Decl<P>>, lookup_table: LookupTable) -> Decls<P> {
         Decls { map, lookup_table }
@@ -182,8 +182,8 @@ impl<P: Phase, T: Mapper<P>> Folder<P, Id<P>> for T {
         self.enter_decl(decl)
     }
 
-    fn fold_prg(&mut self, decls: <Id<P> as Out>::Decls, exp: Option<<Id<P> as Out>::Exp>) -> <Id<P> as Out>::Prg {
-        self.map_prg(decls, exp)
+    fn fold_prg(&mut self, decls: <Id<P> as Out>::Decls) -> <Id<P> as Out>::Prg {
+        self.map_prg(decls)
     }
 
     fn fold_decls(&mut self, map: HashMap<Ident, <Id<P> as Out>::Decl>, source: LookupTable) -> <Id<P> as Out>::Decls {

--- a/lang/syntax/src/trees/generic/visit.rs
+++ b/lang/syntax/src/trees/generic/visit.rs
@@ -11,7 +11,7 @@ use super::lookup_table::LookupTable;
 #[allow(unused_variables)]
 #[allow(clippy::too_many_arguments)]
 pub trait Visitor<P: Phase> {
-    fn visit_prg(&mut self, decls: &Decls<P>, exp: &Option<Rc<Exp<P>>>) {}
+    fn visit_prg(&mut self, decls: &Decls<P>) {}
     fn visit_decls(&mut self, map: &HashMap<Ident, Decl<P>>, source: &LookupTable) {}
     fn visit_decl(&mut self, decl: &Decl<P>) {}
     fn visit_decl_data(&mut self, data: &Data<P>) {}
@@ -128,10 +128,9 @@ impl<P: Phase> Visit<P> for Prg<P> {
     where
         V: Visitor<P>,
     {
-        let Prg { decls, exp } = self;
+        let Prg { decls } = self;
         decls.visit(v);
-        exp.visit(v);
-        v.visit_prg(decls, exp)
+        v.visit_prg(decls)
     }
 }
 

--- a/lang/typechecker/src/typecheck.rs
+++ b/lang/typechecker/src/typecheck.rs
@@ -71,12 +71,11 @@ impl Infer for ust::Prg {
     type Target = tst::Prg;
 
     fn infer(&self, prg: &ust::Prg, ctx: &mut Ctx) -> Result<Self::Target, TypeError> {
-        let ust::Prg { decls, exp } = self;
+        let ust::Prg { decls } = self;
 
         let decls_out = decls.infer(prg, ctx)?;
-        let exp_out = exp.as_ref().map(|exp| exp.infer(prg, ctx)).transpose()?;
 
-        Ok(tst::Prg { decls: decls_out, exp: exp_out })
+        Ok(tst::Prg { decls: decls_out })
     }
 }
 

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -70,8 +70,7 @@ impl Ctx {
 
 impl BuildMatrix for ust::Prg {
     fn build_matrix(&self, ctx: &mut Ctx, out: &mut Prg) -> Result<(), XfuncError> {
-        let ust::Prg { decls, exp } = self;
-        out.exp = exp.clone();
+        let ust::Prg { decls } = self;
 
         for decl in decls.map.values() {
             match decl {

--- a/test/suites/fail-check/002.pol
+++ b/test/suites/fail-check/002.pol
@@ -15,4 +15,8 @@ def Foo(True).foo() : Nat {
     Baz() absurd,
 }
 
-Baz.foo()
+data Unit { Top }
+
+def Unit.example : Nat {
+    Top => Baz.foo
+}

--- a/test/suites/fail-check/003.pol
+++ b/test/suites/fail-check/003.pol
@@ -18,4 +18,8 @@ def Foo(True).foo() : Nat {
     Baz() absurd,
 }
 
-Baz.foo()
+data Unit { Top }
+
+def Unit.example : Nat {
+   Top =>  Baz.foo
+}

--- a/test/suites/fail-check/004.pol
+++ b/test/suites/fail-check/004.pol
@@ -7,9 +7,13 @@ codata Bool {
     and(other: Bool): Bool,
     not: Bool
 }
+data Unit { Top }
 
-comatch {
-    neg_inverse => ?,
-    and(other) => ?,
-    not => ?
-}: Bool
+def Unit.example : Bool {
+    Top => comatch {
+              neg_inverse => ?,
+              and(other) => ?,
+              not => ?
+           }
+}
+


### PR DESCRIPTION
Having a toplevel expression in a file doesn't fit into our future plans where we plan to introduce toplevel definitions (cp 
#12) and module imports. 