### PR TITLE
Annotate CallKind and DotCallKind in AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "miette_util",
  "printer",
  "query",
+ "syntax",
  "tower-lsp",
 ]
 

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -61,7 +61,7 @@ impl Eval for Call {
 
     fn eval(&self, prg: &Prg, env: &mut Env) -> Result<Self::Val, TypeError> {
         let Call { span, name, kind, args, .. } = self;
-        Ok(Rc::new(Val::Ctor {
+        Ok(Rc::new(Val::Call {
             span: *span,
             kind: *kind,
             name: name.clone(),
@@ -78,7 +78,7 @@ impl Eval for DotCall {
         let exp = exp.eval(prg, env)?;
         let args = args.eval(prg, env)?;
         match (*exp).clone() {
-            Val::Ctor { name: ctor_name, kind: _, args: ctor_args, span } => {
+            Val::Call { name: ctor_name, kind: _, args: ctor_args, span } => {
                 let type_decl = prg.decls.type_decl_for_member(&ctor_name, span)?;
                 match type_decl {
                     DataCodata::Data(_) => {
@@ -97,7 +97,7 @@ impl Eval for DotCall {
             }
             Val::Comatch { body, .. } => beta_comatch(prg, body, name, &args),
             Val::Neu { exp } => Ok(Rc::new(Val::Neu {
-                exp: Neu::Dtor {
+                exp: Neu::DotCall {
                     span: *span,
                     kind: *kind,
                     exp: Rc::new(exp),
@@ -136,7 +136,7 @@ impl Eval for LocalMatch {
         let on_exp = on_exp.eval(prg, env)?;
         let body = body.eval(prg, env)?;
         match (*on_exp).clone() {
-            Val::Ctor { name: ctor_name, args, .. } => beta_match(prg, body, &ctor_name, &args),
+            Val::Call { name: ctor_name, args, .. } => beta_match(prg, body, &ctor_name, &args),
             Val::Neu { exp } => Ok(Rc::new(Val::Neu {
                 exp: Neu::Match {
                     span: None,

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -74,7 +74,7 @@ impl Eval for DotCall {
     type Val = Rc<Val>;
 
     fn eval(&self, prg: &Prg, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let DotCall { span, exp, name, args, .. } = self;
+        let DotCall { span, kind, exp, name, args, .. } = self;
         let exp = exp.eval(prg, env)?;
         let args = args.eval(prg, env)?;
         match (*exp).clone() {
@@ -97,7 +97,13 @@ impl Eval for DotCall {
             }
             Val::Comatch { body, .. } => beta_comatch(prg, body, name, &args),
             Val::Neu { exp } => Ok(Rc::new(Val::Neu {
-                exp: Neu::Dtor { span: *span, exp: Rc::new(exp), name: name.to_owned(), args },
+                exp: Neu::Dtor {
+                    span: *span,
+                    kind: *kind,
+                    exp: Rc::new(exp),
+                    name: name.to_owned(),
+                    args,
+                },
             })),
             _ => unreachable!(),
         }

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -60,8 +60,13 @@ impl Eval for Call {
     type Val = Rc<Val>;
 
     fn eval(&self, prg: &Prg, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let Call { span, name, args, .. } = self;
-        Ok(Rc::new(Val::Ctor { span: *span, name: name.clone(), args: args.eval(prg, env)? }))
+        let Call { span, name, kind, args, .. } = self;
+        Ok(Rc::new(Val::Ctor {
+            span: *span,
+            kind: *kind,
+            name: name.clone(),
+            args: args.eval(prg, env)?,
+        }))
     }
 }
 
@@ -73,7 +78,7 @@ impl Eval for DotCall {
         let exp = exp.eval(prg, env)?;
         let args = args.eval(prg, env)?;
         match (*exp).clone() {
-            Val::Ctor { name: ctor_name, args: ctor_args, span } => {
+            Val::Ctor { name: ctor_name, kind: _, args: ctor_args, span } => {
                 let type_decl = prg.decls.type_decl_for_member(&ctor_name, span)?;
                 match type_decl {
                     DataCodata::Data(_) => {

--- a/lang/elaborator/src/normalizer/read_back.rs
+++ b/lang/elaborator/src/normalizer/read_back.rs
@@ -27,8 +27,9 @@ impl ReadBack for val::Val {
                 name: name.clone(),
                 args: Args { args: args.read_back(prg)? },
             }),
-            val::Val::Ctor { span, name, args } => Exp::Call(Call {
+            val::Val::Ctor { span, kind, name, args } => Exp::Call(Call {
                 span: *span,
+                kind: *kind,
                 name: name.clone(),
                 args: Args { args: args.read_back(prg)? },
                 inferred_type: None,

--- a/lang/elaborator/src/normalizer/read_back.rs
+++ b/lang/elaborator/src/normalizer/read_back.rs
@@ -27,7 +27,7 @@ impl ReadBack for val::Val {
                 name: name.clone(),
                 args: Args { args: args.read_back(prg)? },
             }),
-            val::Val::Ctor { span, kind, name, args } => Exp::Call(Call {
+            val::Val::Call { span, kind, name, args } => Exp::Call(Call {
                 span: *span,
                 kind: *kind,
                 name: name.clone(),
@@ -62,7 +62,7 @@ impl ReadBack for val::Neu {
                 name: name.clone(),
                 inferred_type: None,
             }),
-            val::Neu::Dtor { span, kind, exp, name, args } => Exp::DotCall(DotCall {
+            val::Neu::DotCall { span, kind, exp, name, args } => Exp::DotCall(DotCall {
                 span: *span,
                 kind: *kind,
                 exp: exp.read_back(prg)?,

--- a/lang/elaborator/src/normalizer/read_back.rs
+++ b/lang/elaborator/src/normalizer/read_back.rs
@@ -62,8 +62,9 @@ impl ReadBack for val::Neu {
                 name: name.clone(),
                 inferred_type: None,
             }),
-            val::Neu::Dtor { span, exp, name, args } => Exp::DotCall(DotCall {
+            val::Neu::Dtor { span, kind, exp, name, args } => Exp::DotCall(DotCall {
                 span: *span,
+                kind: *kind,
                 exp: exp.read_back(prg)?,
                 name: name.clone(),
                 args: Args { args: args.read_back(prg)? },

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -25,6 +25,7 @@ pub enum Val {
     Ctor {
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         span: Option<Span>,
+        kind: generic::CallKind,
         name: generic::Ident,
         args: Args,
     },
@@ -122,9 +123,12 @@ impl Shift for Val {
                 name: name.clone(),
                 args: args.shift_in_range(range, by),
             },
-            Val::Ctor { span, name, args } => {
-                Val::Ctor { span: *span, name: name.clone(), args: args.shift_in_range(range, by) }
-            }
+            Val::Ctor { span, kind, name, args } => Val::Ctor {
+                span: *span,
+                kind: *kind,
+                name: name.clone(),
+                args: args.shift_in_range(range, by),
+            },
             Val::TypeUniv { span } => Val::TypeUniv { span: *span },
             Val::Comatch { span, name, is_lambda_sugar, body } => Val::Comatch {
                 span: *span,
@@ -195,7 +199,7 @@ impl<'a> Print<'a> for Val {
                     if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
                 alloc.typ(name).append(psubst)
             }
-            Val::Ctor { span: _, name, args } => {
+            Val::Ctor { span: _, kind: _, name, args } => {
                 let psubst =
                     if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
                 alloc.ctor(name).append(psubst)

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -60,6 +60,7 @@ pub enum Neu {
     Dtor {
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         span: Option<Span>,
+        kind: generic::DotCallKind,
         exp: Rc<Neu>,
         name: generic::Ident,
         args: Args,
@@ -147,8 +148,9 @@ impl Shift for Neu {
             Neu::Var { span, name, idx } => {
                 Neu::Var { span: *span, name: name.clone(), idx: idx.shift_in_range(range, by) }
             }
-            Neu::Dtor { span, exp, name, args } => Neu::Dtor {
+            Neu::Dtor { span, kind, exp, name, args } => Neu::Dtor {
                 span: *span,
+                kind: *kind,
                 exp: exp.shift_in_range(range.clone(), by),
                 name: name.clone(),
                 args: args.shift_in_range(range, by),
@@ -220,7 +222,7 @@ impl<'a> Print<'a> for Neu {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         match self {
             Neu::Var { span: _, name, idx } => alloc.text(format!("{name}@{idx}")),
-            Neu::Dtor { span: _, exp, name, args } => {
+            Neu::Dtor { span: _, kind: _, exp, name, args } => {
                 let psubst =
                     if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
                 exp.print(cfg, alloc).append(DOT).append(alloc.dtor(name)).append(psubst)

--- a/lang/elaborator/src/typechecker/typecheck.rs
+++ b/lang/elaborator/src/typechecker/typecheck.rs
@@ -235,7 +235,7 @@ impl CheckInfer for DotCall {
     ///            P, Γ ⊢ e.Dσ ⇒ ...
     /// ```
     fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
-        let DotCall { span, exp, name, args, .. } = self;
+        let DotCall { span, kind, exp, name, args, .. } = self;
         let Dtor { name, params, self_param, ret_typ, .. } = &prg.decls.dtor_or_def(name, *span)?;
 
         let args_out = check_args(args, prg, name, ctx, params, *span)?;
@@ -254,6 +254,7 @@ impl CheckInfer for DotCall {
 
         Ok(DotCall {
             span: *span,
+            kind: *kind,
             exp: exp_out,
             name: name.clone(),
             args: args_out,

--- a/lang/elaborator/src/typechecker/typecheck.rs
+++ b/lang/elaborator/src/typechecker/typecheck.rs
@@ -190,13 +190,19 @@ impl CheckInfer for Call {
     ///            P, Γ ⊢ Cσ ⇒ ...
     /// ```
     fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
-        let Call { span, name, args, .. } = self;
+        let Call { span, kind, name, args, .. } = self;
         let Ctor { name, params, typ, .. } = &prg.decls.ctor_or_codef(name, *span)?;
         let args_out = check_args(args, prg, name, ctx, params, *span)?;
         let typ_out =
             typ.subst_under_ctx(vec![params.len()].into(), &vec![args.args.clone()]).to_exp();
         let typ_nf = typ_out.normalize(prg, &mut ctx.env())?;
-        Ok(Call { span: *span, name: name.clone(), args: args_out, inferred_type: Some(typ_nf) })
+        Ok(Call {
+            span: *span,
+            kind: *kind,
+            name: name.clone(),
+            args: args_out,
+            inferred_type: Some(typ_nf),
+        })
     }
 }
 
@@ -676,6 +682,7 @@ impl<'a> WithDestructee<'a> {
                         .collect();
                     let ctor = Rc::new(Exp::Call(Call {
                         span: None,
+                        kind: CallKind::Codefinition,
                         name: label.clone(),
                         args: Args { args },
                         inferred_type: None,
@@ -741,6 +748,7 @@ fn check_case(
                 .collect();
             let ctor = Rc::new(Exp::Call(Call {
                 span: None,
+                kind: CallKind::Constructor,
                 name: name.clone(),
                 args: Args { args },
                 inferred_type: None,

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -342,9 +342,10 @@ impl Lift for DotCall {
     type Target = Exp;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let DotCall { span, exp, name, args, .. } = self;
+        let DotCall { span, kind, exp, name, args, .. } = self;
         Exp::DotCall(DotCall {
             span: *span,
+            kind: *kind,
             exp: exp.lift(ctx),
             name: name.clone(),
             args: args.lift(ctx),
@@ -599,9 +600,10 @@ impl Ctx {
 
         self.new_decls.push(Decl::Def(def));
 
-        // Replace the match by a destructor call of the new top-level definition
+        // Replace the match by a dotcall of the new top-level definition
         Exp::DotCall(DotCall {
             span: None,
+            kind: DotCallKind::Definition,
             exp: on_exp.lift(self),
             name,
             args,

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -327,9 +327,10 @@ impl Lift for Call {
     type Target = Exp;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Call { span, name, args, .. } = self;
+        let Call { span, name, args, kind, .. } = self;
         Exp::Call(Call {
             span: *span,
+            kind: *kind,
             name: name.clone(),
             args: args.lift(ctx),
             inferred_type: None,
@@ -658,8 +659,14 @@ impl Ctx {
 
         self.new_decls.push(Decl::Codef(codef));
 
-        // Replace the comatch by a call of the new top-level definition
-        Exp::Call(Call { span: None, name, args, inferred_type: None })
+        // Replace the comatch by a call of the new top-level codefinition
+        Exp::Call(Call {
+            span: None,
+            kind: CallKind::Codefinition,
+            name,
+            args,
+            inferred_type: None,
+        })
     }
 
     /// Set the current declaration

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -113,8 +113,16 @@ impl Lower for cst::exp::Call {
                     name: name.to_owned(),
                     span: span.to_miette(),
                 }),
-                DeclKind::Codef | DeclKind::Ctor => Ok(generic::Exp::Call(generic::Call {
+                DeclKind::Ctor => Ok(generic::Exp::Call(generic::Call {
                     span: Some(*span),
+                    kind: generic::CallKind::Constructor,
+                    name: name.to_owned(),
+                    args: generic::Args { args: args.lower(ctx)? },
+                    inferred_type: None,
+                })),
+                DeclKind::Codef => Ok(generic::Exp::Call(generic::Call {
+                    span: Some(*span),
+                    kind: generic::CallKind::Codefinition,
                     name: name.to_owned(),
                     args: generic::Args { args: args.lower(ctx)? },
                     inferred_type: None,
@@ -229,6 +237,7 @@ impl Lower for cst::exp::NatLit {
         let cst::exp::NatLit { span, val } = self;
         let mut out = generic::Exp::Call(generic::Call {
             span: Some(*span),
+            kind: generic::CallKind::Constructor,
             name: "Z".to_owned(),
             args: generic::Args { args: vec![] },
             inferred_type: None,
@@ -240,6 +249,7 @@ impl Lower for cst::exp::NatLit {
             i += 1usize;
             out = generic::Exp::Call(generic::Call {
                 span: Some(*span),
+                kind: generic::CallKind::Constructor,
                 name: "S".to_owned(),
                 args: generic::Args { args: vec![Rc::new(out)] },
                 inferred_type: None,

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -148,8 +148,17 @@ impl Lower for cst::exp::DotCall {
                 Err(LoweringError::CannotUseAsDtor { name: name.clone(), span: span.to_miette() })
             }
             Elem::Decl(meta) => match meta.kind() {
-                DeclKind::Def | DeclKind::Dtor => Ok(generic::Exp::DotCall(generic::DotCall {
+                DeclKind::Dtor => Ok(generic::Exp::DotCall(generic::DotCall {
                     span: Some(*span),
+                    kind: generic::DotCallKind::Destructor,
+                    exp: exp.lower(ctx)?,
+                    name: name.clone(),
+                    args: generic::Args { args: args.lower(ctx)? },
+                    inferred_type: None,
+                })),
+                DeclKind::Def => Ok(generic::Exp::DotCall(generic::DotCall {
+                    span: Some(*span),
+                    kind: generic::DotCallKind::Definition,
                     exp: exp.lower(ctx)?,
                     name: name.clone(),
                     args: generic::Args { args: args.lower(ctx)? },

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -217,9 +217,12 @@ impl CollectInfo for TypCtor {
 
 impl CollectInfo for Call {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Call { span, args, inferred_type, .. } = self;
+        let Call { span, kind, args, inferred_type, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let content = HoverInfoContent::CallInfo(CallInfo { typ: typ.print_to_string(None) });
+            let content = HoverInfoContent::CallInfo(CallInfo {
+                kind: *kind,
+                typ: typ.print_to_string(None),
+            });
             collector.add_hover_content(*span, content)
         }
         args.collect_info(collector)

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -231,10 +231,12 @@ impl CollectInfo for Call {
 
 impl CollectInfo for DotCall {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let DotCall { span, exp, args, inferred_type, .. } = self;
+        let DotCall { span, kind, exp, args, inferred_type, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let content =
-                HoverInfoContent::DotCallInfo(DotCallInfo { typ: typ.print_to_string(None) });
+            let content = HoverInfoContent::DotCallInfo(DotCallInfo {
+                kind: *kind,
+                typ: typ.print_to_string(None),
+            });
             collector.add_hover_content(*span, content)
         }
         exp.collect_info(collector);

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -4,6 +4,7 @@ use printer::PrintToString;
 use syntax::{
     ctx::values::{Binder as TypeCtxBinder, TypeCtx},
     generic::CallKind,
+    generic::DotCallKind,
 };
 
 // HoverInfo
@@ -50,6 +51,7 @@ pub struct CallInfo {
 /// Hover information for dotcalls (destructors or definitions)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DotCallInfo {
+    pub kind: DotCallKind,
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -1,7 +1,10 @@
 use codespan::Span;
 use printer::PrintToString;
 
-use syntax::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
+use syntax::{
+    ctx::values::{Binder as TypeCtxBinder, TypeCtx},
+    generic::CallKind,
+};
 
 // HoverInfo
 //
@@ -40,6 +43,7 @@ pub struct TypeCtorInfo {}
 /// Hover information for calls (constructors, codefinitions or lets)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallInfo {
+    pub kind: CallKind,
     pub typ: String,
 }
 

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -272,8 +272,9 @@ impl Rename for Exp {
                 inferred_ctx: None, // TODO: Rename TypeCtx!
             }),
             Exp::TypeUniv(e) => Exp::TypeUniv(e),
-            Exp::Call(Call { span, name, args, inferred_type }) => Exp::Call(Call {
+            Exp::Call(Call { span, name, args, inferred_type, kind }) => Exp::Call(Call {
                 span,
+                kind,
                 name,
                 args: args.rename_in_ctx(ctx),
                 inferred_type: inferred_type.rename_in_ctx(ctx),

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -291,9 +291,10 @@ impl Rename for Exp {
                     inferred_type: None,
                 })
             }
-            Exp::DotCall(DotCall { span, exp, name, args, inferred_type }) => {
+            Exp::DotCall(DotCall { span, kind, exp, name, args, inferred_type }) => {
                 Exp::DotCall(DotCall {
                     span,
+                    kind,
                     name,
                     exp: exp.rename_in_ctx(ctx),
                     args: args.rename_in_ctx(ctx),

--- a/lang/syntax/src/trees/generic/subst.rs
+++ b/lang/syntax/src/trees/generic/subst.rs
@@ -30,13 +30,16 @@ impl Substitutable<Rc<Exp>> for Rc<Exp> {
                 args: args.subst(ctx, by),
                 inferred_type: None,
             })),
-            Exp::DotCall(DotCall { span, exp, name, args, .. }) => Rc::new(Exp::DotCall(DotCall {
-                span: *span,
-                exp: exp.subst(ctx, by),
-                name: name.clone(),
-                args: args.subst(ctx, by),
-                inferred_type: None,
-            })),
+            Exp::DotCall(DotCall { span, kind, exp, name, args, .. }) => {
+                Rc::new(Exp::DotCall(DotCall {
+                    span: *span,
+                    kind: *kind,
+                    exp: exp.subst(ctx, by),
+                    name: name.clone(),
+                    args: args.subst(ctx, by),
+                    inferred_type: None,
+                }))
+            }
             Exp::Anno(Anno { span, exp, typ, .. }) => Rc::new(Exp::Anno(Anno {
                 span: *span,
                 exp: exp.subst(ctx, by),

--- a/lang/syntax/src/trees/generic/subst.rs
+++ b/lang/syntax/src/trees/generic/subst.rs
@@ -23,8 +23,9 @@ impl Substitutable<Rc<Exp>> for Rc<Exp> {
                 }
             }
             Exp::TypCtor(e) => Rc::new(Exp::TypCtor(e.subst(ctx, by))),
-            Exp::Call(Call { span, name, args, .. }) => Rc::new(Exp::Call(Call {
+            Exp::Call(Call { span, name, args, kind, .. }) => Rc::new(Exp::Call(Call {
                 span: *span,
+                kind: *kind,
                 name: name.clone(),
                 args: args.subst(ctx, by),
                 inferred_type: None,

--- a/util/lsp/Cargo.toml
+++ b/util/lsp/Cargo.toml
@@ -14,6 +14,7 @@ codespan = "0.11"
 # fancy error messages
 miette = "5"
 # workspace members
+syntax = { path = "../../lang/syntax" }
 query = { path = "../../lang/query" }
 printer = { path = "../../lang/printer" }
 miette_util = { path = "../miette_util" }

--- a/util/lsp/src/codeactions.rs
+++ b/util/lsp/src/codeactions.rs
@@ -1,0 +1,48 @@
+//! Implementation of code actions provided by the LSP server
+use std::collections::HashMap;
+use tower_lsp::{jsonrpc, lsp_types::*};
+
+use query::Xfunc;
+
+use super::conversion::*;
+use super::server::*;
+
+pub async fn code_action(
+    server: &Server,
+    params: CodeActionParams,
+) -> jsonrpc::Result<Option<CodeActionResponse>> {
+    let text_document = params.text_document;
+    let range = params.range;
+
+    let db = server.database.read().await;
+    let index = db.get(text_document.uri.as_str()).unwrap();
+    let span_start = index.location_to_index(range.start.from_lsp());
+    let span_end = index.location_to_index(range.end.from_lsp());
+    let span = span_start.and_then(|start| span_end.map(|end| codespan::Span::new(start, end)));
+    let item = span.and_then(|span| index.item_at_span(span));
+
+    if let Some(item) = item {
+        let Xfunc { title, edits } = index.xfunc(item.type_name()).unwrap();
+        let edits = edits
+            .into_iter()
+            .map(|edit| TextEdit {
+                range: index.span_to_locations(edit.span).unwrap().to_lsp(),
+                new_text: edit.text,
+            })
+            .collect();
+
+        let mut changes = HashMap::new();
+        changes.insert(text_document.uri, edits);
+
+        let res = vec![CodeActionOrCommand::CodeAction(CodeAction {
+            title,
+            kind: Some(CodeActionKind::REFACTOR_REWRITE),
+            edit: Some(WorkspaceEdit { changes: Some(changes), ..Default::default() }),
+            ..Default::default()
+        })];
+
+        Ok(Some(res))
+    } else {
+        Ok(Some(vec![]))
+    }
+}

--- a/util/lsp/src/format.rs
+++ b/util/lsp/src/format.rs
@@ -1,0 +1,40 @@
+//! Implementation of the formatting functionality of the LSP server
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+
+use super::server::*;
+use printer::{PrintCfg, PrintToString};
+
+pub async fn formatting(
+    server: &Server,
+    params: DocumentFormattingParams,
+) -> Result<Option<Vec<TextEdit>>> {
+    let text_document = params.text_document;
+    let db = server.database.read().await;
+    let index = db.get(text_document.uri.as_str()).unwrap();
+    let prg = match index.ust() {
+        Ok(prg) => prg,
+        Err(_) => return Ok(None),
+    };
+
+    let rng: Range = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: u32::MAX, character: u32::MAX },
+    };
+
+    let cfg = PrintCfg {
+        width: 100,
+        latex: false,
+        omit_decl_sep: false,
+        de_bruijn: false,
+        indent: 4,
+        print_lambda_sugar: true,
+        print_function_sugar: true,
+    };
+
+    let formatted_prog: String = prg.print_to_string(Some(&cfg));
+
+    let text_edit: TextEdit = TextEdit { range: rng, new_text: formatted_prog };
+
+    Ok(Some(vec![text_edit]))
+}

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -2,6 +2,7 @@
 
 use query::*;
 use syntax::generic::CallKind;
+use syntax::generic::DotCallKind;
 use tower_lsp::{jsonrpc, lsp_types::*};
 
 use super::conversion::*;
@@ -107,8 +108,11 @@ impl ToHoverContent for CallInfo {
 
 impl ToHoverContent for DotCallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let DotCallInfo { typ } = self;
-        let header = MarkedString::String("Destructor / definition".to_owned());
+        let DotCallInfo { kind, typ } = self;
+        let header = match kind {
+            DotCallKind::Destructor => MarkedString::String("Destructor".to_owned()),
+            DotCallKind::Definition => MarkedString::String("Definition".to_owned()),
+        };
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -1,8 +1,8 @@
 //! Implementation of the type-on-hover functionality of the LSP server
 
-use tower_lsp::{jsonrpc, lsp_types::*};
-
 use query::*;
+use syntax::generic::CallKind;
+use tower_lsp::{jsonrpc, lsp_types::*};
 
 use super::conversion::*;
 use super::server::*;
@@ -93,9 +93,13 @@ impl ToHoverContent for TypeCtorInfo {
 
 impl ToHoverContent for CallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let CallInfo { typ } = self;
-        let header =
-            MarkedString::String("Constructor / codefinition / let-bound definition".to_owned());
+        let CallInfo { kind, typ } = self;
+        let header = match kind {
+            CallKind::Constructor => MarkedString::String("Constructor".to_owned()),
+            CallKind::Codefinition => MarkedString::String("Codefinition".to_owned()),
+            CallKind::LetBound => MarkedString::String("Let-bound definition".to_owned()),
+        };
+
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/lib.rs
+++ b/util/lsp/src/lib.rs
@@ -1,6 +1,8 @@
 mod capabilities;
+mod codeactions;
 mod conversion;
 mod diagnostics;
+mod format;
 mod hover;
 mod server;
 


### PR DESCRIPTION
The information whether a `Call` stands for a constructor, codefinition or toplevel definition is currently not recorded in the AST, but has to be reconstructed by looking up in the context what the name refers to. (Similarly for `DotCall` which can stand for destructors or codefinitions). 

This PR annotates the AST with `CallKind` resp. `DotCallKind` and uses this information to display more accurate information on hover.

Other small  refactorings:
- Put the `formatting` and `codeactions` implementations of the LSP server into their own modules.
- Rename `Ctor` and `Dtor` in the evaluator to `Call` and `DotCall` in order to be consistent with the other AST representations.