### PR TITLE
Put Url containing absolute path into definition of modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,9 +716,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -941,9 +941,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -1511,13 +1511,14 @@ dependencies = [
  "miette",
  "num-bigint",
  "thiserror",
+ "url",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -1711,6 +1712,7 @@ dependencies = [
  "rust-lapper",
  "syntax",
  "thiserror",
+ "url",
  "xfunc",
 ]
 
@@ -2132,6 +2134,7 @@ dependencies = [
  "miette_util",
  "num-bigint",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -2306,6 +2309,7 @@ dependencies = [
  "syntax",
  "tantivy",
  "toml",
+ "url",
 ]
 
 [[package]]
@@ -2616,9 +2620,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/lang/elaborator/src/typechecker/decls.rs
+++ b/lang/elaborator/src/typechecker/decls.rs
@@ -24,7 +24,7 @@ pub trait CheckToplevel: Sized {
 /// Check all declarations in a program
 impl CheckToplevel for Module {
     fn check_wf(&self, prg: &Module) -> Result<Self, TypeError> {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         // FIXME: Reconsider order
 
@@ -33,7 +33,7 @@ impl CheckToplevel for Module {
             .map(|(name, decl)| Ok((name.clone(), decl.check_wf(prg)?)))
             .collect::<Result<_, TypeError>>()?;
 
-        Ok(Module { map: map_out, lookup_table: lookup_table.clone() })
+        Ok(Module { uri: uri.clone(), map: map_out, lookup_table: lookup_table.clone() })
     }
 }
 

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -75,7 +75,7 @@ impl Lift for Module {
     type Target = Module;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         let mut map: HashMap<_, _> =
             map.iter().map(|(name, decl)| (name.clone(), decl.lift(ctx))).collect();
@@ -90,7 +90,7 @@ impl Lift for Module {
         let decls_iter = ctx.new_decls.iter().map(|decl| (decl.name().clone(), decl.clone()));
         map.extend(decls_iter);
 
-        Module { map, lookup_table }
+        Module { uri: uri.clone(), map, lookup_table }
     }
 }
 

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -12,7 +12,7 @@ pub use ctx::*;
 pub use result::*;
 
 pub fn lower_module(prg: &cst::decls::Module) -> Result<ast::Module, LoweringError> {
-    let cst::decls::Module { items } = prg;
+    let cst::decls::Module { uri, items } = prg;
 
     let (top_level_map, lookup_table) = build_lookup_table(items)?;
 
@@ -22,5 +22,5 @@ pub fn lower_module(prg: &cst::decls::Module) -> Result<ast::Module, LoweringErr
         item.lower(&mut ctx)?;
     }
 
-    Ok(ast::Module { map: ctx.decls_map, lookup_table })
+    Ok(ast::Module { uri: uri.clone(), map: ctx.decls_map, lookup_table })
 }

--- a/lang/parser/Cargo.toml
+++ b/lang/parser/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # parser generator
 lalrpop = "0.20"
 lalrpop-util = "0.20"
+# url (for file locations)
+url = "2.5.0"
 # source code locations
 codespan = "0.11"
 # fancy error messages

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use codespan::Span;
+use url::Url;
 
 use super::exp;
 use super::ident::*;
@@ -19,6 +20,8 @@ pub struct Attribute {
 
 #[derive(Debug, Clone)]
 pub struct Module {
+    /// The location of the module on disk
+    pub uri: Url,
     pub items: Vec<Decl>,
 }
 

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -89,8 +89,8 @@ DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 //
 //
 
-pub Prg: Module = {
-    <items: Decl*> => Module { items,  },
+pub Decls: Vec<Decl> = {
+    <items: Decl*> => items,
 }
 
 pub Decl: Decl = {

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -4,13 +4,16 @@ mod result;
 
 use std::rc::Rc;
 
-use grammar::cst::{ExpParser, PrgParser};
+use url::Url;
+
+use grammar::cst::{DeclsParser, ExpParser};
 pub use result::*;
 
 pub fn parse_exp(s: &str) -> Result<Rc<cst::exp::Exp>, ParseError> {
     ExpParser::new().parse(s).map_err(From::from)
 }
 
-pub fn parse_module(s: &str) -> Result<cst::decls::Module, ParseError> {
-    PrgParser::new().parse(s).map_err(From::from)
+pub fn parse_module(uri: Url, s: &str) -> Result<cst::decls::Module, ParseError> {
+    let items = DeclsParser::new().parse(s)?;
+    Ok(cst::decls::Module { uri, items })
 }

--- a/lang/query/Cargo.toml
+++ b/lang/query/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# url (for file locations)
+url = "2.5.0"
 # source code spans
 codespan = "0.11"
 # index of source code intervals

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -49,6 +49,7 @@ impl<R: Rename + Clone> Rename for Rc<R> {
 impl Rename for Module {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
         Module {
+            uri: self.uri,
             map: self.map.into_iter().map(|(name, decl)| (name, decl.rename_in_ctx(ctx))).collect(),
             lookup_table: self.lookup_table,
         }

--- a/lang/syntax/Cargo.toml
+++ b/lang/syntax/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # fancy error messages
 miette = "5"
 thiserror = "1"
+# url (for file locations)
+url = "2.5.0"
 # source code locations
 codespan = "0.11"
 # ignoring fields when deriving traits (e.g. Eq, Hash)

--- a/lang/syntax/src/trees/ast/decls.rs
+++ b/lang/syntax/src/trees/ast/decls.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use codespan::Span;
 use derivative::Derivative;
+use url::Url;
 
 use crate::common::*;
 
@@ -30,6 +31,7 @@ pub struct Attribute {
 /// There is a 1-1 correspondence between modules and files in our system.
 #[derive(Debug, Clone)]
 pub struct Module {
+    pub uri: Url,
     /// Map from identifiers to declarations
     pub map: HashMap<Ident, Decl>,
     /// Metadata on declarations
@@ -45,9 +47,10 @@ impl Module {
 
 impl ForgetTST for Module {
     fn forget_tst(&self) -> Self {
-        let Module { map, lookup_table } = self;
+        let Module { uri, map, lookup_table } = self;
 
         Module {
+            uri: uri.clone(),
             map: map.iter().map(|(name, decl)| (name.clone(), decl.forget_tst())).collect(),
             lookup_table: lookup_table.clone(),
         }

--- a/lang/syntax/src/trees/ast/lookup.rs
+++ b/lang/syntax/src/trees/ast/lookup.rs
@@ -1,6 +1,5 @@
 use std::rc::Rc;
 
-use crate::common::*;
 use miette::{Diagnostic, SourceSpan};
 use miette_util::ToMiette;
 use thiserror::Error;
@@ -11,14 +10,6 @@ use super::lookup_table;
 use super::lookup_table::DeclKind;
 
 impl Module {
-    pub fn empty() -> Self {
-        Self { map: HashMap::default(), lookup_table: Default::default() }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = Item<'_>> {
         self.lookup_table.iter().map(|item| match item {
             lookup_table::Item::Type(type_decl) => match &self.map[&type_decl.name] {

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 # full text search engine
 tantivy = "0.18"
+# url (for file locations)
+url = "2.5.0"
 # config
 serde = "1"
 serde_derive = "1"

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use syntax::common::HashMap;
+use url::Url;
 
 use super::cases::Case;
 use super::index::Index;
@@ -82,7 +83,9 @@ impl Runner {
     }
 
     pub fn run_case(&self, config: &suites::Config, case: &Case) -> Report {
-        let input = case.content().unwrap();
+        let canonicalized_path = case.path.clone().canonicalize().unwrap();
+        let uri = Url::from_file_path(canonicalized_path).unwrap();
+        let input = (uri, case.content().unwrap());
 
         Phases::start(input)
             .then(expect(config, case, Parse::new("parse")))


### PR DESCRIPTION
Each module knows to which file it corresponds on disk. This PR replaces #198 .
I need this information in order to implement the "jump-to" functionality in the  LSP  server correctly. Url is the type that the LSP protocol uses everywhere, so I use that one instead of PathBuf, OsPath or something similar.