### PR TITLE
Fix #207

### DIFF
--- a/lang/query/src/view/rt.rs
+++ b/lang/query/src/view/rt.rs
@@ -19,7 +19,7 @@ impl<'a> DatabaseView<'a> {
         // TODO: The database should use Urls as keys everywhere
         // instead of FileId.
         let filename = self.filename();
-        let uri = Url::from_file_path(filename).map_err(|_| parser::ParseError::User {
+        let uri = Url::parse(filename).map_err(|_| parser::ParseError::User {
             error: format!("Cannot convert filepath {:?} to url", filename),
         })?;
         Ok(uri)


### PR DESCRIPTION
Fixes #207

When the LSP server adds a file to the database it converts the uri of the file to a string and passes that. We then lose the information that the String is an Uri, so I have to use `Url::parse` instead of `Url::from_filepath` in order to obtain the Url again. This is only a quickfix, the proper solution is to not loose the information that we have a valid Uri.