### PR TITLE
Add hover information for many more syntax nodes

### DIFF
--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -237,9 +237,9 @@ impl CollectInfo for Exp {
 
 impl CollectInfo for Variable {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Variable { span, inferred_type, .. } = self;
+        let Variable { span, inferred_type, name, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let info = VariableInfo { typ: typ.print_to_string(None) };
+            let info = VariableInfo { typ: typ.print_to_string(None), name: name.clone() };
             collector.add_info(*span, info)
         }
     }

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -104,13 +104,15 @@ impl CollectInfo for Decl {
 
 impl CollectInfo for Data {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Data { name, span, .. } = self;
+        let Data { name, span, doc, typ, .. } = self;
         if let Some(span) = span {
             // Add item
             let item = Item::Data(name.clone());
             collector.add_item(*span, item);
             // Add info
-            let info = DataInfo {};
+            let doc = doc.clone().map(|doc| doc.docs);
+            let info =
+                DataInfo { name: name.clone(), doc, params: typ.params.print_to_string(None) };
             collector.add_info(*span, info)
         }
     }
@@ -118,13 +120,15 @@ impl CollectInfo for Data {
 
 impl CollectInfo for Codata {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Codata { name, span, .. } = self;
+        let Codata { name, doc, typ, span, .. } = self;
         if let Some(span) = span {
             // Add item
             let item = Item::Codata(name.clone());
             collector.add_item(*span, item);
             // Add info
-            let info = CodataInfo {};
+            let doc = doc.clone().map(|doc| doc.docs);
+            let info =
+                CodataInfo { name: name.clone(), doc, params: typ.params.print_to_string(None) };
             collector.add_info(*span, info);
         }
     }
@@ -163,10 +167,11 @@ impl CollectInfo for Codef {
 
 impl CollectInfo for Ctor {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Ctor { span, .. } = self;
+        let Ctor { span, name, doc, .. } = self;
         if let Some(span) = span {
             // Add info
-            let info = CtorInfo {};
+            let doc = doc.clone().map(|doc| doc.docs);
+            let info = CtorInfo { name: name.clone(), doc };
             collector.add_info(*span, info)
         }
     }
@@ -174,10 +179,11 @@ impl CollectInfo for Ctor {
 
 impl CollectInfo for Dtor {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Dtor { span, .. } = self;
+        let Dtor { span, name, doc, .. } = self;
         if let Some(span) = span {
             // Add info
-            let info = DtorInfo {};
+            let doc = doc.clone().map(|doc| doc.docs);
+            let info = DtorInfo { name: name.clone(), doc };
             collector.add_info(*span, info)
         }
     }

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -247,9 +247,9 @@ impl CollectInfo for Variable {
 
 impl CollectInfo for TypCtor {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let TypCtor { span, args, .. } = self;
+        let TypCtor { span, args, name } = self;
         if let Some(span) = span {
-            let info = TypeCtorInfo {};
+            let info = TypeCtorInfo { name: name.clone() };
             collector.add_info(*span, info)
         }
         args.collect_info(collector)

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -6,7 +6,10 @@ use rust_lapper::{Interval, Lapper};
 use printer::PrintToString;
 use syntax::ast::*;
 
-use crate::{CodataInfo, CodefInfo, DataInfo, DefInfo, LetInfo, LocalComatchInfo, LocalMatchInfo};
+use crate::{
+    CodataInfo, CodefInfo, CtorInfo, DataInfo, DefInfo, DtorInfo, LetInfo, LocalComatchInfo,
+    LocalMatchInfo,
+};
 
 use super::data::{
     AnnoInfo, CallInfo, DotCallInfo, HoleInfo, Info, InfoContent, TypeCtorInfo, TypeUnivInfo,
@@ -159,11 +162,25 @@ impl CollectInfo for Codef {
 }
 
 impl CollectInfo for Ctor {
-    fn collect_info(&self, _collector: &mut InfoCollector) {}
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let Ctor { span, .. } = self;
+        if let Some(span) = span {
+            // Add info
+            let info = CtorInfo {};
+            collector.add_info(*span, info)
+        }
+    }
 }
 
 impl CollectInfo for Dtor {
-    fn collect_info(&self, _collector: &mut InfoCollector) {}
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let Dtor { span, .. } = self;
+        if let Some(span) = span {
+            // Add info
+            let info = DtorInfo {};
+            collector.add_info(*span, info)
+        }
+    }
 }
 
 impl CollectInfo for Let {

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -258,9 +258,9 @@ impl CollectInfo for TypCtor {
 
 impl CollectInfo for Call {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Call { span, kind, args, inferred_type, .. } = self;
+        let Call { span, kind, args, inferred_type, name } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let info = CallInfo { kind: *kind, typ: typ.print_to_string(None) };
+            let info = CallInfo { kind: *kind, typ: typ.print_to_string(None), name: name.clone() };
             collector.add_info(*span, info)
         }
         args.collect_info(collector)

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -146,7 +146,7 @@ impl CollectInfo for Codata {
 
 impl CollectInfo for Def {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Def { name, span, self_param, body, params, .. } = self;
+        let Def { name, span, self_param, body, params, ret_typ, .. } = self;
         if let Some(span) = span {
             // Add Item
             let item = Item::Def { name: name.clone(), type_name: self_param.typ.name.clone() };
@@ -156,8 +156,10 @@ impl CollectInfo for Def {
             collector.add_info(*span, info);
         };
 
+        self_param.collect_info(collector);
         body.collect_info(collector);
-        params.collect_info(collector)
+        params.collect_info(collector);
+        ret_typ.collect_info(collector);
     }
 }
 
@@ -179,25 +181,29 @@ impl CollectInfo for Codef {
 
 impl CollectInfo for Ctor {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Ctor { span, name, doc, .. } = self;
+        let Ctor { span, name, doc, typ, .. } = self;
         if let Some(span) = span {
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
             let info = CtorInfo { name: name.clone(), doc };
-            collector.add_info(*span, info)
+            collector.add_info(*span, info);
         }
+        typ.collect_info(collector);
     }
 }
 
 impl CollectInfo for Dtor {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Dtor { span, name, doc, .. } = self;
+        let Dtor { span, name, doc, self_param, params, ret_typ } = self;
         if let Some(span) = span {
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
             let info = DtorInfo { name: name.clone(), doc };
-            collector.add_info(*span, info)
+            collector.add_info(*span, info);
         }
+        self_param.collect_info(collector);
+        params.collect_info(collector);
+        ret_typ.collect_info(collector);
     }
 }
 
@@ -376,5 +382,12 @@ impl CollectInfo for Param {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let Param { typ, .. } = self;
         typ.collect_info(collector)
+    }
+}
+
+impl CollectInfo for SelfParam {
+    fn collect_info(&self, collector: &mut InfoCollector) {
+        let SelfParam { typ, .. } = self;
+        typ.collect_info(collector);
     }
 }

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -303,10 +303,10 @@ impl CollectInfo for Anno {
 
 impl CollectInfo for LocalMatch {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let LocalMatch { span, on_exp, ret_typ, body, .. } = self;
-        if let Some(span) = span {
+        let LocalMatch { span, on_exp, ret_typ, body, inferred_type, .. } = self;
+        if let (Some(span), Some(typ)) = (span, inferred_type) {
             // Add info
-            let info = LocalMatchInfo {};
+            let info = LocalMatchInfo { typ: typ.print_to_string(None) };
             collector.add_info(*span, info)
         }
         on_exp.collect_info(collector);
@@ -317,10 +317,10 @@ impl CollectInfo for LocalMatch {
 
 impl CollectInfo for LocalComatch {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let LocalComatch { span, body, .. } = self;
-        if let Some(span) = span {
+        let LocalComatch { span, body, inferred_type, .. } = self;
+        if let (Some(span), Some(typ)) = (span, inferred_type) {
             // Add info
-            let info = LocalComatchInfo {};
+            let info = LocalComatchInfo { typ: typ.print_to_string(None) };
             collector.add_info(*span, info)
         }
         body.collect_info(collector)

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -269,9 +269,10 @@ impl CollectInfo for Call {
 
 impl CollectInfo for DotCall {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let DotCall { span, kind, exp, args, inferred_type, .. } = self;
+        let DotCall { span, kind, exp, args, inferred_type, name } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let info = DotCallInfo { kind: *kind, typ: typ.print_to_string(None) };
+            let info =
+                DotCallInfo { kind: *kind, name: name.clone(), typ: typ.print_to_string(None) };
             collector.add_info(*span, info)
         }
         exp.collect_info(collector);

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -49,7 +49,14 @@ pub enum InfoContent {
 
 /// Information for toplevel data type declarations
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DataInfo {}
+pub struct DataInfo {
+    /// Name of the data type
+    pub name: String,
+    /// Doc comments for data type
+    pub doc: Option<Vec<String>>,
+    /// Parameters
+    pub params: String,
+}
 
 impl From<DataInfo> for InfoContent {
     fn from(value: DataInfo) -> Self {
@@ -59,7 +66,10 @@ impl From<DataInfo> for InfoContent {
 
 /// Information about constructor within a data type declaration
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CtorInfo {}
+pub struct CtorInfo {
+    pub name: String,
+    pub doc: Option<Vec<String>>,
+}
 
 impl From<CtorInfo> for InfoContent {
     fn from(value: CtorInfo) -> Self {
@@ -69,7 +79,14 @@ impl From<CtorInfo> for InfoContent {
 
 /// Information for toplevel codata type declarations
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CodataInfo {}
+pub struct CodataInfo {
+    /// Name of the data type
+    pub name: String,
+    /// Doc comments for data type
+    pub doc: Option<Vec<String>>,
+    /// Parameters
+    pub params: String,
+}
 
 impl From<CodataInfo> for InfoContent {
     fn from(value: CodataInfo) -> Self {
@@ -79,7 +96,10 @@ impl From<CodataInfo> for InfoContent {
 
 /// Information about destructor within a data type declaration
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DtorInfo {}
+pub struct DtorInfo {
+    pub name: String,
+    pub doc: Option<Vec<String>>,
+}
 
 impl From<DtorInfo> for InfoContent {
     fn from(value: DtorInfo) -> Self {

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -144,6 +144,7 @@ impl From<LetInfo> for InfoContent {
 /// Information for bound variables
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableInfo {
+    pub name: String,
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -7,21 +7,23 @@ use syntax::{
     ctx::values::{Binder as TypeCtxBinder, TypeCtx},
 };
 
-// HoverInfo
+// Info
 //
-// Types which contain the information that is displayed in a
-// code editor when hovering over a point in the program code.
+// Types which contain information about source code locations
+// that can be used by the LSP server to provide various services,
+// such as type-on-hover and jump-to-definition.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HoverInfo {
+pub struct Info {
     /// The source code location to which the content applies
     pub span: Span,
-    /// The information that should be displayed on hover
-    pub content: HoverInfoContent,
+    /// The information that is available for that span
+    pub content: InfoContent,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HoverInfoContent {
+pub enum InfoContent {
+    // Expressions
     VariableInfo(VariableInfo),
     TypeCtorInfo(TypeCtorInfo),
     CallInfo(CallInfo),
@@ -29,47 +31,175 @@ pub enum HoverInfoContent {
     TypeUnivInfo(TypeUnivInfo),
     HoleInfo(HoleInfo),
     AnnoInfo(AnnoInfo),
+    LocalMatchInfo(LocalMatchInfo),
+    LocalComatchInfo(LocalComatchInfo),
+    // Toplevel Declarations
+    DataInfo(DataInfo),
+    CodataInfo(CodataInfo),
+    DefInfo(DefInfo),
+    CodefInfo(CodefInfo),
+    LetInfo(LetInfo),
 }
 
-/// Hover information for bound variables
+// Info structs for toplevel declarations
+//
+//
+
+/// Information for toplevel data type declarations
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataInfo {}
+
+impl From<DataInfo> for InfoContent {
+    fn from(value: DataInfo) -> Self {
+        InfoContent::DataInfo(value)
+    }
+}
+
+/// Information for toplevel codata type declarations
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodataInfo {}
+
+impl From<CodataInfo> for InfoContent {
+    fn from(value: CodataInfo) -> Self {
+        InfoContent::CodataInfo(value)
+    }
+}
+
+/// Information for toplevel definitions
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefInfo {}
+
+impl From<DefInfo> for InfoContent {
+    fn from(value: DefInfo) -> Self {
+        InfoContent::DefInfo(value)
+    }
+}
+
+/// Information for toplevel codefinitions
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodefInfo {}
+
+impl From<CodefInfo> for InfoContent {
+    fn from(value: CodefInfo) -> Self {
+        InfoContent::CodefInfo(value)
+    }
+}
+
+/// Information for toplevel let bindings
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LetInfo {}
+
+impl From<LetInfo> for InfoContent {
+    fn from(value: LetInfo) -> Self {
+        InfoContent::LetInfo(value)
+    }
+}
+
+// Info structs for expressions
+//
+//
+
+/// Information for bound variables
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VariableInfo {
     pub typ: String,
 }
 
-/// Hover information for type constructors
+impl From<VariableInfo> for InfoContent {
+    fn from(value: VariableInfo) -> Self {
+        InfoContent::VariableInfo(value)
+    }
+}
+
+/// Information for type constructors
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeCtorInfo {}
 
-/// Hover information for calls (constructors, codefinitions or lets)
+impl From<TypeCtorInfo> for InfoContent {
+    fn from(value: TypeCtorInfo) -> Self {
+        InfoContent::TypeCtorInfo(value)
+    }
+}
+
+/// Information for calls (constructors, codefinitions or lets)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallInfo {
     pub kind: CallKind,
     pub typ: String,
 }
 
-/// Hover information for dotcalls (destructors or definitions)
+impl From<CallInfo> for InfoContent {
+    fn from(value: CallInfo) -> Self {
+        InfoContent::CallInfo(value)
+    }
+}
+
+/// Information for dotcalls (destructors or definitions)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DotCallInfo {
     pub kind: DotCallKind,
     pub typ: String,
 }
 
-/// Hover information for type universes
+impl From<DotCallInfo> for InfoContent {
+    fn from(value: DotCallInfo) -> Self {
+        InfoContent::DotCallInfo(value)
+    }
+}
+
+/// Information for type universes
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeUnivInfo {}
 
-/// Hover information for type annotated terms
+impl From<TypeUnivInfo> for InfoContent {
+    fn from(value: TypeUnivInfo) -> Self {
+        InfoContent::TypeUnivInfo(value)
+    }
+}
+
+/// Information for type annotated terms
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnnoInfo {
     pub typ: String,
 }
 
-/// Hover information for typed holes
+impl From<AnnoInfo> for InfoContent {
+    fn from(value: AnnoInfo) -> Self {
+        InfoContent::AnnoInfo(value)
+    }
+}
+
+/// Information for local matches
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalMatchInfo {}
+
+impl From<LocalMatchInfo> for InfoContent {
+    fn from(value: LocalMatchInfo) -> Self {
+        InfoContent::LocalMatchInfo(value)
+    }
+}
+
+/// Information for local comatches
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalComatchInfo {}
+
+impl From<LocalComatchInfo> for InfoContent {
+    fn from(value: LocalComatchInfo) -> Self {
+        InfoContent::LocalComatchInfo(value)
+    }
+}
+
+/// Information for typed holes
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HoleInfo {
     pub goal: String,
     pub ctx: Option<Ctx>,
+}
+
+impl From<HoleInfo> for InfoContent {
+    fn from(value: HoleInfo) -> Self {
+        InfoContent::HoleInfo(value)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,28 +224,5 @@ impl From<TypeCtx> for Ctx {
 impl From<TypeCtxBinder> for Binder {
     fn from(binder: TypeCtxBinder) -> Self {
         Binder { name: binder.name, typ: binder.typ.print_to_string(None) }
-    }
-}
-
-// Item
-//
-//
-
-#[derive(PartialEq, Eq, Clone)]
-pub enum Item {
-    Data(String),
-    Codata(String),
-    Def { name: String, type_name: String },
-    Codef { name: String, type_name: String },
-}
-
-impl Item {
-    pub fn type_name(&self) -> &str {
-        match self {
-            Item::Data(name) => name,
-            Item::Codata(name) => name,
-            Item::Def { type_name, .. } => type_name,
-            Item::Codef { type_name, .. } => type_name,
-        }
     }
 }

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -169,6 +169,7 @@ impl From<TypeCtorInfo> for InfoContent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallInfo {
     pub kind: CallKind,
+    pub name: String,
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -213,7 +213,9 @@ impl From<AnnoInfo> for InfoContent {
 
 /// Information for local matches
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LocalMatchInfo {}
+pub struct LocalMatchInfo {
+    pub typ: String,
+}
 
 impl From<LocalMatchInfo> for InfoContent {
     fn from(value: LocalMatchInfo) -> Self {
@@ -223,7 +225,9 @@ impl From<LocalMatchInfo> for InfoContent {
 
 /// Information for local comatches
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LocalComatchInfo {}
+pub struct LocalComatchInfo {
+    pub typ: String,
+}
 
 impl From<LocalComatchInfo> for InfoContent {
     fn from(value: LocalComatchInfo) -> Self {

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -183,6 +183,7 @@ impl From<CallInfo> for InfoContent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DotCallInfo {
     pub kind: DotCallKind,
+    pub name: String,
     pub typ: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -35,7 +35,9 @@ pub enum InfoContent {
     LocalComatchInfo(LocalComatchInfo),
     // Toplevel Declarations
     DataInfo(DataInfo),
+    CtorInfo(CtorInfo),
     CodataInfo(CodataInfo),
+    DtorInfo(DtorInfo),
     DefInfo(DefInfo),
     CodefInfo(CodefInfo),
     LetInfo(LetInfo),
@@ -55,6 +57,16 @@ impl From<DataInfo> for InfoContent {
     }
 }
 
+/// Information about constructor within a data type declaration
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CtorInfo {}
+
+impl From<CtorInfo> for InfoContent {
+    fn from(value: CtorInfo) -> Self {
+        InfoContent::CtorInfo(value)
+    }
+}
+
 /// Information for toplevel codata type declarations
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodataInfo {}
@@ -62,6 +74,16 @@ pub struct CodataInfo {}
 impl From<CodataInfo> for InfoContent {
     fn from(value: CodataInfo) -> Self {
         InfoContent::CodataInfo(value)
+    }
+}
+
+/// Information about destructor within a data type declaration
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DtorInfo {}
+
+impl From<DtorInfo> for InfoContent {
+    fn from(value: DtorInfo) -> Self {
+        InfoContent::DtorInfo(value)
     }
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -155,7 +155,9 @@ impl From<VariableInfo> for InfoContent {
 
 /// Information for type constructors
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TypeCtorInfo {}
+pub struct TypeCtorInfo {
+    pub name: String,
+}
 
 impl From<TypeCtorInfo> for InfoContent {
     fn from(value: TypeCtorInfo) -> Self {

--- a/lang/query/src/info/item.rs
+++ b/lang/query/src/info/item.rs
@@ -1,0 +1,22 @@
+// Item
+//
+//
+
+#[derive(PartialEq, Eq, Clone)]
+pub enum Item {
+    Data(String),
+    Codata(String),
+    Def { name: String, type_name: String },
+    Codef { name: String, type_name: String },
+}
+
+impl Item {
+    pub fn type_name(&self) -> &str {
+        match self {
+            Item::Data(name) => name,
+            Item::Codata(name) => name,
+            Item::Def { type_name, .. } => type_name,
+            Item::Codef { type_name, .. } => type_name,
+        }
+    }
+}

--- a/lang/query/src/info/mod.rs
+++ b/lang/query/src/info/mod.rs
@@ -3,6 +3,8 @@
 
 mod collect;
 mod data;
+mod item;
 
 pub use collect::*;
 pub use data::*;
+pub use item::*;

--- a/lang/query/src/lib.rs
+++ b/lang/query/src/lib.rs
@@ -23,7 +23,7 @@ pub use view_mut::*;
 pub struct Database {
     id_by_name: HashMap<String, FileId>,
     files: Files<String>,
-    info_by_id: HashMap<FileId, Lapper<u32, HoverInfo>>,
+    info_by_id: HashMap<FileId, Lapper<u32, Info>>,
     item_by_id: HashMap<FileId, Lapper<u32, Item>>,
 }
 

--- a/lang/query/src/view/spans.rs
+++ b/lang/query/src/view/spans.rs
@@ -1,7 +1,7 @@
 use codespan::{ByteIndex, Location, Span};
 use rust_lapper::Lapper;
 
-use super::info::{HoverInfo, Item};
+use super::info::{Info, Item};
 use super::DatabaseView;
 
 impl<'a> DatabaseView<'a> {
@@ -23,11 +23,11 @@ impl<'a> DatabaseView<'a> {
         Some((start, end))
     }
 
-    pub fn hoverinfo_at_index(&self, idx: ByteIndex) -> Option<HoverInfo> {
+    pub fn hoverinfo_at_index(&self, idx: ByteIndex) -> Option<Info> {
         self.hoverinfo_at_span(Span::new(idx, ByteIndex(u32::from(idx) + 1)))
     }
 
-    pub fn hoverinfo_at_span(&self, span: Span) -> Option<HoverInfo> {
+    pub fn hoverinfo_at_span(&self, span: Span) -> Option<Info> {
         let lapper = self.infos();
         let intervals = lapper.find(span.start().into(), span.end().into());
         let smallest_interval =
@@ -43,7 +43,7 @@ impl<'a> DatabaseView<'a> {
         largest_interval.map(|interval| interval.val.clone())
     }
 
-    pub fn infos(&self) -> &Lapper<u32, HoverInfo> {
+    pub fn infos(&self) -> &Lapper<u32, Info> {
         &self.database.info_by_id[&self.file_id]
     }
 

--- a/lang/query/src/view/spans.rs
+++ b/lang/query/src/view/spans.rs
@@ -31,7 +31,7 @@ impl<'a> DatabaseView<'a> {
         let lapper = self.infos();
         let intervals = lapper.find(span.start().into(), span.end().into());
         let smallest_interval =
-            intervals.min_by(|i1, i2| (i1.stop - i1.start).cmp(&(i2.stop - i1.start)));
+            intervals.min_by(|i1, i2| (i1.stop - i1.start).cmp(&(i2.stop - i2.start)));
         smallest_interval.map(|interval| interval.val.clone())
     }
 

--- a/lang/query/src/view_mut.rs
+++ b/lang/query/src/view_mut.rs
@@ -38,7 +38,7 @@ impl<'a> DatabaseViewMut<'a> {
         self.database.item_by_id.insert(self.file_id, Lapper::new(vec![]));
     }
 
-    pub fn set(&mut self, info_index: Lapper<u32, HoverInfo>, item_index: Lapper<u32, Item>) {
+    pub fn set(&mut self, info_index: Lapper<u32, Info>, item_index: Lapper<u32, Item>) {
         self.database.info_by_id.insert(self.file_id, info_index);
         self.database.item_by_id.insert(self.file_id, item_index);
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -97,8 +97,8 @@ impl ToHoverContent for InfoContent {
 
 impl ToHoverContent for VariableInfo {
     fn to_hover_content(self) -> HoverContents {
-        let VariableInfo { typ } = self;
-        let header = MarkedString::String("Bound variable".to_owned());
+        let VariableInfo { typ, name } = self;
+        let header = MarkedString::String(format!("Bound variable: `{}`", name));
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])
     }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -186,31 +186,60 @@ impl ToHoverContent for HoleInfo {
 //
 //
 
+fn add_doc_comment(builder: &mut Vec<MarkedString>, doc: Option<Vec<String>>) {
+    if let Some(doc) = doc {
+        builder.push(MarkedString::String("---".to_owned()));
+        for d in doc {
+            builder.push(MarkedString::String(d))
+        }
+    }
+}
+
 impl ToHoverContent for DataInfo {
     fn to_hover_content(self) -> HoverContents {
-        let header = MarkedString::String("Data type declaration".to_owned());
-        HoverContents::Scalar(header)
+        let DataInfo { name, doc, params } = self;
+        let mut content: Vec<MarkedString> = Vec::new();
+        content.push(MarkedString::String(format!("Data declaration: `{name}`")));
+        add_doc_comment(&mut content, doc);
+        if !params.is_empty() {
+            content.push(MarkedString::String("---".to_owned()).to_owned());
+            content.push(MarkedString::String(format!("Parameters: `{}`", params)))
+        }
+        HoverContents::Array(content)
     }
 }
 
 impl ToHoverContent for CtorInfo {
     fn to_hover_content(self) -> HoverContents {
-        let header = MarkedString::String("Constructor".to_owned());
-        HoverContents::Scalar(header)
+        let CtorInfo { name, doc } = self;
+        let mut content: Vec<MarkedString> = Vec::new();
+        content.push(MarkedString::String(format!("Constructor: `{}`", name)));
+        add_doc_comment(&mut content, doc);
+        HoverContents::Array(content)
     }
 }
 
 impl ToHoverContent for CodataInfo {
     fn to_hover_content(self) -> HoverContents {
-        let header = MarkedString::String("Codata type declaration".to_owned());
-        HoverContents::Scalar(header)
+        let CodataInfo { name, doc, params } = self;
+        let mut content: Vec<MarkedString> = Vec::new();
+        content.push(MarkedString::String(format!("Codata declaration: `{}`", name)));
+        add_doc_comment(&mut content, doc);
+        if !params.is_empty() {
+            content.push(MarkedString::String("---".to_owned()).to_owned());
+            content.push(MarkedString::String(format!("Parameters: `{}`", params)))
+        }
+        HoverContents::Array(content)
     }
 }
 
 impl ToHoverContent for DtorInfo {
     fn to_hover_content(self) -> HoverContents {
-        let header = MarkedString::String("Destructor".to_owned());
-        HoverContents::Scalar(header)
+        let DtorInfo { name, doc } = self;
+        let mut content: Vec<MarkedString> = Vec::new();
+        content.push(MarkedString::String(format!("Destructor: `{}`", name)));
+        add_doc_comment(&mut content, doc);
+        HoverContents::Array(content)
     }
 }
 

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -106,7 +106,8 @@ impl ToHoverContent for VariableInfo {
 
 impl ToHoverContent for TypeCtorInfo {
     fn to_hover_content(self) -> HoverContents {
-        let header = MarkedString::String("Type constructor".to_owned());
+        let TypeCtorInfo { name } = self;
+        let header = MarkedString::String(format!("Type constructor: `{}`", name));
         HoverContents::Array(vec![header])
     }
 }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -81,7 +81,9 @@ impl ToHoverContent for InfoContent {
             InfoContent::HoleInfo(i) => i.to_hover_content(),
             InfoContent::AnnoInfo(i) => i.to_hover_content(),
             InfoContent::DataInfo(i) => i.to_hover_content(),
+            InfoContent::CtorInfo(i) => i.to_hover_content(),
             InfoContent::CodataInfo(i) => i.to_hover_content(),
+            InfoContent::DtorInfo(i) => i.to_hover_content(),
             InfoContent::DefInfo(i) => i.to_hover_content(),
             InfoContent::CodefInfo(i) => i.to_hover_content(),
             InfoContent::LetInfo(i) => i.to_hover_content(),
@@ -191,9 +193,23 @@ impl ToHoverContent for DataInfo {
     }
 }
 
+impl ToHoverContent for CtorInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Constructor".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
 impl ToHoverContent for CodataInfo {
     fn to_hover_content(self) -> HoverContents {
         let header = MarkedString::String("Codata type declaration".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for DtorInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Destructor".to_owned());
         HoverContents::Scalar(header)
     }
 }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -27,7 +27,7 @@ pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Opti
     Ok(res)
 }
 
-fn info_to_hover(index: &DatabaseView, info: HoverInfo) -> Hover {
+fn info_to_hover(index: &DatabaseView, info: Info) -> Hover {
     let range = index.span_to_locations(info.span).map(ToLsp::to_lsp);
     let contents = info.content.to_hover_content();
     Hover { contents, range }
@@ -68,19 +68,30 @@ trait ToHoverContent {
     fn to_hover_content(self) -> HoverContents;
 }
 
-impl ToHoverContent for HoverInfoContent {
+impl ToHoverContent for InfoContent {
     fn to_hover_content(self) -> HoverContents {
         match self {
-            HoverInfoContent::VariableInfo(i) => i.to_hover_content(),
-            HoverInfoContent::TypeCtorInfo(i) => i.to_hover_content(),
-            HoverInfoContent::CallInfo(i) => i.to_hover_content(),
-            HoverInfoContent::DotCallInfo(i) => i.to_hover_content(),
-            HoverInfoContent::TypeUnivInfo(i) => i.to_hover_content(),
-            HoverInfoContent::HoleInfo(i) => i.to_hover_content(),
-            HoverInfoContent::AnnoInfo(i) => i.to_hover_content(),
+            InfoContent::VariableInfo(i) => i.to_hover_content(),
+            InfoContent::TypeCtorInfo(i) => i.to_hover_content(),
+            InfoContent::CallInfo(i) => i.to_hover_content(),
+            InfoContent::DotCallInfo(i) => i.to_hover_content(),
+            InfoContent::TypeUnivInfo(i) => i.to_hover_content(),
+            InfoContent::LocalMatchInfo(i) => i.to_hover_content(),
+            InfoContent::LocalComatchInfo(i) => i.to_hover_content(),
+            InfoContent::HoleInfo(i) => i.to_hover_content(),
+            InfoContent::AnnoInfo(i) => i.to_hover_content(),
+            InfoContent::DataInfo(i) => i.to_hover_content(),
+            InfoContent::CodataInfo(i) => i.to_hover_content(),
+            InfoContent::DefInfo(i) => i.to_hover_content(),
+            InfoContent::CodefInfo(i) => i.to_hover_content(),
+            InfoContent::LetInfo(i) => i.to_hover_content(),
         }
     }
 }
+
+// Expressions
+//
+//
 
 impl ToHoverContent for VariableInfo {
     fn to_hover_content(self) -> HoverContents {
@@ -140,6 +151,20 @@ impl ToHoverContent for AnnoInfo {
     }
 }
 
+impl ToHoverContent for LocalMatchInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Local match".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for LocalComatchInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Local comatch".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
 impl ToHoverContent for HoleInfo {
     fn to_hover_content(self) -> HoverContents {
         let HoleInfo { goal, ctx } = self;
@@ -152,5 +177,44 @@ impl ToHoverContent for HoleInfo {
         } else {
             HoverContents::Scalar(string_to_language_string(goal))
         }
+    }
+}
+
+// Toplevel declarations
+//
+//
+
+impl ToHoverContent for DataInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Data type declaration".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for CodataInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Codata type declaration".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for DefInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Definition".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for CodefInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Codefinition".to_owned());
+        HoverContents::Scalar(header)
+    }
+}
+
+impl ToHoverContent for LetInfo {
+    fn to_hover_content(self) -> HoverContents {
+        let header = MarkedString::String("Let-binding".to_owned());
+        HoverContents::Scalar(header)
     }
 }

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -114,11 +114,11 @@ impl ToHoverContent for TypeCtorInfo {
 
 impl ToHoverContent for CallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let CallInfo { kind, typ } = self;
+        let CallInfo { kind, typ, name } = self;
         let header = match kind {
-            CallKind::Constructor => MarkedString::String("Constructor".to_owned()),
-            CallKind::Codefinition => MarkedString::String("Codefinition".to_owned()),
-            CallKind::LetBound => MarkedString::String("Let-bound definition".to_owned()),
+            CallKind::Constructor => MarkedString::String(format!("Constructor: `{}`", name)),
+            CallKind::Codefinition => MarkedString::String(format!("Codefinition: `{}`", name)),
+            CallKind::LetBound => MarkedString::String(format!("Let-bound definition: `{}`", name)),
         };
 
         let typ = string_to_language_string(typ);

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -128,10 +128,10 @@ impl ToHoverContent for CallInfo {
 
 impl ToHoverContent for DotCallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let DotCallInfo { kind, typ } = self;
+        let DotCallInfo { kind, name, typ } = self;
         let header = match kind {
-            DotCallKind::Destructor => MarkedString::String("Destructor".to_owned()),
-            DotCallKind::Definition => MarkedString::String("Definition".to_owned()),
+            DotCallKind::Destructor => MarkedString::String(format!("Destructor: `{}`", name)),
+            DotCallKind::Definition => MarkedString::String(format!("Definition: `{}`", name)),
         };
         let typ = string_to_language_string(typ);
         HoverContents::Array(vec![header, typ])

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -155,15 +155,19 @@ impl ToHoverContent for AnnoInfo {
 
 impl ToHoverContent for LocalMatchInfo {
     fn to_hover_content(self) -> HoverContents {
+        let LocalMatchInfo { typ } = self;
         let header = MarkedString::String("Local match".to_owned());
-        HoverContents::Scalar(header)
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
     }
 }
 
 impl ToHoverContent for LocalComatchInfo {
     fn to_hover_content(self) -> HoverContents {
+        let LocalComatchInfo { typ } = self;
         let header = MarkedString::String("Local comatch".to_owned());
-        HoverContents::Scalar(header)
+        let typ = string_to_language_string(typ);
+        HoverContents::Array(vec![header, typ])
     }
 }
 


### PR DESCRIPTION
Fixes #64

Allows to hover over all kinds of syntax nodes, and displays basic information about that specific syntax node. Should be extended with more info in the future, of course.