### PR TITLE
Remove Phases from syntax representation

### DIFF
--- a/lang/elaborator/src/typechecker/typecheck.rs
+++ b/lang/elaborator/src/typechecker/typecheck.rs
@@ -770,7 +770,7 @@ impl Check for ust::LocalMatch {
                     span: *info,
                     param: tst::ParamInst {
                         span: *info,
-                        info: tst::TypeInfo { typ: self_t_nf, ctx: None },
+                        info: Some(self_t_nf),
                         name: param.name.clone(),
                         typ: Rc::new(typ_app.to_exp()).into(),
                     },
@@ -1065,14 +1065,14 @@ impl CheckTelescope for ust::TelescopeInst {
             iter,
             vec![],
             |ctx, params_out, (param_actual, param_expected)| {
-                let ust::ParamInst { span, info: (), name, typ: _ } = param_actual;
+                let ust::ParamInst { span, name, .. } = param_actual;
                 let ust::Param { typ, .. } = param_expected;
                 let typ_out = typ.check(prg, ctx, type_univ())?;
                 let typ_nf = typ.normalize(prg, &mut ctx.env())?;
                 let mut params_out = params_out;
                 let param_out = tst::ParamInst {
                     span: *span,
-                    info: tst::TypeInfo { typ: typ_nf.clone(), ctx: None },
+                    info: Some(typ_nf.clone()),
                     name: name.clone(),
                     typ: typ_out.into(),
                 };

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -528,9 +528,9 @@ impl Lift for tst::ParamInst {
     type Target = ust::ParamInst;
 
     fn lift(&self, _ctx: &mut Ctx) -> Self::Target {
-        let tst::ParamInst { span, info, name, typ: _ } = self;
+        let tst::ParamInst { span, name, typ: _, .. } = self;
 
-        ust::ParamInst { span: *span, info: info.forget_tst(), name: name.clone(), typ: None }
+        ust::ParamInst { span: *span, info: None, name: name.clone(), typ: None }
     }
 }
 
@@ -593,7 +593,7 @@ impl Ctx {
         let ret_fvs = motive
             .as_ref()
             .map(|m| free_vars(&m.forget_tst(), type_ctx))
-            .unwrap_or_else(|| free_vars(&ret_typ.forget_tst(), type_ctx));
+            .unwrap_or_else(|| free_vars(&ret_typ.as_ref().map(|x| x.forget_tst()), type_ctx));
 
         let body = body.lift(self);
         let self_typ = inferred_type.lift(self);

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -59,7 +59,7 @@ fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ust::TelescopeInst) -> Result<T, 
             let mut params_out = params_out?;
             let span = bs_to_span(param);
             let name = bs_to_name(param);
-            let param_out = ust::ParamInst { span: Some(span), info: (), name, typ: None };
+            let param_out = ust::ParamInst { span: Some(span), info: None, name, typ: None };
             params_out.push(param_out);
             Ok(params_out)
         },
@@ -302,7 +302,7 @@ impl Lower for cst::exp::Motive {
             span: Some(*span),
             param: ust::ParamInst {
                 span: Some(bs_to_span(param)),
-                info: (),
+                info: None,
                 name: bs_to_name(param),
                 typ: None,
             },

--- a/lang/printer/src/generic.rs
+++ b/lang/printer/src/generic.rs
@@ -15,20 +15,14 @@ fn is_visible(attr: &Attribute) -> bool {
     !attr.attrs.contains(&"omit_print".to_owned())
 }
 
-impl<'a, P: Phase> Print<'a> for Prg<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Prg {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Prg { decls } = self;
         decls.print(cfg, alloc)
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Decls<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Decls {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let items =
             self.iter().filter(|item| is_visible(item.attributes())).map(|item| match item {
@@ -44,11 +38,8 @@ where
     }
 }
 
-impl<'a, P: Phase> PrintInCtx<'a> for Decl<P>
-where
-    Exp<P>: Shift,
-{
-    type Ctx = Decls<P>;
+impl<'a> PrintInCtx<'a> for Decl {
+    type Ctx = Decls;
 
     fn print_in_ctx(
         &'a self,
@@ -68,11 +59,8 @@ where
     }
 }
 
-impl<'a, P: Phase> PrintInCtx<'a> for Item<'a, P>
-where
-    Exp<P>: Shift,
-{
-    type Ctx = Decls<P>;
+impl<'a> PrintInCtx<'a> for Item<'a> {
+    type Ctx = Decls;
 
     fn print_in_ctx(
         &'a self,
@@ -90,11 +78,8 @@ where
     }
 }
 
-impl<'a, P: Phase> PrintInCtx<'a> for Data<P>
-where
-    Exp<P>: Shift,
-{
-    type Ctx = Decls<P>;
+impl<'a> PrintInCtx<'a> for Data {
+    type Ctx = Decls;
 
     fn print_in_ctx(
         &'a self,
@@ -138,11 +123,8 @@ where
     }
 }
 
-impl<'a, P: Phase> PrintInCtx<'a> for Codata<P>
-where
-    Exp<P>: Shift,
-{
-    type Ctx = Decls<P>;
+impl<'a> PrintInCtx<'a> for Codata {
+    type Ctx = Decls;
 
     fn print_in_ctx(
         &'a self,
@@ -186,10 +168,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Def<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Def {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Def { span: _, doc, name, attr, params, self_param, ret_typ, body } = self;
         if !is_visible(attr) {
@@ -214,10 +193,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Codef<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Codef {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Codef { span: _, doc, name, attr, params, typ, body } = self;
         if !is_visible(attr) {
@@ -244,10 +220,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Let<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Let {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Let { span: _, doc, name, attr, params, typ, body } = self;
         if !is_visible(attr) {
@@ -270,10 +243,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Ctor<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Ctor {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Ctor { span: _, doc, name, params, typ } = self;
 
@@ -289,10 +259,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Dtor<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Dtor {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Dtor { span: _, doc, name, params, self_param, ret_typ } = self;
 
@@ -311,7 +278,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Match<P> {
+impl<'a> Print<'a> for Match {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Match { span: _, cases, omit_absurd } = self;
         match cases.len() {
@@ -354,7 +321,7 @@ impl<'a, P: Phase> Print<'a> for Match<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Case<P> {
+impl<'a> Print<'a> for Case {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Case { span: _, name, params, body } = self;
 
@@ -371,17 +338,14 @@ impl<'a, P: Phase> Print<'a> for Case<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Telescope<P>
-where
-    Exp<P>: Shift,
-{
+impl<'a> Print<'a> for Telescope {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Telescope { params } = self;
         let mut output = alloc.nil();
         if params.is_empty() {
             return output;
         };
-        let mut running_type: Option<&Rc<Exp<P>>> = None;
+        let mut running_type: Option<&Rc<Exp>> = None;
         for Param { name, typ } in params {
             match running_type {
                 // We need to shift before comparing to ensure we compare the correct De-Bruijn indices
@@ -418,7 +382,7 @@ where
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Args<P> {
+impl<'a> Print<'a> for Args {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let mut doc = alloc.nil();
         let mut iter = self.args.iter().peekable();
@@ -432,7 +396,7 @@ impl<'a, P: Phase> Print<'a> for Args<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for TelescopeInst<P> {
+impl<'a> Print<'a> for TelescopeInst {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         if self.params.is_empty() {
             alloc.nil()
@@ -442,21 +406,21 @@ impl<'a, P: Phase> Print<'a> for TelescopeInst<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Param<P> {
+impl<'a> Print<'a> for Param {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Param { name, typ } = self;
         alloc.text(name).append(COLON).append(alloc.space()).append(typ.print(cfg, alloc))
     }
 }
 
-impl<'a, P: Phase> Print<'a> for ParamInst<P> {
+impl<'a> Print<'a> for ParamInst {
     fn print(&'a self, _cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let ParamInst { span: _, info: _, name, typ: _ } = self;
         alloc.text(name)
     }
 }
 
-impl<'a, P: Phase> Print<'a> for SelfParam<P> {
+impl<'a> Print<'a> for SelfParam {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let SelfParam { info: _, name, typ } = self;
 
@@ -472,7 +436,7 @@ impl<'a, P: Phase> Print<'a> for SelfParam<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Exp<P> {
+impl<'a> Print<'a> for Exp {
     fn print_prec(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>, prec: Precedence) -> Builder<'a> {
         match self {
             Exp::Variable(e) => e.print_prec(cfg, alloc, prec),
@@ -517,7 +481,7 @@ impl<'a> Print<'a> for Variable {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for TypCtor<P> {
+impl<'a> Print<'a> for TypCtor {
     fn print_prec(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>, prec: Precedence) -> Builder<'a> {
         let TypCtor { span: _, name, args } = self;
         if name == "Fun" && args.len() == 2 && cfg.print_function_sugar {
@@ -536,7 +500,7 @@ impl<'a, P: Phase> Print<'a> for TypCtor<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Call<P> {
+impl<'a> Print<'a> for Call {
     fn print_prec(
         &'a self,
         cfg: &PrintCfg,
@@ -549,7 +513,7 @@ impl<'a, P: Phase> Print<'a> for Call<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for syntax::generic::Anno<P> {
+impl<'a> Print<'a> for syntax::generic::Anno {
     fn print_prec(
         &'a self,
         cfg: &PrintCfg,
@@ -583,7 +547,7 @@ impl<'a> Print<'a> for Hole {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for LocalMatch<P> {
+impl<'a> Print<'a> for LocalMatch {
     fn print_prec(
         &'a self,
         cfg: &PrintCfg,
@@ -605,7 +569,7 @@ impl<'a, P: Phase> Print<'a> for LocalMatch<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for LocalComatch<P> {
+impl<'a> Print<'a> for LocalComatch {
     fn print_prec(
         &'a self,
         cfg: &PrintCfg,
@@ -628,7 +592,7 @@ impl<'a, P: Phase> Print<'a> for LocalComatch<P> {
     }
 }
 
-impl<'a, P: Phase> Print<'a> for Motive<P> {
+impl<'a> Print<'a> for Motive {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Motive { span: _, param, ret_typ } = self;
 
@@ -703,11 +667,7 @@ fn print_return_type<'a, T: Print<'a>>(
 /// Only invoke this function if the comatch contains exactly
 /// one cocase "ap" with three arguments; the function will
 /// panic otherwise.
-fn print_lambda_sugar<'a, P: Phase>(
-    e: &'a Match<P>,
-    cfg: &PrintCfg,
-    alloc: &'a Alloc<'a>,
-) -> Builder<'a> {
+fn print_lambda_sugar<'a>(e: &'a Match, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
     let Match { cases, .. } = e;
     let Case { params, body, .. } = cases.first().expect("Empty comatch marked as lambda sugar");
     let var_name = params

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -46,10 +46,7 @@ impl<R: Rename + Clone> Rename for Rc<R> {
     }
 }
 
-impl<P: Phase> Rename for Prg<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Prg {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Prg { decls } = self;
 
@@ -57,10 +54,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Decls<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Decls {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         Decls {
             map: self.map.into_iter().map(|(name, decl)| (name, decl.rename_in_ctx(ctx))).collect(),
@@ -69,10 +63,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Decl<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Decl {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         match self {
             Decl::Data(data) => Decl::Data(data.rename_in_ctx(ctx)),
@@ -86,20 +77,14 @@ where
     }
 }
 
-impl<P: Phase> Rename for Data<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Data {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Data { span, doc, name, attr, typ, ctors } = self;
         Data { span, doc, name, attr, typ: typ.rename_in_ctx(ctx), ctors }
     }
 }
 
-impl<P: Phase> Rename for Codata<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Codata {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Codata { span, doc, name, attr, typ, dtors } = self;
 
@@ -107,10 +92,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Ctor<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Ctor {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Ctor { span, doc, name, params, typ } = self;
         let new_params = params.rename_in_ctx(ctx);
@@ -121,10 +103,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Dtor<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Dtor {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Dtor { span, doc, name, params, self_param, ret_typ } = self;
 
@@ -140,10 +119,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Def<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Def {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Def { span, doc, name, attr, params, self_param, ret_typ, body } = self;
 
@@ -169,10 +145,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Codef<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Codef {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Codef { span, doc, name, attr, params, typ, body } = self;
 
@@ -188,10 +161,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Let<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Let {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Let { span, doc, name, attr, params, typ, body } = self;
 
@@ -207,20 +177,14 @@ where
     }
 }
 
-impl<P: Phase> Rename for TypAbs<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for TypAbs {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let TypAbs { params } = self;
         TypAbs { params: params.rename_in_ctx(ctx) }
     }
 }
 
-impl<P: Phase> Rename for Telescope<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Telescope {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Telescope { params } = self;
 
@@ -238,10 +202,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Param<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Param {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Param { name, typ } = self;
 
@@ -252,10 +213,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for TelescopeInst<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for TelescopeInst {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let TelescopeInst { params } = self;
 
@@ -273,10 +231,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for ParamInst<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for ParamInst {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let ParamInst { span, name, typ, info } = self;
 
@@ -288,10 +243,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for SelfParam<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for SelfParam {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let SelfParam { info, name, typ } = self;
 
@@ -301,10 +253,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Exp<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Exp {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         match self {
             Exp::Variable(e) => Exp::Variable(e.rename_in_ctx(ctx)),
@@ -373,20 +322,14 @@ impl Rename for Variable {
         }
     }
 }
-impl<P: Phase> Rename for TypCtor<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for TypCtor {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let TypCtor { span, name, args } = self;
         TypCtor { span, name, args: args.rename_in_ctx(ctx) }
     }
 }
 
-impl<P: Phase> Rename for Match<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Match {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Match { span, cases, omit_absurd } = self;
 
@@ -394,10 +337,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Args<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Args {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Args { args } = self;
 
@@ -405,10 +345,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Case<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Case {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Case { span, name, params, body } = self;
 
@@ -422,10 +359,7 @@ where
     }
 }
 
-impl<P: Phase> Rename for Motive<P>
-where
-    P::TypeInfo: Rename,
-{
+impl Rename for Motive {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         let Motive { span, param, ret_typ } = self;
 

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -233,13 +233,12 @@ impl Rename for TelescopeInst {
 
 impl Rename for ParamInst {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let ParamInst { span, name, typ, info } = self;
+        let ParamInst { span, name, typ, .. } = self;
 
         let new_typ = typ.rename_in_ctx(ctx);
         let new_name = ctx.disambiguate_name(name);
-        let new_info = info.rename_in_ctx(ctx);
 
-        ParamInst { span, name: new_name, typ: new_typ, info: new_info }
+        ParamInst { span, name: new_name, typ: new_typ, info: None }
     }
 }
 

--- a/lang/renaming/src/ctx.rs
+++ b/lang/renaming/src/ctx.rs
@@ -70,19 +70,19 @@ impl Ctx {
     }
 }
 
-impl<P: Phase> ContextElem<Ctx> for Param<P> {
+impl ContextElem<Ctx> for Param {
     fn as_element(&self) -> <Ctx as Context>::ElemIn {
         self.name.to_owned()
     }
 }
 
-impl<P: Phase> ContextElem<Ctx> for ParamInst<P> {
+impl ContextElem<Ctx> for ParamInst {
     fn as_element(&self) -> <Ctx as Context>::ElemIn {
         self.name.to_owned()
     }
 }
 
-impl<P: Phase> ContextElem<Ctx> for SelfParam<P> {
+impl ContextElem<Ctx> for SelfParam {
     fn as_element(&self) -> <Ctx as Context>::ElemIn {
         self.name.to_owned().unwrap_or_default()
     }

--- a/lang/syntax/src/ctx/map.rs
+++ b/lang/syntax/src/ctx/map.rs
@@ -4,44 +4,44 @@ use codespan::Span;
 
 use std::rc::Rc;
 
-pub trait MapCtxExt<P: Phase> {
+pub trait MapCtxExt {
     fn ctx_map_telescope<X, I, F1, F2>(&mut self, params: I, f_acc: F1, f_inner: F2) -> X
     where
-        I: IntoIterator<Item = Param<P>>,
-        F1: Fn(&mut Self, Param<P>) -> Param<P>,
-        F2: FnOnce(&mut Self, Telescope<P>) -> X;
+        I: IntoIterator<Item = Param>,
+        F1: Fn(&mut Self, Param) -> Param,
+        F2: FnOnce(&mut Self, Telescope) -> X;
 
     fn ctx_map_telescope_inst<X, I, F1, F2>(&mut self, params: I, f_acc: F1, f_inner: F2) -> X
     where
-        I: IntoIterator<Item = ParamInst<P>>,
-        F1: Fn(&mut Self, ParamInst<P>) -> ParamInst<P>,
-        F2: FnOnce(&mut Self, TelescopeInst<P>) -> X;
+        I: IntoIterator<Item = ParamInst>,
+        F1: Fn(&mut Self, ParamInst) -> ParamInst,
+        F2: FnOnce(&mut Self, TelescopeInst) -> X;
 
-    fn ctx_map_motive_param<X, F>(&mut self, param: ParamInst<P>, f_inner: F) -> X
+    fn ctx_map_motive_param<X, F>(&mut self, param: ParamInst, f_inner: F) -> X
     where
-        F: FnOnce(&mut Self, ParamInst<P>) -> X;
+        F: FnOnce(&mut Self, ParamInst) -> X;
 
     fn ctx_map_self_param<X, F>(
         &mut self,
         info: Option<Span>,
         name: Option<Ident>,
-        typ: TypCtor<P>,
+        typ: TypCtor,
         f_inner: F,
     ) -> X
     where
-        F: FnOnce(&mut Self, SelfParam<P>) -> X;
+        F: FnOnce(&mut Self, SelfParam) -> X;
 }
 
-impl<P: Phase, C: BindContext> MapCtxExt<P> for C
+impl<C: BindContext> MapCtxExt for C
 where
-    Param<P>: ContextElem<C::Ctx>,
-    ParamInst<P>: ContextElem<C::Ctx>,
+    Param: ContextElem<C::Ctx>,
+    ParamInst: ContextElem<C::Ctx>,
 {
     fn ctx_map_telescope<X, I, F1, F2>(&mut self, params: I, f_acc: F1, f_inner: F2) -> X
     where
-        I: IntoIterator<Item = Param<P>>,
-        F1: Fn(&mut Self, Param<P>) -> Param<P>,
-        F2: FnOnce(&mut Self, Telescope<P>) -> X,
+        I: IntoIterator<Item = Param>,
+        F1: Fn(&mut Self, Param) -> Param,
+        F2: FnOnce(&mut Self, Telescope) -> X,
     {
         self.bind_fold(
             params.into_iter(),
@@ -59,9 +59,9 @@ where
 
     fn ctx_map_telescope_inst<X, I, F1, F2>(&mut self, params: I, f_acc: F1, f_inner: F2) -> X
     where
-        I: IntoIterator<Item = ParamInst<P>>,
-        F1: Fn(&mut Self, ParamInst<P>) -> ParamInst<P>,
-        F2: FnOnce(&mut Self, TelescopeInst<P>) -> X,
+        I: IntoIterator<Item = ParamInst>,
+        F1: Fn(&mut Self, ParamInst) -> ParamInst,
+        F2: FnOnce(&mut Self, TelescopeInst) -> X,
     {
         self.bind_fold(
             params.into_iter(),
@@ -77,9 +77,9 @@ where
         )
     }
 
-    fn ctx_map_motive_param<X, F>(&mut self, param: ParamInst<P>, f_inner: F) -> X
+    fn ctx_map_motive_param<X, F>(&mut self, param: ParamInst, f_inner: F) -> X
     where
-        F: FnOnce(&mut Self, ParamInst<P>) -> X,
+        F: FnOnce(&mut Self, ParamInst) -> X,
     {
         self.bind_single(param.clone(), |ctx| f_inner(ctx, param))
     }
@@ -88,11 +88,11 @@ where
         &mut self,
         info: Option<Span>,
         name: Option<Ident>,
-        typ: TypCtor<P>,
+        typ: TypCtor,
         f_inner: F,
     ) -> X
     where
-        F: FnOnce(&mut Self, SelfParam<P>) -> X,
+        F: FnOnce(&mut Self, SelfParam) -> X,
     {
         let param = Param { name: name.clone().unwrap_or_default(), typ: Rc::new(typ.to_exp()) };
         self.bind_single(param, |ctx| f_inner(ctx, SelfParam { info, name, typ }))

--- a/lang/syntax/src/trees/generic/decls.rs
+++ b/lang/syntax/src/trees/generic/decls.rs
@@ -21,37 +21,37 @@ pub struct Attribute {
 }
 
 #[derive(Debug, Clone)]
-pub struct Prg<P: Phase> {
-    pub decls: Decls<P>,
+pub struct Prg {
+    pub decls: Decls,
 }
 
-impl<P: Phase> Prg<P> {
-    pub fn find_main(&self) -> Option<Rc<Exp<P>>> {
+impl Prg {
+    pub fn find_main(&self) -> Option<Rc<Exp>> {
         let main_candidate = self.decls.map.get("main")?.get_main()?;
         Some(main_candidate.body)
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Decls<P: Phase> {
+pub struct Decls {
     /// Map from identifiers to declarations
-    pub map: HashMap<Ident, Decl<P>>,
+    pub map: HashMap<Ident, Decl>,
     /// Metadata on declarations
     pub lookup_table: LookupTable,
 }
 
 #[derive(Debug, Clone)]
-pub enum Decl<P: Phase> {
-    Data(Data<P>),
-    Codata(Codata<P>),
-    Ctor(Ctor<P>),
-    Dtor(Dtor<P>),
-    Def(Def<P>),
-    Codef(Codef<P>),
-    Let(Let<P>),
+pub enum Decl {
+    Data(Data),
+    Codata(Codata),
+    Ctor(Ctor),
+    Dtor(Dtor),
+    Def(Def),
+    Codef(Codef),
+    Let(Let),
 }
 
-impl<P: Phase> Decl<P> {
+impl Decl {
     pub fn kind(&self) -> DeclKind {
         match self {
             Decl::Data(_) => DeclKind::Data,
@@ -65,7 +65,7 @@ impl<P: Phase> Decl<P> {
     }
 
     /// Returns whether the declaration is the "main" expression of the module.
-    pub fn get_main(&self) -> Option<Let<P>> {
+    pub fn get_main(&self) -> Option<Let> {
         match self {
             Decl::Let(tl_let) => tl_let.is_main().then(|| tl_let.clone()),
             _ => None,
@@ -73,7 +73,7 @@ impl<P: Phase> Decl<P> {
     }
 }
 
-impl<P: Phase> Named for Decl<P> {
+impl Named for Decl {
     fn name(&self) -> &Ident {
         match self {
             Decl::Data(Data { name, .. }) => name,
@@ -87,7 +87,7 @@ impl<P: Phase> Named for Decl<P> {
     }
 }
 
-impl<P: Phase> HasSpan for Decl<P> {
+impl HasSpan for Decl {
     fn span(&self) -> Option<Span> {
         match self {
             Decl::Data(data) => data.span,
@@ -102,63 +102,63 @@ impl<P: Phase> HasSpan for Decl<P> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Data<P: Phase> {
+pub struct Data {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
     pub attr: Attribute,
-    pub typ: Rc<TypAbs<P>>,
+    pub typ: Rc<TypAbs>,
     pub ctors: Vec<Ident>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Codata<P: Phase> {
+pub struct Codata {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
     pub attr: Attribute,
-    pub typ: Rc<TypAbs<P>>,
+    pub typ: Rc<TypAbs>,
     pub dtors: Vec<Ident>,
 }
 
 #[derive(Debug, Clone)]
-pub struct TypAbs<P: Phase> {
-    pub params: Telescope<P>,
+pub struct TypAbs {
+    pub params: Telescope,
 }
 
 #[derive(Debug, Clone)]
-pub struct Ctor<P: Phase> {
+pub struct Ctor {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
-    pub params: Telescope<P>,
-    pub typ: TypCtor<P>,
+    pub params: Telescope,
+    pub typ: TypCtor,
 }
 
 #[derive(Debug, Clone)]
-pub struct Dtor<P: Phase> {
+pub struct Dtor {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
-    pub params: Telescope<P>,
-    pub self_param: SelfParam<P>,
-    pub ret_typ: Rc<Exp<P>>,
+    pub params: Telescope,
+    pub self_param: SelfParam,
+    pub ret_typ: Rc<Exp>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Def<P: Phase> {
+pub struct Def {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
     pub attr: Attribute,
-    pub params: Telescope<P>,
-    pub self_param: SelfParam<P>,
-    pub ret_typ: Rc<Exp<P>>,
-    pub body: Match<P>,
+    pub params: Telescope,
+    pub self_param: SelfParam,
+    pub ret_typ: Rc<Exp>,
+    pub body: Match,
 }
 
-impl<P: Phase> Def<P> {
-    pub fn to_dtor(&self) -> Dtor<P> {
+impl Def {
+    pub fn to_dtor(&self) -> Dtor {
         Dtor {
             span: self.span,
             doc: self.doc.clone(),
@@ -171,18 +171,18 @@ impl<P: Phase> Def<P> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Codef<P: Phase> {
+pub struct Codef {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
     pub attr: Attribute,
-    pub params: Telescope<P>,
-    pub typ: TypCtor<P>,
-    pub body: Match<P>,
+    pub params: Telescope,
+    pub typ: TypCtor,
+    pub body: Match,
 }
 
-impl<P: Phase> Codef<P> {
-    pub fn to_ctor(&self) -> Ctor<P> {
+impl Codef {
+    pub fn to_ctor(&self) -> Ctor {
         Ctor {
             span: self.span,
             doc: self.doc.clone(),
@@ -194,17 +194,17 @@ impl<P: Phase> Codef<P> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Let<P: Phase> {
+pub struct Let {
     pub span: Option<Span>,
     pub doc: Option<DocComment>,
     pub name: Ident,
     pub attr: Attribute,
-    pub params: Telescope<P>,
-    pub typ: Rc<Exp<P>>,
-    pub body: Rc<Exp<P>>,
+    pub params: Telescope,
+    pub typ: Rc<Exp>,
+    pub body: Rc<Exp>,
 }
 
-impl<P: Phase> Let<P> {
+impl Let {
     /// Returns whether the declaration is the "main" expression of the module.
     pub fn is_main(&self) -> bool {
         self.name == "main" && self.params.is_empty()
@@ -212,14 +212,14 @@ impl<P: Phase> Let<P> {
 }
 
 #[derive(Debug, Clone)]
-pub struct SelfParam<P: Phase> {
+pub struct SelfParam {
     pub info: Option<Span>,
     pub name: Option<Ident>,
-    pub typ: TypCtor<P>,
+    pub typ: TypCtor,
 }
 
-impl<P: Phase> SelfParam<P> {
-    pub fn telescope(&self) -> Telescope<P> {
+impl SelfParam {
+    pub fn telescope(&self) -> Telescope {
         Telescope {
             params: vec![Param {
                 name: self.name.clone().unwrap_or_default(),
@@ -240,11 +240,11 @@ impl<P: Phase> SelfParam<P> {
 /// for the following parameters.
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Telescope<P: Phase> {
-    pub params: Vec<Param<P>>,
+pub struct Telescope {
+    pub params: Vec<Param>,
 }
 
-impl<P: Phase> Telescope<P> {
+impl Telescope {
     pub fn len(&self) -> usize {
         self.params.len()
     }
@@ -256,19 +256,19 @@ impl<P: Phase> Telescope<P> {
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Param<P: Phase> {
+pub struct Param {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub name: Ident,
-    pub typ: Rc<Exp<P>>,
+    pub typ: Rc<Exp>,
 }
 
-impl<P: Phase> Named for Param<P> {
+impl Named for Param {
     fn name(&self) -> &Ident {
         &self.name
     }
 }
 
-impl<P: Phase> Named for ParamInst<P> {
+impl Named for ParamInst {
     fn name(&self) -> &Ident {
         &self.name
     }

--- a/lang/syntax/src/trees/generic/exp.rs
+++ b/lang/syntax/src/trees/generic/exp.rs
@@ -7,16 +7,6 @@ use derivative::Derivative;
 
 use crate::common::*;
 use crate::ctx::values::TypeCtx;
-use crate::tst::TST;
-use crate::ust::UST;
-
-pub trait Phase
-where
-    Self: Default + Clone + fmt::Debug + Eq,
-{
-    /// Type of the `info` field, containing (depending on the phase) type information
-    type TypeInfo: Clone + fmt::Debug;
-}
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
@@ -60,19 +50,19 @@ pub type Ident = String;
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub enum Exp<P: Phase> {
+pub enum Exp {
     Variable(Variable),
-    TypCtor(TypCtor<P>),
-    Call(Call<P>),
-    DotCall(DotCall<P>),
-    Anno(Anno<P>),
+    TypCtor(TypCtor),
+    Call(Call),
+    DotCall(DotCall),
+    Anno(Anno),
     TypeUniv(TypeUniv),
-    LocalMatch(LocalMatch<P>),
-    LocalComatch(LocalComatch<P>),
+    LocalMatch(LocalMatch),
+    LocalComatch(LocalComatch),
     Hole(Hole),
 }
 
-impl<P: Phase> HasSpan for Exp<P> {
+impl HasSpan for Exp {
     fn span(&self) -> Option<Span> {
         match self {
             Exp::Variable(e) => e.span(),
@@ -111,7 +101,7 @@ pub struct Variable {
     pub name: Ident,
     /// Inferred type annotated after elaboration.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<Rc<Exp<UST>>>,
+    pub inferred_type: Option<Rc<Exp>>,
 }
 
 impl HasSpan for Variable {
@@ -120,7 +110,7 @@ impl HasSpan for Variable {
     }
 }
 
-impl<P: Phase> From<Variable> for Exp<P> {
+impl From<Variable> for Exp {
     fn from(val: Variable) -> Self {
         Exp::Variable(val)
     }
@@ -135,18 +125,18 @@ impl<P: Phase> From<Variable> for Exp<P> {
 /// Examples: `Nat`, `List(Nat)`
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct TypCtor<P: Phase> {
+pub struct TypCtor {
     /// Source code location
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     /// Name of the type constructor
     pub name: Ident,
     /// Arguments to the type constructor
-    pub args: Args<P>,
+    pub args: Args,
 }
 
-impl<P: Phase> TypCtor<P> {
-    pub fn to_exp(&self) -> Exp<P> {
+impl TypCtor {
+    pub fn to_exp(&self) -> Exp {
         Exp::TypCtor(self.clone())
     }
 
@@ -156,14 +146,14 @@ impl<P: Phase> TypCtor<P> {
     }
 }
 
-impl<P: Phase> HasSpan for TypCtor<P> {
+impl HasSpan for TypCtor {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<TypCtor<P>> for Exp<P> {
-    fn from(val: TypCtor<P>) -> Self {
+impl From<TypCtor> for Exp {
+    fn from(val: TypCtor) -> Self {
         Exp::TypCtor(val)
     }
 }
@@ -176,7 +166,7 @@ impl<P: Phase> From<TypCtor<P>> for Exp<P> {
 /// Examples: `Zero`, `Cons(True, Nil)`, `minimum(x,y)`
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Call<P: Phase> {
+pub struct Call {
     /// Source code location
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
@@ -185,21 +175,21 @@ pub struct Call<P: Phase> {
     pub name: Ident,
     /// The arguments to the call.
     /// The `(e1...en)` in `f(e1...en)`
-    pub args: Args<P>,
+    pub args: Args,
     /// The inferred result type of the call.
     /// This type is annotated during elaboration.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<Rc<Exp<UST>>>,
+    pub inferred_type: Option<Rc<Exp>>,
 }
 
-impl<P: Phase> HasSpan for Call<P> {
+impl HasSpan for Call {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<Call<P>> for Exp<P> {
-    fn from(val: Call<P>) -> Self {
+impl From<Call> for Exp {
+    fn from(val: Call) -> Self {
         Exp::Call(val)
     }
 }
@@ -212,33 +202,33 @@ impl<P: Phase> From<Call<P>> for Exp<P> {
 /// Examples: `e.head` `xs.append(ys)`
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct DotCall<P: Phase> {
+pub struct DotCall {
     /// Source code location
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     /// The expression to which the dotcall is applied.
     /// The `e` in `e.f(e1...en)`
-    pub exp: Rc<Exp<P>>,
+    pub exp: Rc<Exp>,
     /// The name of the dotcall.
     /// The `f` in `e.f(e1...en)`
     pub name: Ident,
     /// The arguments of the dotcall.
     /// The `(e1...en)` in `e.f(e1...en)`
-    pub args: Args<P>,
+    pub args: Args,
     /// The inferred result type of the dotcall.
     /// This type is annotated during elaboration.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<Rc<Exp<UST>>>,
+    pub inferred_type: Option<Rc<Exp>>,
 }
 
-impl<P: Phase> HasSpan for DotCall<P> {
+impl HasSpan for DotCall {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<DotCall<P>> for Exp<P> {
-    fn from(val: DotCall<P>) -> Self {
+impl From<DotCall> for Exp {
+    fn from(val: DotCall) -> Self {
         Exp::DotCall(val)
     }
 }
@@ -250,29 +240,29 @@ impl<P: Phase> From<DotCall<P>> for Exp<P> {
 /// Type annotated term `e : t`
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Anno<P: Phase> {
+pub struct Anno {
     /// Source code location
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     /// The annotated term, i.e. `e` in `e : t`
-    pub exp: Rc<Exp<P>>,
+    pub exp: Rc<Exp>,
     /// The annotated type, i.e. `t` in `e : t`
-    pub typ: Rc<Exp<P>>,
+    pub typ: Rc<Exp>,
     /// The annotated type written by the user might not
     /// be in normal form. After elaboration we therefore
     /// annotate the normalized type.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub normalized_type: Option<Rc<Exp<UST>>>,
+    pub normalized_type: Option<Rc<Exp>>,
 }
 
-impl<P: Phase> HasSpan for Anno<P> {
+impl HasSpan for Anno {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<Anno<P>> for Exp<P> {
-    fn from(val: Anno<P>) -> Self {
+impl From<Anno> for Exp {
+    fn from(val: Anno) -> Self {
         Exp::Anno(val)
     }
 }
@@ -300,7 +290,7 @@ impl HasSpan for TypeUniv {
     }
 }
 
-impl<P: Phase> From<TypeUniv> for Exp<P> {
+impl From<TypeUniv> for Exp {
     fn from(val: TypeUniv) -> Self {
         Exp::TypeUniv(val)
     }
@@ -312,29 +302,29 @@ impl<P: Phase> From<TypeUniv> for Exp<P> {
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct LocalMatch<P: Phase> {
+pub struct LocalMatch {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub ctx: Option<TypeCtx>,
     pub name: Label,
-    pub on_exp: Rc<Exp<P>>,
-    pub motive: Option<Motive<P>>,
+    pub on_exp: Rc<Exp>,
+    pub motive: Option<Motive>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub ret_typ: Option<Rc<Exp<P>>>,
-    pub body: Match<P>,
+    pub ret_typ: Option<Rc<Exp>>,
+    pub body: Match,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<TypCtor<TST>>,
+    pub inferred_type: Option<TypCtor>,
 }
 
-impl<P: Phase> HasSpan for LocalMatch<P> {
+impl HasSpan for LocalMatch {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<LocalMatch<P>> for Exp<P> {
-    fn from(val: LocalMatch<P>) -> Self {
+impl From<LocalMatch> for Exp {
+    fn from(val: LocalMatch) -> Self {
         Exp::LocalMatch(val)
     }
 }
@@ -345,26 +335,26 @@ impl<P: Phase> From<LocalMatch<P>> for Exp<P> {
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct LocalComatch<P: Phase> {
+pub struct LocalComatch {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub ctx: Option<TypeCtx>,
     pub name: Label,
     pub is_lambda_sugar: bool,
-    pub body: Match<P>,
+    pub body: Match,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<TypCtor<TST>>,
+    pub inferred_type: Option<TypCtor>,
 }
 
-impl<P: Phase> HasSpan for LocalComatch<P> {
+impl HasSpan for LocalComatch {
     fn span(&self) -> Option<Span> {
         self.span
     }
 }
 
-impl<P: Phase> From<LocalComatch<P>> for Exp<P> {
-    fn from(val: LocalComatch<P>) -> Self {
+impl From<LocalComatch> for Exp {
+    fn from(val: LocalComatch) -> Self {
         Exp::LocalComatch(val)
     }
 }
@@ -380,7 +370,7 @@ pub struct Hole {
     pub span: Option<Span>,
     /// The inferred type of the hole annotated during elaboration.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub inferred_type: Option<Rc<Exp<UST>>>,
+    pub inferred_type: Option<Rc<Exp>>,
     /// The type context in which the hole occurs.
     /// This context is annotated during elaboration.
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
@@ -393,7 +383,7 @@ impl HasSpan for Hole {
     }
 }
 
-impl<P: Phase> From<Hole> for Exp<P> {
+impl From<Hole> for Exp {
     fn from(val: Hole) -> Self {
         Exp::Hole(val)
     }
@@ -405,32 +395,32 @@ impl<P: Phase> From<Hole> for Exp<P> {
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Match<P: Phase> {
+pub struct Match {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
-    pub cases: Vec<Case<P>>,
+    pub cases: Vec<Case>,
     pub omit_absurd: bool,
 }
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Case<P: Phase> {
+pub struct Case {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     pub name: Ident,
-    pub params: TelescopeInst<P>,
+    pub params: TelescopeInst,
     /// Body being `None` represents an absurd pattern
-    pub body: Option<Rc<Exp<P>>>,
+    pub body: Option<Rc<Exp>>,
 }
 
 /// Instantiation of a previously declared telescope
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct TelescopeInst<P: Phase> {
-    pub params: Vec<ParamInst<P>>,
+pub struct TelescopeInst {
+    pub params: Vec<ParamInst>,
 }
 
-impl<P: Phase> TelescopeInst<P> {
+impl TelescopeInst {
     pub fn len(&self) -> usize {
         self.params.len()
     }
@@ -443,15 +433,15 @@ impl<P: Phase> TelescopeInst<P> {
 /// Instantiation of a previously declared parameter
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct ParamInst<P: Phase> {
+pub struct ParamInst {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub info: P::TypeInfo,
+    pub info: Option<Rc<Exp>>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub name: Ident,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub typ: Option<Rc<Exp<P>>>,
+    pub typ: Option<Rc<Exp>>,
 }
 
 /// A list of arguments
@@ -462,11 +452,11 @@ pub struct ParamInst<P: Phase> {
 /// Unifiers are another example of context morphisms and applying a unifier to an expression mean substituting various terms,
 /// which are not necessarily part of a single argument list.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Args<P: Phase> {
-    pub args: Vec<Rc<Exp<P>>>,
+pub struct Args {
+    pub args: Vec<Rc<Exp>>,
 }
 
-impl<P: Phase> Args<P> {
+impl Args {
     pub fn len(&self) -> usize {
         self.args.len()
     }
@@ -478,9 +468,9 @@ impl<P: Phase> Args<P> {
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub struct Motive<P: Phase> {
+pub struct Motive {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
-    pub param: ParamInst<P>,
-    pub ret_typ: Rc<Exp<P>>,
+    pub param: ParamInst,
+    pub ret_typ: Rc<Exp>,
 }

--- a/lang/syntax/src/trees/generic/lookup.rs
+++ b/lang/syntax/src/trees/generic/lookup.rs
@@ -10,7 +10,7 @@ use super::exp::*;
 use super::lookup_table;
 use super::lookup_table::DeclKind;
 
-impl<P: Phase> Decls<P> {
+impl Decls {
     pub fn empty() -> Self {
         Self { map: HashMap::default(), lookup_table: Default::default() }
     }
@@ -19,7 +19,7 @@ impl<P: Phase> Decls<P> {
         self.map.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = Item<'_, P>> {
+    pub fn iter(&self) -> impl Iterator<Item = Item<'_>> {
         self.lookup_table.iter().map(|item| match item {
             lookup_table::Item::Type(type_decl) => match &self.map[&type_decl.name] {
                 Decl::Data(data) => Item::Data(data),
@@ -42,7 +42,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &Ident,
         span: Option<codespan::Span>,
-    ) -> Result<DataCodata<'_, P>, LookupError> {
+    ) -> Result<DataCodata<'_>, LookupError> {
         let type_decl = self
             .lookup_table
             .type_decl_for_xtor(name)
@@ -58,7 +58,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &str,
         span: Option<codespan::Span>,
-    ) -> Result<&Data<P>, LookupError> {
+    ) -> Result<&Data, LookupError> {
         self.ctor(name, span)?;
         let type_decl = self.lookup_table.type_decl_for_xtor(name).ok_or_else(|| {
             LookupError::MissingTypeDeclaration { name: name.to_owned(), span: span.to_miette() }
@@ -70,7 +70,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &str,
         span: Option<codespan::Span>,
-    ) -> Result<&Codata<P>, LookupError> {
+    ) -> Result<&Codata, LookupError> {
         self.dtor(name, span)?;
         let type_decl = self.lookup_table.type_decl_for_xtor(name).ok_or_else(|| {
             LookupError::MissingTypeDeclaration { name: name.to_owned(), span: span.to_miette() }
@@ -90,7 +90,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &str,
         span: Option<codespan::Span>,
-    ) -> Result<DataCodata<'_, P>, LookupError> {
+    ) -> Result<DataCodata<'_>, LookupError> {
         match self.decl(name, span)? {
             Decl::Data(data) => Ok(DataCodata::Data(data)),
             Decl::Codata(codata) => Ok(DataCodata::Codata(codata)),
@@ -102,7 +102,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn data(&self, name: &str, span: Option<codespan::Span>) -> Result<&Data<P>, LookupError> {
+    pub fn data(&self, name: &str, span: Option<codespan::Span>) -> Result<&Data, LookupError> {
         match self.decl(name, span)? {
             Decl::Data(data) => Ok(data),
             other => Err(LookupError::ExpectedData {
@@ -113,11 +113,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn codata(
-        &self,
-        name: &str,
-        span: Option<codespan::Span>,
-    ) -> Result<&Codata<P>, LookupError> {
+    pub fn codata(&self, name: &str, span: Option<codespan::Span>) -> Result<&Codata, LookupError> {
         match self.decl(name, span)? {
             Decl::Codata(codata) => Ok(codata),
             other => Err(LookupError::ExpectedCodata {
@@ -128,7 +124,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn def(&self, name: &str, span: Option<codespan::Span>) -> Result<&Def<P>, LookupError> {
+    pub fn def(&self, name: &str, span: Option<codespan::Span>) -> Result<&Def, LookupError> {
         match self.decl(name, span)? {
             Decl::Def(def) => Ok(def),
             other => Err(LookupError::ExpectedDef {
@@ -139,11 +135,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn codef(
-        &self,
-        name: &str,
-        span: Option<codespan::Span>,
-    ) -> Result<&Codef<P>, LookupError> {
+    pub fn codef(&self, name: &str, span: Option<codespan::Span>) -> Result<&Codef, LookupError> {
         match self.decl(name, span)? {
             Decl::Codef(codef) => Ok(codef),
             other => Err(LookupError::ExpectedCodef {
@@ -154,7 +146,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn ctor(&self, name: &str, span: Option<codespan::Span>) -> Result<&Ctor<P>, LookupError> {
+    pub fn ctor(&self, name: &str, span: Option<codespan::Span>) -> Result<&Ctor, LookupError> {
         match self.decl(name, span)? {
             Decl::Ctor(ctor) => Ok(ctor),
             other => Err(LookupError::ExpectedCtor {
@@ -165,7 +157,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    pub fn dtor(&self, name: &str, span: Option<codespan::Span>) -> Result<&Dtor<P>, LookupError> {
+    pub fn dtor(&self, name: &str, span: Option<codespan::Span>) -> Result<&Dtor, LookupError> {
         match self.decl(name, span)? {
             Decl::Dtor(dtor) => Ok(dtor),
             other => Err(LookupError::ExpectedDtor {
@@ -180,7 +172,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &str,
         span: Option<codespan::Span>,
-    ) -> Result<Ctor<P>, LookupError> {
+    ) -> Result<Ctor, LookupError> {
         match self.decl(name, span)? {
             Decl::Ctor(ctor) => Ok(ctor.clone()),
             Decl::Codef(codef) => Ok(codef.to_ctor()),
@@ -196,7 +188,7 @@ impl<P: Phase> Decls<P> {
         &self,
         name: &str,
         span: Option<codespan::Span>,
-    ) -> Result<Dtor<P>, LookupError> {
+    ) -> Result<Dtor, LookupError> {
         match self.decl(name, span)? {
             Decl::Dtor(dtor) => Ok(dtor.clone()),
             Decl::Def(def) => Ok(def.to_dtor()),
@@ -208,7 +200,7 @@ impl<P: Phase> Decls<P> {
         }
     }
 
-    fn decl(&self, name: &str, span: Option<codespan::Span>) -> Result<&Decl<P>, LookupError> {
+    fn decl(&self, name: &str, span: Option<codespan::Span>) -> Result<&Decl, LookupError> {
         self.map.get(name).ok_or_else(|| LookupError::UndefinedDeclaration {
             name: name.to_owned(),
             span: span.to_miette(),
@@ -217,15 +209,15 @@ impl<P: Phase> Decls<P> {
 }
 
 #[derive(Debug, Clone)]
-pub enum Item<'a, P: Phase> {
-    Data(&'a Data<P>),
-    Codata(&'a Codata<P>),
-    Def(&'a Def<P>),
-    Codef(&'a Codef<P>),
-    Let(&'a Let<P>),
+pub enum Item<'a> {
+    Data(&'a Data),
+    Codata(&'a Codata),
+    Def(&'a Def),
+    Codef(&'a Codef),
+    Let(&'a Let),
 }
 
-impl<'a, P: Phase> Item<'a, P> {
+impl<'a> Item<'a> {
     pub fn attributes(&self) -> &Attribute {
         match self {
             Item::Data(data) => &data.attr,
@@ -238,12 +230,12 @@ impl<'a, P: Phase> Item<'a, P> {
 }
 
 #[derive(Debug, Clone)]
-pub enum DataCodata<'a, P: Phase> {
-    Data(&'a Data<P>),
-    Codata(&'a Codata<P>),
+pub enum DataCodata<'a> {
+    Data(&'a Data),
+    Codata(&'a Codata),
 }
 
-impl<'a, P: Phase> DataCodata<'a, P> {
+impl<'a> DataCodata<'a> {
     pub fn name(&self) -> &Ident {
         match self {
             DataCodata::Data(data) => &data.name,
@@ -251,7 +243,7 @@ impl<'a, P: Phase> DataCodata<'a, P> {
         }
     }
 
-    pub fn typ(&self) -> Rc<TypAbs<P>> {
+    pub fn typ(&self) -> Rc<TypAbs> {
         match self {
             DataCodata::Data(data) => data.typ.clone(),
             DataCodata::Codata(codata) => codata.typ.clone(),

--- a/lang/syntax/src/trees/tst/def.rs
+++ b/lang/syntax/src/trees/tst/def.rs
@@ -2,7 +2,6 @@
 
 use std::rc::Rc;
 
-use crate::ctx::values::TypeCtx;
 use crate::generic::TypeUniv;
 use crate::ust;
 
@@ -10,58 +9,39 @@ use crate::generic;
 
 use super::forget::ForgetTST;
 
-#[derive(Default, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct TST;
-
-impl generic::Phase for TST {
-    type TypeInfo = TypeInfo;
-}
-
 pub type Ident = generic::Ident;
 pub type Label = generic::Label;
 pub type DocComment = generic::DocComment;
 pub type Attribute = generic::Attribute;
-pub type Prg = generic::Prg<TST>;
-pub type Decls = generic::Decls<TST>;
-pub type Decl = generic::Decl<TST>;
-pub type DataCodata<'a> = generic::DataCodata<'a, TST>;
-pub type Data = generic::Data<TST>;
-pub type Codata = generic::Codata<TST>;
-pub type TypAbs = generic::TypAbs<TST>;
-pub type Ctor = generic::Ctor<TST>;
-pub type Dtor = generic::Dtor<TST>;
-pub type Def = generic::Def<TST>;
-pub type Codef = generic::Codef<TST>;
-pub type Let = generic::Let<TST>;
-pub type Match = generic::Match<TST>;
-pub type Case = generic::Case<TST>;
-pub type SelfParam = generic::SelfParam<TST>;
-pub type Exp = generic::Exp<TST>;
-pub type Motive = generic::Motive<TST>;
-pub type Telescope = generic::Telescope<TST>;
-pub type TelescopeInst = generic::TelescopeInst<TST>;
-pub type Args = generic::Args<TST>;
-pub type Param = generic::Param<TST>;
-pub type ParamInst = generic::ParamInst<TST>;
+pub type Prg = generic::Prg;
+pub type Decls = generic::Decls;
+pub type Decl = generic::Decl;
+pub type DataCodata<'a> = generic::DataCodata<'a>;
+pub type Data = generic::Data;
+pub type Codata = generic::Codata;
+pub type TypAbs = generic::TypAbs;
+pub type Ctor = generic::Ctor;
+pub type Dtor = generic::Dtor;
+pub type Def = generic::Def;
+pub type Codef = generic::Codef;
+pub type Let = generic::Let;
+pub type Match = generic::Match;
+pub type Case = generic::Case;
+pub type SelfParam = generic::SelfParam;
+pub type Exp = generic::Exp;
+pub type Motive = generic::Motive;
+pub type Telescope = generic::Telescope;
+pub type TelescopeInst = generic::TelescopeInst;
+pub type Args = generic::Args;
+pub type Param = generic::Param;
+pub type ParamInst = generic::ParamInst;
 
-pub type TypCtor = generic::TypCtor<TST>;
-pub type Call = generic::Call<TST>;
-pub type DotCall = generic::DotCall<TST>;
-pub type Anno = generic::Anno<TST>;
-pub type LocalMatch = generic::LocalMatch<TST>;
-pub type LocalComatch = generic::LocalComatch<TST>;
-
-#[derive(Debug, Clone)]
-pub struct TypeInfo {
-    pub typ: Rc<ust::Exp>,
-    pub ctx: Option<TypeCtx>,
-}
-
-impl From<Rc<ust::Exp>> for TypeInfo {
-    fn from(typ: Rc<ust::Exp>) -> Self {
-        TypeInfo { typ, ctx: None }
-    }
-}
+pub type TypCtor = generic::TypCtor;
+pub type Call = generic::Call;
+pub type DotCall = generic::DotCall;
+pub type Anno = generic::Anno;
+pub type LocalMatch = generic::LocalMatch;
+pub type LocalComatch = generic::LocalComatch;
 
 pub trait HasTypeInfo {
     fn typ(&self) -> Option<Rc<ust::Exp>>;

--- a/lang/syntax/src/trees/tst/def.rs
+++ b/lang/syntax/src/trees/tst/def.rs
@@ -7,8 +7,6 @@ use crate::ust;
 
 use crate::generic;
 
-use super::forget::ForgetTST;
-
 pub type Ident = generic::Ident;
 pub type Label = generic::Label;
 pub type DocComment = generic::DocComment;
@@ -56,12 +54,8 @@ impl HasTypeInfo for Exp {
             Exp::DotCall(e) => e.inferred_type.clone(),
             Exp::Anno(e) => e.normalized_type.clone(),
             Exp::TypeUniv(_) => Some(Rc::new(ust::Exp::TypeUniv(TypeUniv { span: None }))),
-            Exp::LocalMatch(e) => {
-                e.inferred_type.forget_tst().map(|typctor| Rc::new(ust::Exp::TypCtor(typctor)))
-            }
-            Exp::LocalComatch(e) => {
-                e.inferred_type.forget_tst().map(|typctor| Rc::new(ust::Exp::TypCtor(typctor)))
-            }
+            Exp::LocalMatch(e) => e.inferred_type.clone().map(|x| Rc::new(x.into())),
+            Exp::LocalComatch(e) => e.inferred_type.clone().map(|x| Rc::new(x.into())),
             Exp::Hole(e) => e.inferred_type.clone(),
         }
     }

--- a/lang/syntax/src/trees/tst/forget.rs
+++ b/lang/syntax/src/trees/tst/forget.rs
@@ -22,14 +22,6 @@ impl<T: ForgetTST> ForgetTST for Rc<T> {
     }
 }
 
-impl<T: ForgetTST> ForgetTST for Option<T> {
-    type Target = Option<T::Target>;
-
-    fn forget_tst(&self) -> Self::Target {
-        self.as_ref().map(ForgetTST::forget_tst)
-    }
-}
-
 impl<T: ForgetTST> ForgetTST for Vec<T> {
     type Target = Vec<T::Target>;
 
@@ -229,7 +221,7 @@ impl ForgetTST for Case {
             span: *span,
             name: name.clone(),
             params: params.forget_tst(),
-            body: body.forget_tst(),
+            body: body.as_ref().map(|x| x.forget_tst()),
         }
     }
 }
@@ -337,8 +329,8 @@ impl ForgetTST for LocalMatch {
             ctx: None,
             name: name.clone(),
             on_exp: on_exp.forget_tst(),
-            motive: motive.forget_tst(),
-            ret_typ: ret_typ.forget_tst(),
+            motive: motive.as_ref().map(|x| x.forget_tst()),
+            ret_typ: ret_typ.as_ref().map(|x| x.forget_tst()),
             body: body.forget_tst(),
             inferred_type: None,
         }
@@ -415,13 +407,13 @@ impl ForgetTST for ParamInst {
     type Target = ust::ParamInst;
 
     fn forget_tst(&self) -> Self::Target {
-        let ParamInst { span, info, name, typ } = self;
+        let ParamInst { span, name, typ, .. } = self;
 
         ust::ParamInst {
             span: *span,
-            info: info.forget_tst(),
+            info: None,
             name: name.clone(),
-            typ: typ.forget_tst(),
+            typ: typ.as_ref().map(|x| x.forget_tst()),
         }
     }
 }

--- a/lang/syntax/src/trees/tst/forget.rs
+++ b/lang/syntax/src/trees/tst/forget.rs
@@ -433,9 +433,3 @@ impl ForgetTST for Args {
         ust::Args { args: self.args.forget_tst() }
     }
 }
-
-impl ForgetTST for TypeInfo {
-    type Target = ();
-
-    fn forget_tst(&self) -> Self::Target {}
-}

--- a/lang/syntax/src/trees/ust/def.rs
+++ b/lang/syntax/src/trees/ust/def.rs
@@ -1,42 +1,35 @@
 use crate::trees::generic;
 
-#[derive(Default, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct UST;
-
-impl generic::Phase for UST {
-    type TypeInfo = ();
-}
-
 pub type Ident = generic::Ident;
 pub type Label = generic::Label;
 pub type DocComment = generic::DocComment;
 pub type Attribute = generic::Attribute;
-pub type Prg = generic::Prg<UST>;
-pub type Decls = generic::Decls<UST>;
-pub type Decl = generic::Decl<UST>;
-pub type DataCodata<'a> = generic::DataCodata<'a, UST>;
-pub type Data = generic::Data<UST>;
-pub type Codata = generic::Codata<UST>;
-pub type TypAbs = generic::TypAbs<UST>;
-pub type Ctor = generic::Ctor<UST>;
-pub type Dtor = generic::Dtor<UST>;
-pub type Def = generic::Def<UST>;
-pub type Codef = generic::Codef<UST>;
-pub type Let = generic::Let<UST>;
-pub type Match = generic::Match<UST>;
-pub type Case = generic::Case<UST>;
-pub type SelfParam = generic::SelfParam<UST>;
-pub type Exp = generic::Exp<UST>;
-pub type Motive = generic::Motive<UST>;
-pub type Telescope = generic::Telescope<UST>;
-pub type TelescopeInst = generic::TelescopeInst<UST>;
-pub type Args = generic::Args<UST>;
-pub type Param = generic::Param<UST>;
-pub type ParamInst = generic::ParamInst<UST>;
+pub type Prg = generic::Prg;
+pub type Decls = generic::Decls;
+pub type Decl = generic::Decl;
+pub type DataCodata<'a> = generic::DataCodata<'a>;
+pub type Data = generic::Data;
+pub type Codata = generic::Codata;
+pub type TypAbs = generic::TypAbs;
+pub type Ctor = generic::Ctor;
+pub type Dtor = generic::Dtor;
+pub type Def = generic::Def;
+pub type Codef = generic::Codef;
+pub type Let = generic::Let;
+pub type Match = generic::Match;
+pub type Case = generic::Case;
+pub type SelfParam = generic::SelfParam;
+pub type Exp = generic::Exp;
+pub type Motive = generic::Motive;
+pub type Telescope = generic::Telescope;
+pub type TelescopeInst = generic::TelescopeInst;
+pub type Args = generic::Args;
+pub type Param = generic::Param;
+pub type ParamInst = generic::ParamInst;
 
-pub type TypCtor = generic::TypCtor<UST>;
-pub type Call = generic::Call<UST>;
-pub type DotCall = generic::DotCall<UST>;
-pub type Anno = generic::Anno<UST>;
-pub type LocalMatch = generic::LocalMatch<UST>;
-pub type LocalComatch = generic::LocalComatch<UST>;
+pub type TypCtor = generic::TypCtor;
+pub type Call = generic::Call;
+pub type DotCall = generic::DotCall;
+pub type Anno = generic::Anno;
+pub type LocalMatch = generic::LocalMatch;
+pub type LocalComatch = generic::LocalComatch;

--- a/lang/syntax/src/trees/ust/util.rs
+++ b/lang/syntax/src/trees/ust/util.rs
@@ -12,7 +12,7 @@ impl Instantiate for Telescope {
             .map(|Param { name, .. }| ParamInst {
                 span: None,
                 name: name.clone(),
-                info: (),
+                info: None,
                 typ: None,
             })
             .collect();

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -286,9 +286,3 @@ impl TestOutput for ust::Prg {
         self.print_to_string(None)
     }
 }
-
-impl TestOutput for tst::Prg {
-    fn test_output(&self) -> String {
-        self.forget_tst().print_to_string(None)
-    }
-}


### PR DESCRIPTION
I restrained myself to one commit for this PR :D This is the commit which finally completely removes the Phase annotation. Afterwards there is still some clean up and refactoring to do, but I wanted to keep those separate.