### PR TITLE
Use Url as index into Hashmaps in query crate

### DIFF
--- a/lang/query/src/view/mod.rs
+++ b/lang/query/src/view/mod.rs
@@ -1,4 +1,4 @@
-use codespan::FileId;
+use url::Url;
 
 mod edit;
 mod lift;
@@ -13,6 +13,6 @@ use crate::*;
 
 /// View on a file in the database
 pub struct DatabaseView<'a> {
-    pub(crate) file_id: FileId,
+    pub(crate) url: Url,
     pub(crate) database: &'a Database,
 }

--- a/lang/query/src/view/spans.rs
+++ b/lang/query/src/view/spans.rs
@@ -6,15 +6,17 @@ use super::DatabaseView;
 
 impl<'a> DatabaseView<'a> {
     pub fn location_to_index(&self, location: Location) -> Option<ByteIndex> {
-        let DatabaseView { file_id, database } = self;
-        let line_span = database.files.line_span(*file_id, location.line).ok()?;
-        let index = line_span.start().to_usize() + location.column.to_usize();
+        let DatabaseView { url, database } = self;
+        let file = database.files.get(url).unwrap();
+        let line_span = file.line_span(location.line).ok()?;
+        let index: usize = line_span.start().to_usize() + location.column.to_usize();
         Some((index as u32).into())
     }
 
     pub fn index_to_location(&self, idx: ByteIndex) -> Option<Location> {
-        let DatabaseView { file_id, database } = self;
-        database.files.location(*file_id, idx).ok()
+        let DatabaseView { url, database } = self;
+        let file = database.files.get(url).unwrap();
+        file.location(idx).ok()
     }
 
     pub fn span_to_locations(&self, span: Span) -> Option<(Location, Location)> {
@@ -44,10 +46,10 @@ impl<'a> DatabaseView<'a> {
     }
 
     pub fn infos(&self) -> &Lapper<u32, Info> {
-        &self.database.info_by_id[&self.file_id]
+        &self.database.info_by_id[&self.url]
     }
 
     pub fn items(&self) -> &Lapper<u32, Item> {
-        &self.database.item_by_id[&self.file_id]
+        &self.database.item_by_id[&self.url]
     }
 }

--- a/util/lsp/src/codeactions.rs
+++ b/util/lsp/src/codeactions.rs
@@ -20,7 +20,7 @@ pub async fn code_action(
         .await;
 
     let db = server.database.read().await;
-    let index = db.get(text_document.uri.as_str()).unwrap();
+    let index = db.get(&text_document.uri).unwrap();
     let span_start = index.location_to_index(range.start.from_lsp());
     let span_end = index.location_to_index(range.end.from_lsp());
     let span = span_start.and_then(|start| span_end.map(|end| codespan::Span::new(start, end)));

--- a/util/lsp/src/format.rs
+++ b/util/lsp/src/format.rs
@@ -17,7 +17,7 @@ pub async fn formatting(
         .await;
 
     let db = server.database.read().await;
-    let index = db.get(text_document.uri.as_str()).unwrap();
+    let index = db.get(&text_document.uri).unwrap();
     let prg = match index.ust() {
         Ok(prg) => prg,
         Err(_) => return Ok(None),

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -20,7 +20,7 @@ pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Opti
 
     let pos = pos_params.position;
     let db = server.database.read().await;
-    let index = db.get(text_document.uri.as_str()).unwrap();
+    let index = db.get(&text_document.uri).unwrap();
     let info =
         index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
     let res = info.map(|info| info_to_hover(&index, info));

--- a/util/lsp/src/server.rs
+++ b/util/lsp/src/server.rs
@@ -42,7 +42,7 @@ impl LanguageServer for Server {
             .log_message(MessageType::INFO, format!("Opened file: {}", text_document.uri))
             .await;
 
-        let file = File { name: text_document.uri.to_string(), source: text_document.text };
+        let file = File { name: text_document.uri.clone(), source: text_document.text };
         let mut view = db.add(file);
 
         let res = view.load();
@@ -61,7 +61,7 @@ impl LanguageServer for Server {
         let mut db = self.database.write().await;
         let text = content_changes.drain(0..).next().unwrap().text;
 
-        let mut view = db.get_mut(text_document.uri.as_str()).unwrap();
+        let mut view = db.get_mut(&text_document.uri).unwrap();
 
         let res = view.update(text);
         let diags = view.query().diagnostics(res);


### PR DESCRIPTION
We no longer depend on the `FileId` type from the codespan library but use the `Url` type everywhere to index the Hashmaps of the query crate. This is simpler, because we always communicate using the `Url` type with the LSP server.