### PR TITLE
Simplify modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,9 +716,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -941,9 +941,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1510,13 +1510,14 @@ dependencies = [
  "miette",
  "num-bigint",
  "thiserror",
+ "url",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -2131,6 +2132,7 @@ dependencies = [
  "miette_util",
  "num-bigint",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -2615,9 +2617,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/app/src/cli/format.rs
+++ b/app/src/cli/format.rs
@@ -73,7 +73,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
     Ok(())
 }
 
-fn print_prg<W: WriteColor>(prg: generic::Prg, cfg: &PrintCfg, stream: &mut W) {
+fn print_prg<W: WriteColor>(prg: generic::Module, cfg: &PrintCfg, stream: &mut W) {
     prg.print_colored(cfg, stream).expect("Failed to print to stdout");
     println!();
 }

--- a/app/src/cli/lift.rs
+++ b/app/src/cli/lift.rs
@@ -37,7 +37,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
     Ok(())
 }
 
-fn print_prg<W: io::Write>(prg: generic::Prg, cfg: &PrintCfg, stream: &mut W) {
+fn print_prg<W: io::Write>(prg: generic::Module, cfg: &PrintCfg, stream: &mut W) {
     prg.print(cfg, stream).expect("Failed to print to stdout");
     println!();
 }

--- a/app/src/cli/texify.rs
+++ b/app/src/cli/texify.rs
@@ -111,7 +111,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
     Ok(())
 }
 
-fn print_prg<W: io::Write>(prg: generic::Prg, cfg: &PrintCfg, stream: &mut W) {
+fn print_prg<W: io::Write>(prg: generic::Module, cfg: &PrintCfg, stream: &mut W) {
     prg.print_latex(cfg, stream).expect("Failed to print to stdout");
     println!();
 }

--- a/lang/elaborator/src/normalizer/normalize.rs
+++ b/lang/elaborator/src/normalizer/normalize.rs
@@ -8,9 +8,9 @@ use crate::result::*;
 pub trait Normalize {
     type Nf;
 
-    fn normalize(&self, prg: &Prg, env: &mut Env) -> Result<Self::Nf, TypeError>;
+    fn normalize(&self, prg: &Module, env: &mut Env) -> Result<Self::Nf, TypeError>;
 
-    fn normalize_in_empty_env(&self, prg: &Prg) -> Result<Self::Nf, TypeError> {
+    fn normalize_in_empty_env(&self, prg: &Module) -> Result<Self::Nf, TypeError> {
         self.normalize(prg, &mut Env::empty())
     }
 }
@@ -22,7 +22,7 @@ where
 {
     type Nf = <<T as Eval>::Val as ReadBack>::Nf;
 
-    fn normalize(&self, prg: &Prg, env: &mut Env) -> Result<Self::Nf, TypeError> {
+    fn normalize(&self, prg: &Module, env: &mut Env) -> Result<Self::Nf, TypeError> {
         let val = self.eval(prg, env)?;
         val.read_back(prg)
     }

--- a/lang/elaborator/src/typechecker/ctx.rs
+++ b/lang/elaborator/src/typechecker/ctx.rs
@@ -27,11 +27,11 @@ impl Default for Ctx {
 }
 
 pub trait ContextSubstExt: Sized {
-    fn subst<S: Substitution<Rc<Exp>>>(&mut self, prg: &Prg, s: &S) -> Result<(), TypeError>;
+    fn subst<S: Substitution<Rc<Exp>>>(&mut self, prg: &Module, s: &S) -> Result<(), TypeError>;
 }
 
 impl ContextSubstExt for Ctx {
-    fn subst<S: Substitution<Rc<Exp>>>(&mut self, prg: &Prg, s: &S) -> Result<(), TypeError> {
+    fn subst<S: Substitution<Rc<Exp>>>(&mut self, prg: &Module, s: &S) -> Result<(), TypeError> {
         let env = self.vars.env();
         let levels = self.vars.levels();
         self.map_failable(|nf| {

--- a/lang/elaborator/src/typechecker/decls.rs
+++ b/lang/elaborator/src/typechecker/decls.rs
@@ -24,7 +24,7 @@ pub trait CheckToplevel: Sized {
 /// Check all declarations in a program
 impl CheckToplevel for Module {
     fn check_wf(&self, prg: &Module) -> Result<Self, TypeError> {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         // FIXME: Reconsider order
 
@@ -33,7 +33,7 @@ impl CheckToplevel for Module {
             .map(|(name, decl)| Ok((name.clone(), decl.check_wf(prg)?)))
             .collect::<Result<_, TypeError>>()?;
 
-        Ok(Module { map: map_out, lookup_table: lookup_table.clone() })
+        Ok(Module { uri: uri.clone(), map: map_out, lookup_table: lookup_table.clone() })
     }
 }
 

--- a/lang/elaborator/src/typechecker/typecheck.rs
+++ b/lang/elaborator/src/typechecker/typecheck.rs
@@ -31,7 +31,7 @@ pub trait CheckInfer: Sized {
     /// ```
     /// - P: The program context of toplevel declarations.
     /// - Γ: The context of locally bound variables.
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError>;
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError>;
     /// Tries to infer a type for the given expression. For inference we use the
     /// following syntax:
     /// ```text
@@ -39,14 +39,14 @@ pub trait CheckInfer: Sized {
     /// ```
     ///  - P: The program context of toplevel declarations.
     ///  - Γ: The context of locally bound variables.
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError>;
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError>;
 }
 
 impl<T: CheckInfer> CheckInfer for Rc<T> {
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         Ok(Rc::new((**self).check(prg, ctx, t)?))
     }
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         Ok(Rc::new((**self).infer(prg, ctx)?))
     }
 }
@@ -57,7 +57,7 @@ impl<T: CheckInfer> CheckInfer for Rc<T> {
 
 impl CheckInfer for Exp {
     #[trace("{:P} |- {:P} <= {:P}", ctx, self, t)]
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         match self {
             Exp::Variable(e) => Ok(e.check(prg, ctx, t.clone())?.into()),
             Exp::TypCtor(e) => Ok(e.check(prg, ctx, t.clone())?.into()),
@@ -72,7 +72,7 @@ impl CheckInfer for Exp {
     }
 
     #[trace("{:P} |- {:P} => {return:P}", ctx, self, |ret| ret.as_ref().map(|e| e.typ()))]
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         match self {
             Exp::Variable(e) => Ok(e.infer(prg, ctx)?.into()),
             Exp::TypCtor(e) => Ok(e.infer(prg, ctx)?.into()),
@@ -99,7 +99,7 @@ impl CheckInfer for Variable {
     ///           ───────────────
     ///            P, Γ ⊢ x ⇐ σ
     /// ```
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let inferred_term = self.infer(prg, ctx)?;
         let inferred_typ = inferred_term.typ().ok_or(TypeError::Impossible {
             message: "Expected inferred type".to_owned(),
@@ -116,7 +116,7 @@ impl CheckInfer for Variable {
     ///           ───────────────
     ///            P, Γ ⊢ x ⇒ τ
     /// ```
-    fn infer(&self, _prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, _prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         let Variable { span, idx, name, .. } = self;
         let typ_nf = ctx.lookup(*idx);
         Ok(Variable { span: *span, idx: *idx, name: name.clone(), inferred_type: Some(typ_nf) })
@@ -135,7 +135,7 @@ impl CheckInfer for TypCtor {
     ///           ──────────────────
     ///            P, Γ ⊢ Tσ ⇐ τ
     /// ```
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let inferred_term = self.infer(prg, ctx)?;
         let inferred_typ = inferred_term.typ().ok_or(TypeError::Impossible {
             message: "Expected inferred type".to_owned(),
@@ -153,9 +153,9 @@ impl CheckInfer for TypCtor {
     ///           ─────────────────────────
     ///            P, Γ ⊢ Tσ ⇒ Type
     /// ```
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         let TypCtor { span, name, args } = self;
-        let params = &*prg.decls.typ(name, *span)?.typ();
+        let params = &*prg.typ(name, *span)?.typ();
         let args_out = check_args(args, prg, name, ctx, params, *span)?;
 
         Ok(TypCtor { span: *span, name: name.clone(), args: args_out })
@@ -173,7 +173,7 @@ impl CheckInfer for Call {
     ///           ──────────────────
     ///            P, Γ ⊢ Cσ ⇐ τ
     /// ```
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let inferred_term = self.infer(prg, ctx)?;
         let inferred_typ = inferred_term.typ().ok_or(TypeError::Impossible {
             message: "Expected inferred type".to_owned(),
@@ -189,9 +189,9 @@ impl CheckInfer for Call {
     ///           ──────────────────
     ///            P, Γ ⊢ Cσ ⇒ ...
     /// ```
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         let Call { span, name, args, .. } = self;
-        let Ctor { name, params, typ, .. } = &prg.decls.ctor_or_codef(name, *span)?;
+        let Ctor { name, params, typ, .. } = &prg.ctor_or_codef(name, *span)?;
         let args_out = check_args(args, prg, name, ctx, params, *span)?;
         let typ_out =
             typ.subst_under_ctx(vec![params.len()].into(), &vec![args.args.clone()]).to_exp();
@@ -211,7 +211,7 @@ impl CheckInfer for DotCall {
     ///           ──────────────────
     ///            P, Γ ⊢ e.Dσ ⇐ τ
     /// ```
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let inferred_term = self.infer(prg, ctx)?;
         let inferred_typ = inferred_term.typ().ok_or(TypeError::Impossible {
             message: "Expected inferred type".to_owned(),
@@ -228,9 +228,9 @@ impl CheckInfer for DotCall {
     ///           ──────────────────
     ///            P, Γ ⊢ e.Dσ ⇒ ...
     /// ```
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         let DotCall { span, exp, name, args, .. } = self;
-        let Dtor { name, params, self_param, ret_typ, .. } = &prg.decls.dtor_or_def(name, *span)?;
+        let Dtor { name, params, self_param, ret_typ, .. } = &prg.dtor_or_def(name, *span)?;
 
         let args_out = check_args(args, prg, name, ctx, params, *span)?;
 
@@ -261,7 +261,7 @@ impl CheckInfer for DotCall {
 //
 
 impl CheckInfer for Anno {
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let inferred_term = self.infer(prg, ctx)?;
         let inferred_typ = inferred_term.typ().ok_or(TypeError::Impossible {
             message: "Expected inferred type".to_owned(),
@@ -280,7 +280,7 @@ impl CheckInfer for Anno {
     ///           ──────────────────────
     ///            P, Γ ⊢ (e : τ) ⇒ τ'
     /// ```
-    fn infer(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         let Anno { span, exp, typ, .. } = self;
         let typ_out = typ.check(prg, ctx, Rc::new(TypeUniv::new().into()))?;
         let typ_nf = typ.normalize(prg, &mut ctx.env())?;
@@ -300,7 +300,7 @@ impl CheckInfer for TypeUniv {
     ///           ──────────────────
     ///            P, Γ ⊢ Type ⇐ τ
     /// ```
-    fn check(&self, _prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, _prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         convert(ctx.levels(), Rc::new(TypeUniv::new().into()), &t)?;
         Ok(self.clone())
     }
@@ -312,7 +312,7 @@ impl CheckInfer for TypeUniv {
     /// ```
     /// Note: The type universe is impredicative and the theory
     /// therefore inconsistent.
-    fn infer(&self, _prg: &Prg, _ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, _prg: &Module, _ctx: &mut Ctx) -> Result<Self, TypeError> {
         Ok(self.clone())
     }
 }
@@ -322,7 +322,7 @@ impl CheckInfer for TypeUniv {
 //
 
 impl CheckInfer for Hole {
-    fn check(&self, _prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, _prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let Hole { span, .. } = self;
         Ok(Hole {
             span: *span,
@@ -331,7 +331,7 @@ impl CheckInfer for Hole {
         })
     }
 
-    fn infer(&self, _prg: &Prg, _ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, _prg: &Module, _ctx: &mut Ctx) -> Result<Self, TypeError> {
         let Hole { span, .. } = self;
         Ok(Hole {
             span: *span,
@@ -346,7 +346,7 @@ impl CheckInfer for Hole {
 //
 
 impl CheckInfer for LocalMatch {
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let LocalMatch { span, name, on_exp, motive, body, .. } = self;
         let on_exp_out = on_exp.infer(prg, ctx)?;
         let typ_app_nf = on_exp_out
@@ -418,7 +418,7 @@ impl CheckInfer for LocalMatch {
         })
     }
 
-    fn infer(&self, _prg: &Prg, _ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, _prg: &Module, _ctx: &mut Ctx) -> Result<Self, TypeError> {
         Err(TypeError::CannotInferMatch { span: self.span().to_miette() })
     }
 }
@@ -428,13 +428,13 @@ impl CheckInfer for LocalMatch {
 //
 
 impl CheckInfer for LocalComatch {
-    fn check(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
+    fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
         let LocalComatch { span, name, is_lambda_sugar, body, .. } = self;
         let typ_app_nf = t.expect_typ_app()?;
         let typ_app = typ_app_nf.infer(prg, ctx)?;
 
         // Local comatches don't support self parameters, yet.
-        let codata = prg.decls.codata(&typ_app.name, *span)?;
+        let codata = prg.codata(&typ_app.name, *span)?;
         if uses_self(prg, codata)? {
             return Err(TypeError::LocalComatchWithSelf {
                 type_name: codata.name.to_owned(),
@@ -460,7 +460,7 @@ impl CheckInfer for LocalComatch {
         })
     }
 
-    fn infer(&self, _prg: &Prg, _ctx: &mut Ctx) -> Result<Self, TypeError> {
+    fn infer(&self, _prg: &Module, _ctx: &mut Ctx) -> Result<Self, TypeError> {
         Err(TypeError::CannotInferComatch { span: self.span().to_miette() })
     }
 }
@@ -474,7 +474,7 @@ pub trait CheckTelescope {
 
     fn check_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> Result<T, TypeError>>(
         &self,
-        prg: &Prg,
+        prg: &Module,
         name: &str,
         ctx: &mut Ctx,
         params: &Telescope,
@@ -488,7 +488,7 @@ pub trait InferTelescope {
 
     fn infer_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> Result<T, TypeError>>(
         &self,
-        prg: &Prg,
+        prg: &Module,
         ctx: &mut Ctx,
         f: F,
     ) -> Result<T, TypeError>;
@@ -501,11 +501,11 @@ pub struct WithScrutinee<'a> {
 
 /// Check a pattern match
 impl<'a> WithScrutinee<'a> {
-    pub fn check_ws(&self, prg: &Prg, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Match, TypeError> {
+    pub fn check_ws(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Match, TypeError> {
         let Match { span, cases, omit_absurd } = &self.inner;
 
         // Check that this match is on a data type
-        let data = prg.decls.data(&self.scrutinee.name, *span)?;
+        let data = prg.data(&self.scrutinee.name, *span)?;
 
         // Check exhaustiveness
         let ctors_expected: HashSet<_> = data.ctors.iter().cloned().collect();
@@ -538,7 +538,7 @@ impl<'a> WithScrutinee<'a> {
 
         if *omit_absurd {
             for name in ctors_missing.cloned() {
-                let Ctor { params, .. } = prg.decls.ctor(&name, *span)?;
+                let Ctor { params, .. } = prg.ctor(&name, *span)?;
 
                 let case = Case { span: *span, name, params: params.instantiate(), body: None };
                 cases.push((case, true));
@@ -550,7 +550,7 @@ impl<'a> WithScrutinee<'a> {
         for (case, omit) in cases {
             // Build equations for this case
             let Ctor { typ: TypCtor { args: def_args, .. }, params, .. } =
-                prg.decls.ctor(&case.name, case.span)?;
+                prg.ctor(&case.name, case.span)?;
 
             let def_args_nf = LevelCtx::empty()
                 .bind_iter(params.params.iter(), |ctx| def_args.normalize(prg, &mut ctx.env()))?;
@@ -587,11 +587,11 @@ pub struct WithDestructee<'a> {
 
 /// Infer a copattern match
 impl<'a> WithDestructee<'a> {
-    pub fn infer_wd(&self, prg: &Prg, ctx: &mut Ctx) -> Result<Match, TypeError> {
+    pub fn infer_wd(&self, prg: &Module, ctx: &mut Ctx) -> Result<Match, TypeError> {
         let Match { span, cases, omit_absurd } = &self.inner;
 
         // Check that this comatch is on a codata type
-        let codata = prg.decls.codata(&self.destructee.name, *span)?;
+        let codata = prg.codata(&self.destructee.name, *span)?;
 
         // Check exhaustiveness
         let dtors_expected: HashSet<_> = codata.dtors.iter().cloned().collect();
@@ -625,7 +625,7 @@ impl<'a> WithDestructee<'a> {
 
         if *omit_absurd {
             for name in dtors_missing.cloned() {
-                let Dtor { params, .. } = prg.decls.dtor(&name, *span)?;
+                let Dtor { params, .. } = prg.dtor(&name, *span)?;
 
                 let case = Case { span: *span, name, params: params.instantiate(), body: None };
                 cases.push((case, true));
@@ -641,7 +641,7 @@ impl<'a> WithDestructee<'a> {
                 ret_typ,
                 params,
                 ..
-            } = prg.decls.dtor(&case.name, case.span)?;
+            } = prg.dtor(&case.name, case.span)?;
 
             let def_args_nf =
                 def_args.normalize(prg, &mut LevelCtx::from(vec![params.len()]).env())?;
@@ -708,12 +708,12 @@ impl<'a> WithDestructee<'a> {
 fn check_case(
     eqns: Vec<Eqn>,
     case: &Case,
-    prg: &Prg,
+    prg: &Module,
     ctx: &mut Ctx,
     t: Rc<Exp>,
 ) -> Result<Case, TypeError> {
     let Case { span, name, params: args, body } = case;
-    let Ctor { name, params, .. } = prg.decls.ctor(name, *span)?;
+    let Ctor { name, params, .. } = prg.ctor(name, *span)?;
 
     // FIXME: Refactor this
     let mut subst_ctx_1 = ctx.levels().append(&vec![1, params.len()].into());
@@ -798,12 +798,12 @@ fn check_case(
 fn check_cocase(
     eqns: Vec<Eqn>,
     cocase: &Case,
-    prg: &Prg,
+    prg: &Module,
     ctx: &mut Ctx,
     t: Rc<Exp>,
 ) -> Result<Case, TypeError> {
     let Case { span, name, params: params_inst, body } = cocase;
-    let Dtor { name, params, .. } = prg.decls.dtor(name, *span)?;
+    let Dtor { name, params, .. } = prg.dtor(name, *span)?;
 
     params_inst.check_telescope(
         prg,
@@ -852,7 +852,7 @@ fn check_cocase(
 
 fn check_args(
     this: &Args,
-    prg: &Prg,
+    prg: &Module,
     name: &str,
     ctx: &mut Ctx,
     params: &Telescope,
@@ -888,7 +888,7 @@ impl CheckTelescope for TelescopeInst {
 
     fn check_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> Result<T, TypeError>>(
         &self,
-        prg: &Prg,
+        prg: &Module,
         name: &str,
         ctx: &mut Ctx,
         param_types: &Telescope,
@@ -938,7 +938,7 @@ impl InferTelescope for Telescope {
 
     fn infer_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> Result<T, TypeError>>(
         &self,
-        prg: &Prg,
+        prg: &Module,
         ctx: &mut Ctx,
         f: F,
     ) -> Result<T, TypeError> {
@@ -966,7 +966,7 @@ impl InferTelescope for SelfParam {
 
     fn infer_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> Result<T, TypeError>>(
         &self,
-        prg: &Prg,
+        prg: &Module,
         ctx: &mut Ctx,
         f: F,
     ) -> Result<T, TypeError> {

--- a/lang/elaborator/src/typechecker/util.rs
+++ b/lang/elaborator/src/typechecker/util.rs
@@ -8,9 +8,9 @@ use crate::unifier::unify::{unify, Eqn};
 use super::TypeError;
 
 // Checks whether the codata type contains destructors with a self parameter
-pub fn uses_self(prg: &Prg, codata: &Codata) -> Result<bool, TypeError> {
+pub fn uses_self(prg: &Module, codata: &Codata) -> Result<bool, TypeError> {
     for dtor_name in &codata.dtors {
-        let dtor = prg.decls.dtor(dtor_name, None)?;
+        let dtor = prg.dtor(dtor_name, None)?;
         let mut ctx = LevelCtx::from(vec![dtor.params.len(), 1]);
         if dtor.ret_typ.occurs(&mut ctx, Lvl { fst: 1, snd: 0 }) {
             return Ok(true);

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -75,7 +75,7 @@ impl Lift for Module {
     type Target = Module;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         let mut map: HashMap<_, _> =
             map.iter().map(|(name, decl)| (name.clone(), decl.lift(ctx))).collect();
@@ -90,7 +90,7 @@ impl Lift for Module {
         let decls_iter = ctx.new_decls.iter().map(|decl| (decl.name().clone(), decl.clone()));
         map.extend(decls_iter);
 
-        Module { map, lookup_table }
+        Module { uri: uri.clone(), map, lookup_table }
     }
 }
 

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -12,7 +12,7 @@ mod fv;
 use fv::*;
 
 /// Lift local (co)matches for `name` in `prg` to top-level (co)definitions
-pub fn lift(prg: Prg, name: &str) -> LiftResult {
+pub fn lift(prg: Module, name: &str) -> LiftResult {
     let mut ctx = Ctx {
         name: name.to_owned(),
         new_decls: vec![],
@@ -30,7 +30,7 @@ pub fn lift(prg: Prg, name: &str) -> LiftResult {
 /// Result of lifting
 pub struct LiftResult {
     /// The resulting program
-    pub prg: Prg,
+    pub prg: Module,
     /// List of new top-level definitions
     pub new_decls: HashSet<Ident>,
     /// List of top-level declarations that have been modified in the lifting process
@@ -71,21 +71,11 @@ trait LiftTelescope {
     fn lift_telescope<T, F: FnOnce(&mut Ctx, Self::Target) -> T>(&self, ctx: &mut Ctx, f: F) -> T;
 }
 
-impl Lift for Prg {
-    type Target = Prg;
+impl Lift for Module {
+    type Target = Module;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Prg { decls } = self;
-
-        Prg { decls: decls.lift(ctx) }
-    }
-}
-
-impl Lift for Decls {
-    type Target = Decls;
-
-    fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Decls { map, lookup_table } = self;
+        let Module { map, lookup_table } = self;
 
         let mut map: HashMap<_, _> =
             map.iter().map(|(name, decl)| (name.clone(), decl.lift(ctx))).collect();
@@ -100,7 +90,7 @@ impl Lift for Decls {
         let decls_iter = ctx.new_decls.iter().map(|decl| (decl.name().clone(), decl.clone()));
         map.extend(decls_iter);
 
-        Decls { map, lookup_table }
+        Module { map, lookup_table }
     }
 }
 

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -11,8 +11,8 @@ use crate::lower::Lower;
 pub use ctx::*;
 pub use result::*;
 
-pub fn lower_module(prg: &cst::decls::Prg) -> Result<generic::Module, LoweringError> {
-    let cst::decls::Prg { items } = prg;
+pub fn lower_module(prg: &cst::decls::Module) -> Result<generic::Module, LoweringError> {
+    let cst::decls::Module { items } = prg;
 
     let (top_level_map, lookup_table) = build_lookup_table(items)?;
 

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -11,7 +11,7 @@ use crate::lower::Lower;
 pub use ctx::*;
 pub use result::*;
 
-pub fn lower_prg(prg: &cst::decls::Prg) -> Result<generic::Prg, LoweringError> {
+pub fn lower_module(prg: &cst::decls::Prg) -> Result<generic::Module, LoweringError> {
     let cst::decls::Prg { items } = prg;
 
     let (top_level_map, lookup_table) = build_lookup_table(items)?;
@@ -22,5 +22,5 @@ pub fn lower_prg(prg: &cst::decls::Prg) -> Result<generic::Prg, LoweringError> {
         item.lower(&mut ctx)?;
     }
 
-    Ok(generic::Prg { decls: generic::Decls { map: ctx.decls_map, lookup_table } })
+    Ok(generic::Module { map: ctx.decls_map, lookup_table })
 }

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -12,7 +12,7 @@ pub use ctx::*;
 pub use result::*;
 
 pub fn lower_module(prg: &cst::decls::Module) -> Result<generic::Module, LoweringError> {
-    let cst::decls::Module { items } = prg;
+    let cst::decls::Module { uri, items } = prg;
 
     let (top_level_map, lookup_table) = build_lookup_table(items)?;
 
@@ -22,5 +22,5 @@ pub fn lower_module(prg: &cst::decls::Module) -> Result<generic::Module, Lowerin
         item.lower(&mut ctx)?;
     }
 
-    Ok(generic::Module { map: ctx.decls_map, lookup_table })
+    Ok(generic::Module { uri: uri.clone(), map: ctx.decls_map, lookup_table })
 }

--- a/lang/parser/Cargo.toml
+++ b/lang/parser/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # parser generator
 lalrpop = "0.20"
 lalrpop-util = "0.20"
+# url (for file locations)
+url = "2.5.0"
 # source code locations
 codespan = "0.11"
 # fancy error messages

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use codespan::Span;
+use url::Url;
 
 use super::exp;
 
@@ -18,6 +19,8 @@ pub struct Attribute {
 
 #[derive(Debug, Clone)]
 pub struct Module {
+    /// The location of the module on disk
+    pub uri: Url,
     pub items: Vec<Decl>,
 }
 

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -17,7 +17,7 @@ pub struct Attribute {
 }
 
 #[derive(Debug, Clone)]
-pub struct Prg {
+pub struct Module {
     pub items: Vec<Decl>,
 }
 

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -87,8 +87,8 @@ DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 //
 //
 
-pub Prg: Module = {
-    <items: Decl*> => Module { items,  },
+pub Decls: Vec<Decl> = {
+    <items: Decl*> => items,
 }
 
 pub Decl: Decl = {

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -87,8 +87,8 @@ DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 //
 //
 
-pub Prg: Prg = {
-    <items: Decl*> => Prg { items,  },
+pub Prg: Module = {
+    <items: Decl*> => Module { items,  },
 }
 
 pub Decl: Decl = {

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -2,15 +2,20 @@ pub mod cst;
 mod grammar;
 mod result;
 
-use std::rc::Rc;
+use std::{path::Path, rc::Rc};
 
-use grammar::cst::{ExpParser, PrgParser};
+use grammar::cst::{DeclsParser, ExpParser};
 pub use result::*;
+use url::Url;
 
 pub fn parse_exp(s: &str) -> Result<Rc<cst::exp::Exp>, ParseError> {
     ExpParser::new().parse(s).map_err(From::from)
 }
 
-pub fn parse_module(s: &str) -> Result<cst::decls::Module, ParseError> {
-    PrgParser::new().parse(s).map_err(From::from)
+pub fn parse_module(fp: &Path, s: &str) -> Result<cst::decls::Module, ParseError> {
+    let uri = Url::from_file_path(fp).map_err(|_| ParseError::User {
+        error: format!("Cannot convert filepath {:?} to url", fp),
+    })?;
+    let decls = DeclsParser::new().parse(s)?;
+    Ok(cst::decls::Module { uri, items: decls })
 }

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -11,6 +11,6 @@ pub fn parse_exp(s: &str) -> Result<Rc<cst::exp::Exp>, ParseError> {
     ExpParser::new().parse(s).map_err(From::from)
 }
 
-pub fn parse_program(s: &str) -> Result<cst::decls::Prg, ParseError> {
+pub fn parse_module(s: &str) -> Result<cst::decls::Module, ParseError> {
     PrgParser::new().parse(s).map_err(From::from)
 }

--- a/lang/printer/src/fragments.rs
+++ b/lang/printer/src/fragments.rs
@@ -1,14 +1,14 @@
 use pretty::DocAllocator;
 
 use super::types::*;
-use syntax::generic::{Decl, Decls};
+use syntax::generic::{Decl, Module};
 
 pub struct Items {
     pub items: Vec<Decl>,
 }
 
 impl<'a> PrintInCtx<'a> for Items {
-    type Ctx = Decls;
+    type Ctx = Module;
 
     fn print_in_ctx(
         &'a self,

--- a/lang/printer/src/generic.rs
+++ b/lang/printer/src/generic.rs
@@ -15,14 +15,7 @@ fn is_visible(attr: &Attribute) -> bool {
     !attr.attrs.contains(&"omit_print".to_owned())
 }
 
-impl<'a> Print<'a> for Prg {
-    fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let Prg { decls } = self;
-        decls.print(cfg, alloc)
-    }
-}
-
-impl<'a> Print<'a> for Decls {
+impl<'a> Print<'a> for Module {
     fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let items =
             self.iter().filter(|item| is_visible(item.attributes())).map(|item| match item {
@@ -39,7 +32,7 @@ impl<'a> Print<'a> for Decls {
 }
 
 impl<'a> PrintInCtx<'a> for Decl {
-    type Ctx = Decls;
+    type Ctx = Module;
 
     fn print_in_ctx(
         &'a self,
@@ -60,7 +53,7 @@ impl<'a> PrintInCtx<'a> for Decl {
 }
 
 impl<'a> PrintInCtx<'a> for Item<'a> {
-    type Ctx = Decls;
+    type Ctx = Module;
 
     fn print_in_ctx(
         &'a self,
@@ -79,7 +72,7 @@ impl<'a> PrintInCtx<'a> for Item<'a> {
 }
 
 impl<'a> PrintInCtx<'a> for Data {
-    type Ctx = Decls;
+    type Ctx = Module;
 
     fn print_in_ctx(
         &'a self,
@@ -124,7 +117,7 @@ impl<'a> PrintInCtx<'a> for Data {
 }
 
 impl<'a> PrintInCtx<'a> for Codata {
-    type Ctx = Decls;
+    type Ctx = Module;
 
     fn print_in_ctx(
         &'a self,

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -12,7 +12,7 @@ use super::data::{
 };
 
 /// Traverse the program and collect information for the LSP server.
-pub fn collect_info(prg: &Prg) -> (Lapper<u32, HoverInfo>, Lapper<u32, Item>) {
+pub fn collect_info(prg: &Module) -> (Lapper<u32, HoverInfo>, Lapper<u32, Item>) {
     let mut c = InfoCollector::default();
 
     prg.collect_info(&mut c);
@@ -68,16 +68,9 @@ impl<T: CollectInfo> CollectInfo for Option<T> {
 //
 //
 
-impl CollectInfo for Prg {
+impl CollectInfo for Module {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Prg { decls } = self;
-        decls.collect_info(collector)
-    }
-}
-
-impl CollectInfo for Decls {
-    fn collect_info(&self, collector: &mut InfoCollector) {
-        let Decls { map, .. } = self;
+        let Module { map, .. } = self;
         for item in map.values() {
             item.collect_info(collector)
         }

--- a/lang/query/src/view/lift.rs
+++ b/lang/query/src/view/lift.rs
@@ -5,7 +5,7 @@ use syntax::generic;
 use super::DatabaseView;
 
 impl<'a> DatabaseView<'a> {
-    pub fn lift(&self, type_name: &str) -> Result<generic::Prg, crate::Error> {
+    pub fn lift(&self, type_name: &str) -> Result<generic::Module, crate::Error> {
         let prg = self.tst()?;
 
         let LiftResult { prg, .. } = lifting::lift(prg, type_name);

--- a/lang/query/src/view/rt.rs
+++ b/lang/query/src/view/rt.rs
@@ -4,7 +4,7 @@ use super::DatabaseView;
 
 use elaborator::normalizer::normalize::Normalize;
 use parser::cst;
-use syntax::{generic::Exp, generic::ForgetTST, generic::Prg};
+use syntax::{generic::Exp, generic::ForgetTST, generic::Module};
 
 use crate::*;
 
@@ -23,12 +23,12 @@ impl<'a> DatabaseView<'a> {
         parser::parse_program(source).map_err(Error::Parser)
     }
 
-    pub fn ust(&self) -> Result<Prg, Error> {
+    pub fn ust(&self) -> Result<Module, Error> {
         let cst = self.cst()?;
-        lowering::lower_prg(&cst).map_err(Error::Lowering)
+        lowering::lower_module(&cst).map_err(Error::Lowering)
     }
 
-    pub fn tst(&self) -> Result<Prg, Error> {
+    pub fn tst(&self) -> Result<Module, Error> {
         let ust = self.ust()?;
         elaborator::typechecker::check(&ust).map_err(Error::Type)
     }

--- a/lang/query/src/view/rt.rs
+++ b/lang/query/src/view/rt.rs
@@ -18,9 +18,9 @@ impl<'a> DatabaseView<'a> {
         database.files.source(*file_id)
     }
 
-    pub fn cst(&self) -> Result<cst::decls::Prg, Error> {
+    pub fn cst(&self) -> Result<cst::decls::Module, Error> {
         let source = self.source();
-        parser::parse_program(source).map_err(Error::Parser)
+        parser::parse_module(source).map_err(Error::Parser)
     }
 
     pub fn ust(&self) -> Result<Module, Error> {

--- a/lang/query/src/view/rt.rs
+++ b/lang/query/src/view/rt.rs
@@ -20,7 +20,7 @@ impl<'a> DatabaseView<'a> {
 
     pub fn cst(&self) -> Result<cst::decls::Module, Error> {
         let source = self.source();
-        parser::parse_module(source).map_err(Error::Parser)
+        parser::parse_module(Path::new(self.filename()), source).map_err(Error::Parser)
     }
 
     pub fn ust(&self) -> Result<Module, Error> {

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -49,6 +49,7 @@ impl<R: Rename + Clone> Rename for Rc<R> {
 impl Rename for Module {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         Module {
+            uri: self.uri,
             map: self.map.into_iter().map(|(name, decl)| (name, decl.rename_in_ctx(ctx))).collect(),
             lookup_table: self.lookup_table,
         }

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -46,17 +46,9 @@ impl<R: Rename + Clone> Rename for Rc<R> {
     }
 }
 
-impl Rename for Prg {
+impl Rename for Module {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Prg { decls } = self;
-
-        Prg { decls: decls.rename_in_ctx(ctx) }
-    }
-}
-
-impl Rename for Decls {
-    fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        Decls {
+        Module {
             map: self.map.into_iter().map(|(name, decl)| (name, decl.rename_in_ctx(ctx))).collect(),
             lookup_table: self.lookup_table,
         }

--- a/lang/syntax/Cargo.toml
+++ b/lang/syntax/Cargo.toml
@@ -9,6 +9,8 @@ miette = "5"
 thiserror = "1"
 # source code locations
 codespan = "0.11"
+# url (for file locations)
+url = "2.5.0"
 # ignoring fields when deriving traits (e.g. Eq, Hash)
 derivative = "2"
 # big integers

--- a/lang/syntax/src/trees/generic/decls.rs
+++ b/lang/syntax/src/trees/generic/decls.rs
@@ -20,47 +20,33 @@ pub struct Attribute {
     pub attrs: Vec<String>,
 }
 
-// Prg
+// Module
 //
 //
 
+/// A module containing declarations
+///
+/// There is a 1-1 correspondence between modules and files in our system.
 #[derive(Debug, Clone)]
-pub struct Prg {
-    pub decls: Decls,
-}
-
-impl Prg {
-    pub fn find_main(&self) -> Option<Rc<Exp>> {
-        let main_candidate = self.decls.map.get("main")?.get_main()?;
-        Some(main_candidate.body)
-    }
-}
-
-impl ForgetTST for Prg {
-    fn forget_tst(&self) -> Self {
-        let Prg { decls } = self;
-
-        Prg { decls: decls.forget_tst() }
-    }
-}
-
-// Decls
-//
-//
-
-#[derive(Debug, Clone)]
-pub struct Decls {
+pub struct Module {
     /// Map from identifiers to declarations
     pub map: HashMap<Ident, Decl>,
     /// Metadata on declarations
     pub lookup_table: LookupTable,
 }
 
-impl ForgetTST for Decls {
-    fn forget_tst(&self) -> Self {
-        let Decls { map, lookup_table } = self;
+impl Module {
+    pub fn find_main(&self) -> Option<Rc<Exp>> {
+        let main_candidate = self.map.get("main")?.get_main()?;
+        Some(main_candidate.body)
+    }
+}
 
-        Decls {
+impl ForgetTST for Module {
+    fn forget_tst(&self) -> Self {
+        let Module { map, lookup_table } = self;
+
+        Module {
             map: map.iter().map(|(name, decl)| (name.clone(), decl.forget_tst())).collect(),
             lookup_table: lookup_table.clone(),
         }

--- a/lang/syntax/src/trees/generic/decls.rs
+++ b/lang/syntax/src/trees/generic/decls.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use codespan::Span;
 use derivative::Derivative;
+use url::Url;
 
 use crate::common::*;
 
@@ -29,6 +30,8 @@ pub struct Attribute {
 /// There is a 1-1 correspondence between modules and files in our system.
 #[derive(Debug, Clone)]
 pub struct Module {
+    /// The location of the module on disk
+    pub uri: Url,
     /// Map from identifiers to declarations
     pub map: HashMap<Ident, Decl>,
     /// Metadata on declarations
@@ -44,9 +47,10 @@ impl Module {
 
 impl ForgetTST for Module {
     fn forget_tst(&self) -> Self {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         Module {
+            uri: uri.clone(),
             map: map.iter().map(|(name, decl)| (name.clone(), decl.forget_tst())).collect(),
             lookup_table: lookup_table.clone(),
         }

--- a/lang/syntax/src/trees/generic/lookup.rs
+++ b/lang/syntax/src/trees/generic/lookup.rs
@@ -10,7 +10,7 @@ use super::exp::*;
 use super::lookup_table;
 use super::lookup_table::DeclKind;
 
-impl Decls {
+impl Module {
     pub fn empty() -> Self {
         Self { map: HashMap::default(), lookup_table: Default::default() }
     }

--- a/lang/syntax/src/trees/generic/lookup.rs
+++ b/lang/syntax/src/trees/generic/lookup.rs
@@ -1,6 +1,5 @@
 use std::rc::Rc;
 
-use crate::common::*;
 use miette::{Diagnostic, SourceSpan};
 use miette_util::ToMiette;
 use thiserror::Error;
@@ -11,14 +10,6 @@ use super::lookup_table;
 use super::lookup_table::DeclKind;
 
 impl Module {
-    pub fn empty() -> Self {
-        Self { map: HashMap::default(), lookup_table: Default::default() }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = Item<'_>> {
         self.lookup_table.iter().map(|item| match item {
             lookup_table::Item::Type(type_decl) => match &self.map[&type_decl.name] {

--- a/lang/xfunc/src/lib.rs
+++ b/lang/xfunc/src/lib.rs
@@ -3,7 +3,7 @@ use syntax::generic;
 pub mod matrix;
 pub mod result;
 
-pub fn as_matrix(prg: &generic::Prg) -> Result<matrix::Prg, crate::result::XfuncError> {
+pub fn as_matrix(prg: &generic::Module) -> Result<matrix::Prg, crate::result::XfuncError> {
     matrix::build(prg)
 }
 

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -46,7 +46,7 @@ pub enum Repr {
 }
 
 /// Take the red pill
-pub fn build(prg: &generic::Prg) -> Result<Prg, XfuncError> {
+pub fn build(prg: &generic::Module) -> Result<Prg, XfuncError> {
     let mut out = Prg { map: HashMap::default(), exp: None };
     let mut ctx = Ctx::empty();
     prg.build_matrix(&mut ctx, &mut out)?;
@@ -67,11 +67,11 @@ impl Ctx {
     }
 }
 
-impl BuildMatrix for generic::Prg {
+impl BuildMatrix for generic::Module {
     fn build_matrix(&self, ctx: &mut Ctx, out: &mut Prg) -> Result<(), XfuncError> {
-        let generic::Prg { decls } = self;
+        let generic::Module { map, .. } = self;
 
-        for decl in decls.map.values() {
+        for decl in map.values() {
             match decl {
                 generic::Decl::Data(data) => data.build_matrix(ctx, out),
                 generic::Decl::Codata(codata) => codata.build_matrix(ctx, out),
@@ -79,7 +79,7 @@ impl BuildMatrix for generic::Prg {
             }?
         }
 
-        for decl in decls.map.values() {
+        for decl in map.values() {
             match decl {
                 generic::Decl::Ctor(ctor) => ctor.build_matrix(ctx, out),
                 generic::Decl::Dtor(dtor) => dtor.build_matrix(ctx, out),

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
 use std::fmt;
+use std::{error::Error, path::Path};
 
 use parser::cst;
 use printer::PrintToString;
@@ -197,7 +197,7 @@ impl Phase for Parse {
     }
 
     fn run(input: Self::In) -> Result<Self::Out, Self::Err> {
-        parser::parse_module(&input)
+        parser::parse_module(Path::new("/"), &input) // TODO: Fix this!
     }
 }
 

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -185,7 +185,7 @@ pub struct Print {
 
 impl Phase for Parse {
     type In = String;
-    type Out = cst::decls::Prg;
+    type Out = cst::decls::Module;
     type Err = parser::ParseError;
 
     fn new(name: &'static str) -> Self {
@@ -197,12 +197,12 @@ impl Phase for Parse {
     }
 
     fn run(input: Self::In) -> Result<Self::Out, Self::Err> {
-        parser::parse_program(&input)
+        parser::parse_module(&input)
     }
 }
 
 impl Phase for Lower {
-    type In = cst::decls::Prg;
+    type In = cst::decls::Module;
     type Out = Module;
     type Err = lowering::LoweringError;
 
@@ -273,7 +273,7 @@ impl Phase for Forget {
     }
 }
 
-impl TestOutput for cst::decls::Prg {
+impl TestOutput for cst::decls::Module {
     fn test_output(&self) -> String {
         // TODO: Improve test output
         format!("{self:?}")

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use parser::cst;
 use printer::PrintToString;
 use renaming::Rename;
-use syntax::generic::{ForgetTST, Prg};
+use syntax::generic::{ForgetTST, Module};
 
 use super::infallible::NoError;
 
@@ -203,7 +203,7 @@ impl Phase for Parse {
 
 impl Phase for Lower {
     type In = cst::decls::Prg;
-    type Out = Prg;
+    type Out = Module;
     type Err = lowering::LoweringError;
 
     fn new(name: &'static str) -> Self {
@@ -215,13 +215,13 @@ impl Phase for Lower {
     }
 
     fn run(input: Self::In) -> Result<Self::Out, Self::Err> {
-        lowering::lower_prg(&input)
+        lowering::lower_module(&input)
     }
 }
 
 impl Phase for Check {
-    type In = Prg;
-    type Out = Prg;
+    type In = Module;
+    type Out = Module;
     type Err = elaborator::result::TypeError;
 
     fn new(name: &'static str) -> Self {
@@ -238,7 +238,7 @@ impl Phase for Check {
 }
 
 impl Phase for Print {
-    type In = Prg;
+    type In = Module;
     type Out = String;
     type Err = NoError;
 
@@ -256,8 +256,8 @@ impl Phase for Print {
 }
 
 impl Phase for Forget {
-    type In = Prg;
-    type Out = Prg;
+    type In = Module;
+    type Out = Module;
     type Err = NoError;
 
     fn new(name: &'static str) -> Self {
@@ -280,7 +280,7 @@ impl TestOutput for cst::decls::Prg {
     }
 }
 
-impl TestOutput for Prg {
+impl TestOutput for Module {
     fn test_output(&self) -> String {
         self.print_to_string(None)
     }


### PR DESCRIPTION
Merge the `Decls` and `Prg` structs into one single `Module` struct.

In order to implement jump-to-definition correctly I need every module to know its own filepath (encoded as type `Url`, since this is what the LSP protocol uses).

But there are some design decisions here on how the parser should learn about the filepath: Should the parser itself be tasked with reading the file? (probably not, since the LSP implements some sort of virtual file system). So what type should we pass to the `parse_module`function. The already converted url? A `Path` , an `OsString` ?

Need advice @timsueberkrueb  :)