### PR TITLE
Fix crash of LSP server and add info logs

### DIFF
--- a/lang/query/src/view_mut.rs
+++ b/lang/query/src/view_mut.rs
@@ -10,6 +10,7 @@ pub struct DatabaseViewMut<'a> {
 
 impl<'a> DatabaseViewMut<'a> {
     pub fn load(&mut self) -> Result<(), Error> {
+        self.reset();
         let prg = self.query_ref().tst()?;
         let (info_lapper, item_lapper) = collect_info(&prg);
         self.set(info_lapper, item_lapper);

--- a/util/lsp/src/codeactions.rs
+++ b/util/lsp/src/codeactions.rs
@@ -14,6 +14,11 @@ pub async fn code_action(
     let text_document = params.text_document;
     let range = params.range;
 
+    server
+        .client
+        .log_message(MessageType::INFO, format!("Code action request: {}", text_document.uri))
+        .await;
+
     let db = server.database.read().await;
     let index = db.get(text_document.uri.as_str()).unwrap();
     let span_start = index.location_to_index(range.start.from_lsp());

--- a/util/lsp/src/format.rs
+++ b/util/lsp/src/format.rs
@@ -10,6 +10,12 @@ pub async fn formatting(
     params: DocumentFormattingParams,
 ) -> Result<Option<Vec<TextEdit>>> {
     let text_document = params.text_document;
+
+    server
+        .client
+        .log_message(MessageType::INFO, format!("Formatting request: {}", text_document.uri))
+        .await;
+
     let db = server.database.read().await;
     let index = db.get(text_document.uri.as_str()).unwrap();
     let prg = match index.ust() {

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -12,6 +12,12 @@ use super::server::*;
 pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
     let pos_params = params.text_document_position_params;
     let text_document = pos_params.text_document;
+
+    server
+        .client
+        .log_message(MessageType::INFO, format!("Hover request: {}", text_document.uri))
+        .await;
+
     let pos = pos_params.position;
     let db = server.database.read().await;
     let index = db.get(text_document.uri.as_str()).unwrap();

--- a/util/lsp/src/server.rs
+++ b/util/lsp/src/server.rs
@@ -30,12 +30,18 @@ impl LanguageServer for Server {
     }
 
     async fn shutdown(&self) -> jsonrpc::Result<()> {
+        self.client.log_message(MessageType::INFO, "server shutdown!").await;
         Ok(())
     }
 
     async fn did_open(&self, params: lsp::DidOpenTextDocumentParams) {
         let text_document = params.text_document;
         let mut db = self.database.write().await;
+
+        self.client
+            .log_message(MessageType::INFO, format!("Opened file: {}", text_document.uri))
+            .await;
+
         let file = File { name: text_document.uri.to_string(), source: text_document.text };
         let mut view = db.add(file);
 
@@ -47,6 +53,11 @@ impl LanguageServer for Server {
     async fn did_change(&self, params: lsp::DidChangeTextDocumentParams) {
         let text_document = params.text_document;
         let mut content_changes = params.content_changes;
+
+        self.client
+            .log_message(MessageType::INFO, format!("Changed file: {}", text_document.uri))
+            .await;
+
         let mut db = self.database.write().await;
         let text = content_changes.drain(0..).next().unwrap().text;
 


### PR DESCRIPTION
It turns out the `reset()` that we decided to remove was necessary after all 😅 
The problem is that if the file doesn't typecheck, then the lapper is never initialized, and then when we process the hover or codeaction request we try to look up something in a hashmap which doesn't exist.