### PR TITLE
Improve type-on-hover

### DIFF
--- a/lang/query/src/index.rs
+++ b/lang/query/src/index.rs
@@ -3,12 +3,12 @@ use rust_lapper::Lapper;
 
 use syntax::common::*;
 
-use super::info::{Info, Item};
+use super::info::{HoverInfo, Item};
 
 #[derive(Default)]
 pub struct Index {
     pub(crate) index_enabled: HashSet<FileId>,
-    pub(crate) info_index_by_id: HashMap<FileId, Lapper<u32, Info>>,
+    pub(crate) info_index_by_id: HashMap<FileId, Lapper<u32, HoverInfo>>,
     pub(crate) item_index_by_id: HashMap<FileId, Lapper<u32, Item>>,
 }
 
@@ -55,14 +55,14 @@ impl<'a> IndexViewMut<'a> {
         self.index.item_index_by_id.insert(self.file_id, Lapper::new(vec![]));
     }
 
-    pub fn set(&mut self, info_index: Lapper<u32, Info>, item_index: Lapper<u32, Item>) {
+    pub fn set(&mut self, info_index: Lapper<u32, HoverInfo>, item_index: Lapper<u32, Item>) {
         self.index.info_index_by_id.insert(self.file_id, info_index);
         self.index.item_index_by_id.insert(self.file_id, item_index);
     }
 }
 
 impl<'a> IndexView<'a> {
-    pub fn infos(&self) -> &Lapper<u32, Info> {
+    pub fn infos(&self) -> &Lapper<u32, HoverInfo> {
         &self.index.info_index_by_id[&self.file_id]
     }
 

--- a/lang/query/src/info.rs
+++ b/lang/query/src/info.rs
@@ -217,48 +217,87 @@ impl CollectInfo for tst::Args {
 impl CollectInfo for tst::Exp {
     fn collect_info(&self, collector: &mut InfoCollector) {
         match self {
-            tst::Exp::Variable(tst::Variable { info, .. }) => info.collect_info(collector),
-            tst::Exp::TypCtor(tst::TypCtor { info, name: _, args }) => {
-                info.collect_info(collector);
-                args.collect_info(collector)
-            }
-            tst::Exp::Call(tst::Call { info, name: _, args }) => {
-                info.collect_info(collector);
-                args.collect_info(collector)
-            }
-            tst::Exp::DotCall(tst::DotCall { info, exp, name: _, args }) => {
-                info.collect_info(collector);
-                exp.collect_info(collector);
-                args.collect_info(collector)
-            }
-            tst::Exp::Hole(tst::Hole { info }) => info.collect_info(collector),
-            tst::Exp::Type(tst::Type { info }) => info.collect_info(collector),
-            tst::Exp::Anno(tst::Anno { info, exp, typ }) => {
-                info.collect_info(collector);
-                exp.collect_info(collector);
-                typ.collect_info(collector)
-            }
-            tst::Exp::LocalMatch(tst::LocalMatch {
-                info: _,
-                ctx: _,
-                name: _,
-                on_exp,
-                motive: _,
-                ret_typ,
-                body,
-            }) => {
-                on_exp.collect_info(collector);
-                ret_typ.as_exp().collect_info(collector);
-                body.collect_info(collector)
-            }
-            tst::Exp::LocalComatch(tst::LocalComatch {
-                info: _,
-                ctx: _,
-                name: _,
-                is_lambda_sugar: _,
-                body,
-            }) => body.collect_info(collector),
+            tst::Exp::Variable(e) => e.collect_info(collector),
+            tst::Exp::TypCtor(e) => e.collect_info(collector),
+            tst::Exp::Call(e) => e.collect_info(collector),
+            tst::Exp::DotCall(e) => e.collect_info(collector),
+            tst::Exp::Hole(e) => e.collect_info(collector),
+            tst::Exp::Type(e) => e.collect_info(collector),
+            tst::Exp::Anno(e) => e.collect_info(collector),
+            tst::Exp::LocalMatch(e) => e.collect_info(collector),
+            tst::Exp::LocalComatch(e) => e.collect_info(collector),
         }
+    }
+}
+
+impl CollectInfo for tst::Variable {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::Variable { info, .. } = self;
+        info.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::TypCtor {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::TypCtor { info, args, .. } = self;
+        info.collect_info(collector);
+        args.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::Call {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::Call { info, args, .. } = self;
+        info.collect_info(collector);
+        args.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::DotCall {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::DotCall { info, exp, args, .. } = self;
+        info.collect_info(collector);
+        exp.collect_info(collector);
+        args.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::Hole {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::Hole { info } = self;
+        info.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::Type {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::Type { info } = self;
+        info.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::Anno {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::Anno { info, exp, typ } = self;
+        info.collect_info(collector);
+        exp.collect_info(collector);
+        typ.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::LocalMatch {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::LocalMatch { on_exp, ret_typ, body, .. } = self;
+        on_exp.collect_info(collector);
+        ret_typ.as_exp().collect_info(collector);
+        body.collect_info(collector)
+    }
+}
+
+impl CollectInfo for tst::LocalComatch {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let tst::LocalComatch { body, .. } = self;
+        body.collect_info(collector)
     }
 }
 

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -1,4 +1,3 @@
-
 use std::rc::Rc;
 
 use printer::PrintToString;
@@ -8,9 +7,8 @@ use syntax::tst::{self};
 
 use super::data::*;
 
-
 /// Traverse the program and collect information for the LSP server.
-pub fn collect_info(prg: &tst::Prg) -> (Lapper<u32, Info>, Lapper<u32, Item>) {
+pub fn collect_info(prg: &tst::Prg) -> (Lapper<u32, HoverInfo>, Lapper<u32, Item>) {
     let mut c = InfoCollector::default();
 
     prg.collect_info(&mut c);
@@ -22,7 +20,7 @@ pub fn collect_info(prg: &tst::Prg) -> (Lapper<u32, Info>, Lapper<u32, Item>) {
 
 #[derive(Default)]
 struct InfoCollector {
-    info_spans: Vec<Interval<u32, Info>>,
+    info_spans: Vec<Interval<u32, HoverInfo>>,
     item_spans: Vec<Interval<u32, Item>>,
 }
 
@@ -31,7 +29,6 @@ struct InfoCollector {
 trait CollectInfo {
     fn collect_info(&self, _collector: &mut InfoCollector) {}
 }
-
 
 // Generic implementations
 //
@@ -259,7 +256,7 @@ impl CollectInfo for tst::TypeInfo {
             let info = Interval {
                 start: span.start().into(),
                 stop: span.end().into(),
-                val: Info {
+                val: HoverInfo {
                     typ: typ.print_to_string(None),
                     span: Some(*span),
                     ctx: ctx.clone().map(Into::into),

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -257,9 +257,11 @@ impl CollectInfo for tst::TypeInfo {
                 start: span.start().into(),
                 stop: span.end().into(),
                 val: HoverInfo {
-                    typ: typ.print_to_string(None),
                     span: *span,
-                    ctx: ctx.clone().map(Into::into),
+                    content: HoverInfoContent {
+                        typ: typ.print_to_string(None),
+                        ctx: ctx.clone().map(Into::into),
+                    },
                 },
             };
             collector.info_spans.push(info)

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -205,7 +205,12 @@ impl CollectInfo for tst::Variable {
 impl CollectInfo for tst::TypCtor {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::TypCtor { info, args, .. } = self;
-        info.collect_info(collector);
+        if let Some(span) = info.span {
+            let content = HoverInfoContent::TypeCtorInfo(TypeCtorInfo {
+                typ: info.typ.print_to_string(None),
+            });
+            collector.add_hover_content(span, content)
+        }
         args.collect_info(collector)
     }
 }

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -243,7 +243,13 @@ impl CollectInfo for tst::DotCall {
 impl CollectInfo for tst::Hole {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::Hole { info } = self;
-        info.collect_info(collector)
+        if let Some(span) = info.span {
+            let content = HoverInfoContent::HoleInfo(HoleInfo {
+                goal: info.typ.print_to_string(None),
+                ctx: info.ctx.clone().map(Into::into),
+            });
+            collector.add_hover_content(span, content)
+        }
     }
 }
 

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -258,7 +258,7 @@ impl CollectInfo for tst::TypeInfo {
                 stop: span.end().into(),
                 val: HoverInfo {
                     typ: typ.print_to_string(None),
-                    span: Some(*span),
+                    span: *span,
                     ctx: ctx.clone().map(Into::into),
                 },
             };

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -30,7 +30,7 @@ impl InfoCollector {
         let info = Interval {
             start: span.start().into(),
             stop: span.end().into(),
-            val: HoverInfo { span: span, content },
+            val: HoverInfo { span, content },
         };
         self.info_spans.push(info)
     }
@@ -268,7 +268,11 @@ impl CollectInfo for tst::Type {
 impl CollectInfo for tst::Anno {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::Anno { info, exp, typ } = self;
-        info.collect_info(collector);
+        if let Some(span) = info.span {
+            let content =
+                HoverInfoContent::AnnoInfo(AnnoInfo { typ: info.typ.print_to_string(None) });
+            collector.add_hover_content(span, content)
+        }
         exp.collect_info(collector);
         typ.collect_info(collector)
     }
@@ -287,19 +291,6 @@ impl CollectInfo for tst::LocalComatch {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::LocalComatch { body, .. } = self;
         body.collect_info(collector)
-    }
-}
-
-impl CollectInfo for tst::TypeInfo {
-    fn collect_info(&self, collector: &mut InfoCollector) {
-        let tst::TypeInfo { typ, span, ctx } = self;
-        if let Some(span) = span {
-            let content = HoverInfoContent::GenericInfo(GenericInfo {
-                typ: typ.print_to_string(None),
-                ctx: ctx.clone().map(Into::into),
-            });
-            collector.add_hover_content(*span, content)
-        }
     }
 }
 

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -250,7 +250,12 @@ impl CollectInfo for tst::Hole {
 impl CollectInfo for tst::Type {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::Type { info } = self;
-        info.collect_info(collector)
+        if let Some(span) = info.span {
+            let content = HoverInfoContent::TypeUnivInfo(TypeUnivInfo {
+                typ: info.typ.print_to_string(None),
+            });
+            collector.add_hover_content(span, content)
+        }
     }
 }
 

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -218,7 +218,11 @@ impl CollectInfo for tst::TypCtor {
 impl CollectInfo for tst::Call {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::Call { info, args, .. } = self;
-        info.collect_info(collector);
+        if let Some(span) = info.span {
+            let content =
+                HoverInfoContent::CallInfo(CallInfo { typ: info.typ.print_to_string(None) });
+            collector.add_hover_content(span, content)
+        }
         args.collect_info(collector)
     }
 }
@@ -226,7 +230,11 @@ impl CollectInfo for tst::Call {
 impl CollectInfo for tst::DotCall {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let tst::DotCall { info, exp, args, .. } = self;
-        info.collect_info(collector);
+        if let Some(span) = info.span {
+            let content =
+                HoverInfoContent::DotCallInfo(DotCallInfo { typ: info.typ.print_to_string(None) });
+            collector.add_hover_content(span, content)
+        }
         exp.collect_info(collector);
         args.collect_info(collector)
     }

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -21,6 +21,8 @@ pub enum HoverInfoContent {
     GenericInfo(GenericInfo),
     VariableInfo(VariableInfo),
     TypeCtorInfo(TypeCtorInfo),
+    CallInfo(CallInfo),
+    DotCallInfo(DotCallInfo),
 }
 
 // TODO: Completely remove generic info and replace it with concrete types.
@@ -39,6 +41,18 @@ pub struct VariableInfo {
 /// Hover information for type constructors
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeCtorInfo {
+    pub typ: String,
+}
+
+/// Hover information for calls (constructors, codefinitions or lets)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallInfo {
+    pub typ: String,
+}
+
+/// Hover information for dotcalls (destructors or definitions)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DotCallInfo {
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -24,6 +24,7 @@ pub enum HoverInfoContent {
     CallInfo(CallInfo),
     DotCallInfo(DotCallInfo),
     TypeUnivInfo(TypeUnivInfo),
+    HoleInfo(HoleInfo),
 }
 
 // TODO: Completely remove generic info and replace it with concrete types.
@@ -61,6 +62,13 @@ pub struct DotCallInfo {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeUnivInfo {
     pub typ: String,
+}
+
+/// Hover information for typed holes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoleInfo {
+    pub goal: String,
+    pub ctx: Option<Ctx>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -10,14 +10,28 @@ use syntax::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoverInfo {
+    /// The source code location to which the content applies
     pub span: Span,
+    /// The information that should be displayed on hover
     pub content: HoverInfoContent,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HoverInfoContent {
+pub enum HoverInfoContent {
+    GenericInfo(GenericInfo),
+    VariableInfo(VariableInfo),
+}
+
+// TODO: Completely remove generic info and replace it with concrete types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericInfo {
     pub typ: String,
     pub ctx: Option<Ctx>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariableInfo {
+    pub typ: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -9,7 +9,7 @@ use syntax::tst::{self};
 //
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Info {
+pub struct HoverInfo {
     pub typ: String,
     pub span: Option<Span>,
     pub ctx: Option<Ctx>,
@@ -26,9 +26,13 @@ pub struct Binder {
     pub typ: String,
 }
 
-impl From<tst::TypeInfo> for Info {
+impl From<tst::TypeInfo> for HoverInfo {
     fn from(info: tst::TypeInfo) -> Self {
-        Info { typ: info.typ.print_to_string(None), ctx: info.ctx.map(Into::into), span: info.span }
+        HoverInfo {
+            typ: info.typ.print_to_string(None),
+            ctx: info.ctx.map(Into::into),
+            span: info.span,
+        }
     }
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -1,0 +1,70 @@
+use codespan::Span;
+use printer::PrintToString;
+
+use syntax::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
+use syntax::tst::{self};
+
+// Info
+//
+//
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Info {
+    pub typ: String,
+    pub span: Option<Span>,
+    pub ctx: Option<Ctx>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ctx {
+    pub bound: Vec<Vec<Binder>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Binder {
+    pub name: String,
+    pub typ: String,
+}
+
+impl From<tst::TypeInfo> for Info {
+    fn from(info: tst::TypeInfo) -> Self {
+        Info { typ: info.typ.print_to_string(None), ctx: info.ctx.map(Into::into), span: info.span }
+    }
+}
+
+impl From<TypeCtx> for Ctx {
+    fn from(ctx: TypeCtx) -> Self {
+        let bound =
+            ctx.bound.into_iter().map(|tel| tel.into_iter().map(Into::into).collect()).collect();
+        Ctx { bound }
+    }
+}
+
+impl From<TypeCtxBinder> for Binder {
+    fn from(binder: TypeCtxBinder) -> Self {
+        Binder { name: binder.name, typ: binder.typ.print_to_string(None) }
+    }
+}
+
+// Item
+//
+//
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum Item {
+    Data(String),
+    Codata(String),
+    Def { name: String, type_name: String },
+    Codef { name: String, type_name: String },
+}
+
+impl Item {
+    pub fn type_name(&self) -> &str {
+        match self {
+            Item::Data(name) => name,
+            Item::Codata(name) => name,
+            Item::Def { type_name, .. } => type_name,
+            Item::Codef { type_name, .. } => type_name,
+        }
+    }
+}

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -2,16 +2,16 @@ use codespan::Span;
 use printer::PrintToString;
 
 use syntax::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
-use syntax::tst::{self};
 
-// Info
+// HoverInfo
 //
-//
+// Types which contain the information that is displayed in a
+// code editor when hovering over a point in the program code.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoverInfo {
     pub typ: String,
-    pub span: Option<Span>,
+    pub span: Span,
     pub ctx: Option<Ctx>,
 }
 
@@ -24,16 +24,6 @@ pub struct Ctx {
 pub struct Binder {
     pub name: String,
     pub typ: String,
-}
-
-impl From<tst::TypeInfo> for HoverInfo {
-    fn from(info: tst::TypeInfo) -> Self {
-        HoverInfo {
-            typ: info.typ.print_to_string(None),
-            ctx: info.ctx.map(Into::into),
-            span: info.span,
-        }
-    }
 }
 
 impl From<TypeCtx> for Ctx {

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -18,20 +18,13 @@ pub struct HoverInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HoverInfoContent {
-    GenericInfo(GenericInfo),
     VariableInfo(VariableInfo),
     TypeCtorInfo(TypeCtorInfo),
     CallInfo(CallInfo),
     DotCallInfo(DotCallInfo),
     TypeUnivInfo(TypeUnivInfo),
     HoleInfo(HoleInfo),
-}
-
-// TODO: Completely remove generic info and replace it with concrete types.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GenericInfo {
-    pub typ: String,
-    pub ctx: Option<Ctx>,
+    AnnoInfo(AnnoInfo),
 }
 
 /// Hover information for bound variables
@@ -61,6 +54,12 @@ pub struct DotCallInfo {
 /// Hover information for type universes
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeUnivInfo {
+    pub typ: String,
+}
+
+/// Hover information for type annotated terms
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnnoInfo {
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -10,8 +10,13 @@ use syntax::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoverInfo {
-    pub typ: String,
     pub span: Span,
+    pub content: HoverInfoContent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoverInfoContent {
+    pub typ: String,
     pub ctx: Option<Ctx>,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -23,6 +23,7 @@ pub enum HoverInfoContent {
     TypeCtorInfo(TypeCtorInfo),
     CallInfo(CallInfo),
     DotCallInfo(DotCallInfo),
+    TypeUnivInfo(TypeUnivInfo),
 }
 
 // TODO: Completely remove generic info and replace it with concrete types.
@@ -53,6 +54,12 @@ pub struct CallInfo {
 /// Hover information for dotcalls (destructors or definitions)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DotCallInfo {
+    pub typ: String,
+}
+
+/// Hover information for type universes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeUnivInfo {
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -20,6 +20,7 @@ pub struct HoverInfo {
 pub enum HoverInfoContent {
     GenericInfo(GenericInfo),
     VariableInfo(VariableInfo),
+    TypeCtorInfo(TypeCtorInfo),
 }
 
 // TODO: Completely remove generic info and replace it with concrete types.
@@ -29,8 +30,15 @@ pub struct GenericInfo {
     pub ctx: Option<Ctx>,
 }
 
+/// Hover information for bound variables
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableInfo {
+    pub typ: String,
+}
+
+/// Hover information for type constructors
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeCtorInfo {
     pub typ: String,
 }
 

--- a/lang/query/src/info/mod.rs
+++ b/lang/query/src/info/mod.rs
@@ -1,8 +1,8 @@
 //! This module provides utilities which are used by the language
 //! server for the type-on-hover and code-action features.
 
-mod data;
 mod collect;
+mod data;
 
-pub use data::*;
 pub use collect::*;
+pub use data::*;

--- a/lang/query/src/info/mod.rs
+++ b/lang/query/src/info/mod.rs
@@ -1,0 +1,8 @@
+//! This module provides utilities which are used by the language
+//! server for the type-on-hover and code-action features.
+
+mod data;
+mod collect;
+
+pub use data::*;
+pub use collect::*;

--- a/lang/query/src/view/spans.rs
+++ b/lang/query/src/view/spans.rs
@@ -1,6 +1,6 @@
 use codespan::{ByteIndex, Location, Span};
 
-use super::info::{Info, Item};
+use super::info::{HoverInfo, Item};
 use super::DatabaseView;
 
 impl<'a> DatabaseView<'a> {
@@ -22,11 +22,11 @@ impl<'a> DatabaseView<'a> {
         Some((start, end))
     }
 
-    pub fn info_at_index(&self, idx: ByteIndex) -> Option<Info> {
-        self.info_at_span(Span::new(idx, ByteIndex(u32::from(idx) + 1)))
+    pub fn hoverinfo_at_index(&self, idx: ByteIndex) -> Option<HoverInfo> {
+        self.hoverinfo_at_span(Span::new(idx, ByteIndex(u32::from(idx) + 1)))
     }
 
-    pub fn info_at_span(&self, span: Span) -> Option<Info> {
+    pub fn hoverinfo_at_span(&self, span: Span) -> Option<HoverInfo> {
         let index = self.index()?;
         let lapper = index.infos();
         let intervals = lapper.find(span.start().into(), span.end().into());

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -2,7 +2,7 @@
 
 use tower_lsp::{jsonrpc, lsp_types::*};
 
-use query::{Binder, Ctx, DatabaseView, HoverInfo};
+use query::{Binder, Ctx, DatabaseView, HoverInfo, HoverInfoContent};
 
 use super::conversion::*;
 use super::server::*;
@@ -22,7 +22,7 @@ pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Opti
 
 fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
     let range = index.span_to_locations(info.span).map(ToLsp::to_lsp);
-    let contents = info.to_hover_content();
+    let contents = info.content.to_hover_content();
     Hover { contents, range }
 }
 
@@ -53,7 +53,7 @@ trait ToHoverContent {
     fn to_hover_content(self) -> HoverContents;
 }
 
-impl ToHoverContent for HoverInfo {
+impl ToHoverContent for HoverInfoContent {
     fn to_hover_content(self) -> HoverContents {
         match self.ctx {
             Some(ctx) => {

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -67,6 +67,8 @@ impl ToHoverContent for HoverInfoContent {
             HoverInfoContent::GenericInfo(i) => i.to_hover_content(),
             HoverInfoContent::VariableInfo(i) => i.to_hover_content(),
             HoverInfoContent::TypeCtorInfo(i) => i.to_hover_content(),
+            HoverInfoContent::CallInfo(i) => i.to_hover_content(),
+            HoverInfoContent::DotCallInfo(i) => i.to_hover_content(),
         }
     }
 }
@@ -99,6 +101,24 @@ impl ToHoverContent for TypeCtorInfo {
     fn to_hover_content(self) -> HoverContents {
         let TypeCtorInfo { typ } = self;
         let header = MarkedString::String("Type constructor".to_owned());
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
+    }
+}
+
+impl ToHoverContent for CallInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let CallInfo { typ } = self;
+        let header =
+            MarkedString::String("Constructor / codefinition / let-bound definition".to_owned());
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
+    }
+}
+impl ToHoverContent for DotCallInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let DotCallInfo { typ } = self;
+        let header = MarkedString::String("Destructor / definition".to_owned());
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -70,6 +70,7 @@ impl ToHoverContent for HoverInfoContent {
             HoverInfoContent::CallInfo(i) => i.to_hover_content(),
             HoverInfoContent::DotCallInfo(i) => i.to_hover_content(),
             HoverInfoContent::TypeUnivInfo(i) => i.to_hover_content(),
+            HoverInfoContent::HoleInfo(i) => i.to_hover_content(),
         }
     }
 }
@@ -132,5 +133,20 @@ impl ToHoverContent for TypeUnivInfo {
         let header = MarkedString::String("Type universe".to_owned());
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
+    }
+}
+
+impl ToHoverContent for HoleInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let HoleInfo { goal, ctx } = self;
+        if let Some(ctx) = ctx {
+            let mut value = String::new();
+            goal_to_markdown(&goal, &mut value);
+            value.push_str("\n\n");
+            ctx_to_markdown(&ctx, &mut value);
+            HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
+        } else {
+            HoverContents::Scalar(string_to_language_string(goal))
+        }
     }
 }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -7,23 +7,22 @@ use query::{Binder, Ctx, DatabaseView, HoverInfo};
 use super::conversion::*;
 use super::server::*;
 
+// The implementation of the hover functionality that gets called by the LSP server.
+pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
+    let pos_params = params.text_document_position_params;
+    let text_document = pos_params.text_document;
+    let pos = pos_params.position;
+    let db = server.database.read().await;
+    let index = db.get(text_document.uri.as_str()).unwrap();
+    let info =
+        index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
+    let res = info.map(|info| info_to_hover(&index, info));
+    Ok(res)
+}
+
 fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
-    let range = info.span.and_then(|span| index.span_to_locations(span)).map(ToLsp::to_lsp);
-
-    let contents = match info.ctx {
-        Some(ctx) => {
-            let mut value = String::new();
-            goal_to_markdown(&info.typ, &mut value);
-            value.push_str("\n\n");
-            ctx_to_markdown(&ctx, &mut value);
-            HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
-        }
-        None => HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
-            language: "pol".to_owned(),
-            value: info.typ,
-        })),
-    };
-
+    let range = index.span_to_locations(info.span).map(ToLsp::to_lsp);
+    let contents = info.to_hover_content();
     Hover { contents, range }
 }
 
@@ -50,14 +49,24 @@ fn goal_to_markdown(goal_type: &str, value: &mut String) {
     value.push_str("\n```\n");
 }
 
-pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
-    let pos_params = params.text_document_position_params;
-    let text_document = pos_params.text_document;
-    let pos = pos_params.position;
-    let db = server.database.read().await;
-    let index = db.get(text_document.uri.as_str()).unwrap();
-    let info =
-        index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
-    let res = info.map(|info| info_to_hover(&index, info));
-    Ok(res)
+trait ToHoverContent {
+    fn to_hover_content(self) -> HoverContents;
+}
+
+impl ToHoverContent for HoverInfo {
+    fn to_hover_content(self) -> HoverContents {
+        match self.ctx {
+            Some(ctx) => {
+                let mut value = String::new();
+                goal_to_markdown(&self.typ, &mut value);
+                value.push_str("\n\n");
+                ctx_to_markdown(&ctx, &mut value);
+                HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
+            }
+            None => HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
+                language: "pol".to_owned(),
+                value: self.typ,
+            })),
+        }
+    }
 }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -66,6 +66,7 @@ impl ToHoverContent for HoverInfoContent {
         match self {
             HoverInfoContent::GenericInfo(i) => i.to_hover_content(),
             HoverInfoContent::VariableInfo(i) => i.to_hover_content(),
+            HoverInfoContent::TypeCtorInfo(i) => i.to_hover_content(),
         }
     }
 }
@@ -89,6 +90,15 @@ impl ToHoverContent for VariableInfo {
     fn to_hover_content(self) -> HoverContents {
         let VariableInfo { typ } = self;
         let header = MarkedString::String("Bound variable".to_owned());
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
+    }
+}
+
+impl ToHoverContent for TypeCtorInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let TypeCtorInfo { typ } = self;
+        let header = MarkedString::String("Type constructor".to_owned());
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -69,6 +69,7 @@ impl ToHoverContent for HoverInfoContent {
             HoverInfoContent::TypeCtorInfo(i) => i.to_hover_content(),
             HoverInfoContent::CallInfo(i) => i.to_hover_content(),
             HoverInfoContent::DotCallInfo(i) => i.to_hover_content(),
+            HoverInfoContent::TypeUnivInfo(i) => i.to_hover_content(),
         }
     }
 }
@@ -115,10 +116,20 @@ impl ToHoverContent for CallInfo {
         HoverContents::Array(vec![header, typ])
     }
 }
+
 impl ToHoverContent for DotCallInfo {
     fn to_hover_content(self) -> HoverContents {
         let DotCallInfo { typ } = self;
         let header = MarkedString::String("Destructor / definition".to_owned());
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
+    }
+}
+
+impl ToHoverContent for TypeUnivInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let TypeUnivInfo { typ } = self;
+        let header = MarkedString::String("Type universe".to_owned());
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -1,0 +1,63 @@
+//! Implementation of the type-on-hover functionality of the LSP server
+
+use tower_lsp::{jsonrpc, lsp_types::*};
+
+use query::{Binder, Ctx, DatabaseView, HoverInfo};
+
+use super::conversion::*;
+use super::server::*;
+
+fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
+    let range = info.span.and_then(|span| index.span_to_locations(span)).map(ToLsp::to_lsp);
+
+    let contents = match info.ctx {
+        Some(ctx) => {
+            let mut value = String::new();
+            goal_to_markdown(&info.typ, &mut value);
+            value.push_str("\n\n");
+            ctx_to_markdown(&ctx, &mut value);
+            HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
+        }
+        None => HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
+            language: "pol".to_owned(),
+            value: info.typ,
+        })),
+    };
+
+    Hover { contents, range }
+}
+
+fn ctx_to_markdown(ctx: &Ctx, value: &mut String) {
+    value.push_str("**Context**\n\n");
+    value.push_str("| | |\n");
+    value.push_str("|-|-|\n");
+    for Binder { name, typ } in ctx.bound.iter().rev().flatten() {
+        if name == "_" {
+            continue;
+        }
+        value.push_str("| ");
+        value.push_str(name);
+        value.push_str(" | `");
+        value.push_str(typ);
+        value.push_str("` |\n");
+    }
+}
+
+fn goal_to_markdown(goal_type: &str, value: &mut String) {
+    value.push_str("**Goal**\n\n");
+    value.push_str("```\n");
+    value.push_str(goal_type);
+    value.push_str("\n```\n");
+}
+
+pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
+    let pos_params = params.text_document_position_params;
+    let text_document = pos_params.text_document;
+    let pos = pos_params.position;
+    let db = server.database.read().await;
+    let index = db.get(text_document.uri.as_str()).unwrap();
+    let info =
+        index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
+    let res = info.map(|info| info_to_hover(&index, info));
+    Ok(res)
+}

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -64,28 +64,13 @@ trait ToHoverContent {
 impl ToHoverContent for HoverInfoContent {
     fn to_hover_content(self) -> HoverContents {
         match self {
-            HoverInfoContent::GenericInfo(i) => i.to_hover_content(),
             HoverInfoContent::VariableInfo(i) => i.to_hover_content(),
             HoverInfoContent::TypeCtorInfo(i) => i.to_hover_content(),
             HoverInfoContent::CallInfo(i) => i.to_hover_content(),
             HoverInfoContent::DotCallInfo(i) => i.to_hover_content(),
             HoverInfoContent::TypeUnivInfo(i) => i.to_hover_content(),
             HoverInfoContent::HoleInfo(i) => i.to_hover_content(),
-        }
-    }
-}
-
-impl ToHoverContent for GenericInfo {
-    fn to_hover_content(self) -> HoverContents {
-        match self {
-            GenericInfo { typ, ctx: Some(ctx) } => {
-                let mut value = String::new();
-                goal_to_markdown(&typ, &mut value);
-                value.push_str("\n\n");
-                ctx_to_markdown(&ctx, &mut value);
-                HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
-            }
-            GenericInfo { typ, ctx: None } => HoverContents::Scalar(string_to_language_string(typ)),
+            HoverInfoContent::AnnoInfo(i) => i.to_hover_content(),
         }
     }
 }
@@ -131,6 +116,15 @@ impl ToHoverContent for TypeUnivInfo {
     fn to_hover_content(self) -> HoverContents {
         let TypeUnivInfo { typ } = self;
         let header = MarkedString::String("Type universe".to_owned());
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
+    }
+}
+
+impl ToHoverContent for AnnoInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let AnnoInfo { typ } = self;
+        let header = MarkedString::String("Annotated term".to_owned());
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/lib.rs
+++ b/util/lsp/src/lib.rs
@@ -1,6 +1,7 @@
 mod capabilities;
 mod conversion;
 mod diagnostics;
+mod hover;
 mod server;
 
 pub use server::*;

--- a/util/lsp/src/server.rs
+++ b/util/lsp/src/server.rs
@@ -4,7 +4,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::{jsonrpc, lsp_types::*, LanguageServer};
 
 use printer::{PrintCfg, PrintToString};
-use query::{Binder, Ctx, Database, DatabaseView, File, Info, Xfunc};
+use query::{Binder, Ctx, Database, DatabaseView, File, HoverInfo, Xfunc};
 
 use super::capabilities::*;
 use super::conversion::*;
@@ -67,7 +67,8 @@ impl LanguageServer for Server {
         let pos = pos_params.position;
         let db = self.database.read().await;
         let index = db.get(text_document.uri.as_str()).unwrap();
-        let info = index.location_to_index(pos.from_lsp()).and_then(|idx| index.info_at_index(idx));
+        let info =
+            index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
         let res = info.map(|info| info_to_hover(&index, info));
         Ok(res)
     }
@@ -149,7 +150,7 @@ impl Server {
     }
 }
 
-fn info_to_hover(index: &DatabaseView, info: Info) -> Hover {
+fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
     let range = info.span.and_then(|span| index.span_to_locations(span)).map(ToLsp::to_lsp);
 
     let contents = match info.ctx {

--- a/util/lsp/src/server.rs
+++ b/util/lsp/src/server.rs
@@ -4,7 +4,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::{jsonrpc, lsp_types::*, LanguageServer};
 
 use printer::{PrintCfg, PrintToString};
-use query::{Binder, Ctx, Database, DatabaseView, File, HoverInfo, Xfunc};
+use query::{Database, File, Xfunc};
 
 use super::capabilities::*;
 use super::conversion::*;
@@ -62,15 +62,7 @@ impl LanguageServer for Server {
     }
 
     async fn hover(&self, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
-        let pos_params = params.text_document_position_params;
-        let text_document = pos_params.text_document;
-        let pos = pos_params.position;
-        let db = self.database.read().await;
-        let index = db.get(text_document.uri.as_str()).unwrap();
-        let info =
-            index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
-        let res = info.map(|info| info_to_hover(&index, info));
-        Ok(res)
+        super::hover::hover(self, params).await
     }
 
     async fn code_action(
@@ -148,47 +140,4 @@ impl Server {
     async fn send_diagnostics(&self, url: Url, diags: Vec<Diagnostic>) {
         self.client.publish_diagnostics(url, diags, None).await;
     }
-}
-
-fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
-    let range = info.span.and_then(|span| index.span_to_locations(span)).map(ToLsp::to_lsp);
-
-    let contents = match info.ctx {
-        Some(ctx) => {
-            let mut value = String::new();
-            goal_to_markdown(&info.typ, &mut value);
-            value.push_str("\n\n");
-            ctx_to_markdown(&ctx, &mut value);
-            HoverContents::Markup(MarkupContent { kind: MarkupKind::Markdown, value })
-        }
-        None => HoverContents::Scalar(MarkedString::LanguageString(LanguageString {
-            language: "pol".to_owned(),
-            value: info.typ,
-        })),
-    };
-
-    Hover { contents, range }
-}
-
-fn ctx_to_markdown(ctx: &Ctx, value: &mut String) {
-    value.push_str("**Context**\n\n");
-    value.push_str("| | |\n");
-    value.push_str("|-|-|\n");
-    for Binder { name, typ } in ctx.bound.iter().rev().flatten() {
-        if name == "_" {
-            continue;
-        }
-        value.push_str("| ");
-        value.push_str(name);
-        value.push_str(" | `");
-        value.push_str(typ);
-        value.push_str("` |\n");
-    }
-}
-
-fn goal_to_markdown(goal_type: &str, value: &mut String) {
-    value.push_str("**Goal**\n\n");
-    value.push_str("```\n");
-    value.push_str(goal_type);
-    value.push_str("\n```\n");
 }


### PR DESCRIPTION
Previously we only generated hover information from the "TypeInfo" field which was annotated in various expressions. This had the downside that we could not print specific information about the syntax node, for example if it is a bound variable or a constructor, or a typed hole, etc.

I have rewritten a huge chunk of the `type-on-hover` functionality so that we now display additional information when you hover over a syntax node.
Currently the only additional information is the "kind" of syntax node, but we can add more information in the future, for example the doc strings.