### PR TITLE
Use a fork of codespan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,20 +425,10 @@ checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 [[package]]
 name = "codespan"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
+source = "git+https://github.com/polarity-lang/codespan.git?rev=542320ab177fd38fff3a398a97b3f0352e065149#542320ab177fd38fff3a398a97b3f0352e065149"
 dependencies = [
- "codespan-reporting",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
+ "lsp-types 0.91.1",
+ "url",
 ]
 
 [[package]]
@@ -1226,13 +1216,26 @@ version = "0.1.0"
 dependencies = [
  "async-lock",
  "codespan",
- "lsp-types",
+ "lsp-types 0.93.2",
  "miette",
  "miette_util",
  "printer",
  "query",
  "syntax",
  "tower-lsp",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+dependencies = [
+ "bitflags",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
 ]
 
 [[package]]
@@ -2459,7 +2462,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "lsp-types",
+ "lsp-types 0.93.2",
  "memchr",
  "serde",
  "serde_json",

--- a/lang/elaborator/Cargo.toml
+++ b/lang/elaborator/Cargo.toml
@@ -2,13 +2,12 @@
 name = "elaborator"
 version = "0.1.0"
 edition = "2021"
-
 [dependencies]
 # fancy error messages
 miette = "5"
 thiserror = "1"
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # ignoring fields when deriving traits (e.g. Eq, Hash)
 derivative = "2"
 pretty = { version = "0.11", features = ["termcolor"] }

--- a/lang/lifting/Cargo.toml
+++ b/lang/lifting/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # ignoring fields when deriving traits (e.g. Eq, Hash)
 derivative = "2"
 # workspace members

--- a/lang/lowering/Cargo.toml
+++ b/lang/lowering/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # fancy error messages
 miette = "5"
 thiserror = "1"

--- a/lang/parser/Cargo.toml
+++ b/lang/parser/Cargo.toml
@@ -10,7 +10,7 @@ lalrpop-util = "0.20"
 # url (for file locations)
 url = "2.5.0"
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # fancy error messages
 miette = "5"
 thiserror = "1"

--- a/lang/query/Cargo.toml
+++ b/lang/query/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # url (for file locations)
 url = "2.5.0"
 # source code spans
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # index of source code intervals
 rust-lapper = "1"
 # text rope

--- a/lang/renaming/Cargo.toml
+++ b/lang/renaming/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # workspace members
 syntax = { path = "../syntax" }

--- a/lang/syntax/Cargo.toml
+++ b/lang/syntax/Cargo.toml
@@ -10,7 +10,7 @@ thiserror = "1"
 # url (for file locations)
 url = "2.5.0"
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # ignoring fields when deriving traits (e.g. Eq, Hash)
 derivative = "2"
 # big integers

--- a/lang/xfunc/Cargo.toml
+++ b/lang/xfunc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # source code locations
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # fancy error messages
 miette = "5"
 thiserror = "1"

--- a/util/lsp/Cargo.toml
+++ b/util/lsp/Cargo.toml
@@ -10,7 +10,7 @@ tower-lsp = { version = "0.17", default-features = false, features = ["runtime-a
 # asynchronous locks
 async-lock = "2"
 # source code spans
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}
 # fancy error messages
 miette = "5"
 # workspace members

--- a/util/miette_util/Cargo.toml
+++ b/util/miette_util/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 miette = "5"
-codespan = "0.11"
+codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149"}


### PR DESCRIPTION
The codespan library made the unfortunate decision to practice information hiding. We therefore have to fork the library in order to access the internal structure of `File`.

I could also move the fork to the polarity repo , if you prefer that @timsueberkrueb 