### PR TITLE
Jump to definition

### DIFF
--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -258,12 +258,12 @@ impl CollectInfo for TypCtor {
         let TypCtor { span, args, name } = self;
         if let Some(span) = span {
             let decl = collector.lookup_table.get(name);
-            let target_span = match decl {
+            let definition_site = match decl {
                 Some(Decl::Data(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 Some(Decl::Codata(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 _ => None,
             };
-            let info = TypeCtorInfo { name: name.clone(), target_span };
+            let info = TypeCtorInfo { name: name.clone(), definition_site };
             collector.add_info(*span, info)
         }
         args.collect_info(collector)
@@ -275,7 +275,7 @@ impl CollectInfo for Call {
         let Call { span, kind, args, inferred_type, name } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
             let decl = collector.lookup_table.get(name);
-            let target_span = match decl {
+            let definition_site = match decl {
                 Some(Decl::Codef(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 Some(Decl::Ctor(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 Some(Decl::Let(d)) => d.span.map(|span| (collector.uri.clone(), span)),
@@ -285,7 +285,7 @@ impl CollectInfo for Call {
                 kind: *kind,
                 typ: typ.print_to_string(None),
                 name: name.clone(),
-                target_span,
+                definition_site,
             };
             collector.add_info(*span, info)
         }
@@ -298,7 +298,7 @@ impl CollectInfo for DotCall {
         let DotCall { span, kind, exp, args, inferred_type, name } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
             let decl = collector.lookup_table.get(name);
-            let target_span = match decl {
+            let definition_site = match decl {
                 Some(Decl::Def(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 Some(Decl::Dtor(d)) => d.span.map(|span| (collector.uri.clone(), span)),
                 _ => None,
@@ -307,7 +307,7 @@ impl CollectInfo for DotCall {
                 kind: *kind,
                 name: name.clone(),
                 typ: typ.print_to_string(None),
-                target_span,
+                definition_site,
             };
             collector.add_info(*span, info)
         }

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -160,7 +160,7 @@ impl From<VariableInfo> for InfoContent {
 pub struct TypeCtorInfo {
     /// The span where the type constructor was defined.
     /// This is used for the jump-to-definition feature.
-    pub target_span: Option<(Url, Span)>,
+    pub definition_site: Option<(Url, Span)>,
     pub name: String,
 }
 
@@ -175,7 +175,7 @@ impl From<TypeCtorInfo> for InfoContent {
 pub struct CallInfo {
     /// The span where the call was defined.
     /// This is used for the jump-to-definition feature.
-    pub target_span: Option<(Url, Span)>,
+    pub definition_site: Option<(Url, Span)>,
     pub kind: CallKind,
     pub name: String,
     pub typ: String,
@@ -192,7 +192,7 @@ impl From<CallInfo> for InfoContent {
 pub struct DotCallInfo {
     /// The span where the dotcall was defined.
     /// This is used for the jump-to-definition feature.
-    pub target_span: Option<(Url, Span)>,
+    pub definition_site: Option<(Url, Span)>,
     pub kind: DotCallKind,
     pub name: String,
     pub typ: String,

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -6,6 +6,7 @@ use syntax::{
     ast::DotCallKind,
     ctx::values::{Binder as TypeCtxBinder, TypeCtx},
 };
+use url::Url;
 
 // Info
 //
@@ -157,6 +158,9 @@ impl From<VariableInfo> for InfoContent {
 /// Information for type constructors
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeCtorInfo {
+    /// The span where the type constructor was defined.
+    /// This is used for the jump-to-definition feature.
+    pub target_span: Option<(Url, Span)>,
     pub name: String,
 }
 

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -173,6 +173,9 @@ impl From<TypeCtorInfo> for InfoContent {
 /// Information for calls (constructors, codefinitions or lets)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallInfo {
+    /// The span where the call was defined.
+    /// This is used for the jump-to-definition feature.
+    pub target_span: Option<(Url, Span)>,
     pub kind: CallKind,
     pub name: String,
     pub typ: String,
@@ -187,6 +190,9 @@ impl From<CallInfo> for InfoContent {
 /// Information for dotcalls (destructors or definitions)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DotCallInfo {
+    /// The span where the dotcall was defined.
+    /// This is used for the jump-to-definition feature.
+    pub target_span: Option<(Url, Span)>,
     pub kind: DotCallKind,
     pub name: String,
     pub typ: String,

--- a/util/lsp/src/capabilities.rs
+++ b/util/lsp/src/capabilities.rs
@@ -16,11 +16,14 @@ pub fn capabilities() -> lsp::ServerCapabilities {
 
     let document_formatting_provider = Some(lsp::OneOf::Left(true));
 
+    let definition_provider = Some(lsp::OneOf::Left(true));
+
     lsp::ServerCapabilities {
         text_document_sync,
         hover_provider,
         code_action_provider,
         document_formatting_provider,
+        definition_provider,
         ..Default::default()
     }
 }

--- a/util/lsp/src/gotodefinition.rs
+++ b/util/lsp/src/gotodefinition.rs
@@ -17,133 +17,137 @@ pub async fn goto_definition(
     let index = db.get(&text_document.uri).unwrap();
     let info =
         index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
-    let res = info.and_then(|info| info_to_jump(&index, text_document.uri, info));
+    let res = info.and_then(|info| info_to_jump(&index, info));
     Ok(res)
 }
 
-fn info_to_jump(index: &DatabaseView, uri: Url, info: Info) -> Option<GotoDefinitionResponse> {
-    info.content.to_jump_content(index, uri).map(GotoDefinitionResponse::Scalar)
+fn info_to_jump(index: &DatabaseView, info: Info) -> Option<GotoDefinitionResponse> {
+    info.content.to_jump_content(index).map(GotoDefinitionResponse::Scalar)
 }
 
 trait ToJumpContent {
-    fn to_jump_content(&self, index: &DatabaseView, uri: Url) -> Option<Location>;
+    fn to_jump_content(&self, index: &DatabaseView) -> Option<Location>;
 }
 
 impl ToJumpContent for InfoContent {
-    fn to_jump_content(&self, index: &DatabaseView, uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, index: &DatabaseView) -> Option<Location> {
         match self {
-            InfoContent::VariableInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::TypeCtorInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::CallInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::DotCallInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::TypeUnivInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::HoleInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::AnnoInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::LocalComatchInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::LocalMatchInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::DefInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::CodefInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::LetInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::DataInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::CodataInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::CtorInfo(i) => i.to_jump_content(index, uri),
-            InfoContent::DtorInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::VariableInfo(i) => i.to_jump_content(index),
+            InfoContent::TypeCtorInfo(i) => i.to_jump_content(index),
+            InfoContent::CallInfo(i) => i.to_jump_content(index),
+            InfoContent::DotCallInfo(i) => i.to_jump_content(index),
+            InfoContent::TypeUnivInfo(i) => i.to_jump_content(index),
+            InfoContent::HoleInfo(i) => i.to_jump_content(index),
+            InfoContent::AnnoInfo(i) => i.to_jump_content(index),
+            InfoContent::LocalComatchInfo(i) => i.to_jump_content(index),
+            InfoContent::LocalMatchInfo(i) => i.to_jump_content(index),
+            InfoContent::DefInfo(i) => i.to_jump_content(index),
+            InfoContent::CodefInfo(i) => i.to_jump_content(index),
+            InfoContent::LetInfo(i) => i.to_jump_content(index),
+            InfoContent::DataInfo(i) => i.to_jump_content(index),
+            InfoContent::CodataInfo(i) => i.to_jump_content(index),
+            InfoContent::CtorInfo(i) => i.to_jump_content(index),
+            InfoContent::DtorInfo(i) => i.to_jump_content(index),
         }
     }
 }
 
 impl ToJumpContent for VariableInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for TypeCtorInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
-        None
+    fn to_jump_content(&self, index: &DatabaseView) -> Option<Location> {
+        let TypeCtorInfo { target_span, .. } = self;
+        target_span.as_ref().map(|span| {
+            let rng = index.span_to_locations(span.1).map(ToLsp::to_lsp);
+            Location { uri: span.0.clone(), range: rng.unwrap() }
+        })
     }
 }
 
 impl ToJumpContent for CallInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for DotCallInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for TypeUnivInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for HoleInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for AnnoInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for LocalMatchInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for LocalComatchInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for DefInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for CodefInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for LetInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for DataInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for CodataInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for CtorInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }
 
 impl ToJumpContent for DtorInfo {
-    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+    fn to_jump_content(&self, _index: &DatabaseView) -> Option<Location> {
         None
     }
 }

--- a/util/lsp/src/gotodefinition.rs
+++ b/util/lsp/src/gotodefinition.rs
@@ -1,0 +1,149 @@
+//! Implementation of the goto-definition functionality of the LSP server
+
+use tower_lsp::{jsonrpc, lsp_types::*};
+
+use super::conversion::*;
+use super::server::*;
+use query::*;
+
+pub async fn goto_definition(
+    server: &Server,
+    params: GotoDefinitionParams,
+) -> jsonrpc::Result<Option<GotoDefinitionResponse>> {
+    let pos_params = params.text_document_position_params;
+    let text_document = pos_params.text_document;
+    let pos = pos_params.position;
+    let db = server.database.read().await;
+    let index = db.get(&text_document.uri).unwrap();
+    let info =
+        index.location_to_index(pos.from_lsp()).and_then(|idx| index.hoverinfo_at_index(idx));
+    let res = info.and_then(|info| info_to_jump(&index, text_document.uri, info));
+    Ok(res)
+}
+
+fn info_to_jump(index: &DatabaseView, uri: Url, info: Info) -> Option<GotoDefinitionResponse> {
+    info.content.to_jump_content(index, uri).map(GotoDefinitionResponse::Scalar)
+}
+
+trait ToJumpContent {
+    fn to_jump_content(&self, index: &DatabaseView, uri: Url) -> Option<Location>;
+}
+
+impl ToJumpContent for InfoContent {
+    fn to_jump_content(&self, index: &DatabaseView, uri: Url) -> Option<Location> {
+        match self {
+            InfoContent::VariableInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::TypeCtorInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::CallInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::DotCallInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::TypeUnivInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::HoleInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::AnnoInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::LocalComatchInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::LocalMatchInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::DefInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::CodefInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::LetInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::DataInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::CodataInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::CtorInfo(i) => i.to_jump_content(index, uri),
+            InfoContent::DtorInfo(i) => i.to_jump_content(index, uri),
+        }
+    }
+}
+
+impl ToJumpContent for VariableInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for TypeCtorInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for CallInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for DotCallInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for TypeUnivInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for HoleInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for AnnoInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for LocalMatchInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for LocalComatchInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for DefInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for CodefInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for LetInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for DataInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for CodataInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for CtorInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}
+
+impl ToJumpContent for DtorInfo {
+    fn to_jump_content(&self, _index: &DatabaseView, _uri: Url) -> Option<Location> {
+        None
+    }
+}

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -114,7 +114,7 @@ impl ToHoverContent for TypeCtorInfo {
 
 impl ToHoverContent for CallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let CallInfo { kind, typ, name } = self;
+        let CallInfo { kind, typ, name, .. } = self;
         let header = match kind {
             CallKind::Constructor => MarkedString::String(format!("Constructor: `{}`", name)),
             CallKind::Codefinition => MarkedString::String(format!("Codefinition: `{}`", name)),
@@ -128,7 +128,7 @@ impl ToHoverContent for CallInfo {
 
 impl ToHoverContent for DotCallInfo {
     fn to_hover_content(self) -> HoverContents {
-        let DotCallInfo { kind, name, typ } = self;
+        let DotCallInfo { kind, name, typ, .. } = self;
         let header = match kind {
             DotCallKind::Destructor => MarkedString::String(format!("Destructor: `{}`", name)),
             DotCallKind::Definition => MarkedString::String(format!("Definition: `{}`", name)),

--- a/util/lsp/src/hover.rs
+++ b/util/lsp/src/hover.rs
@@ -106,7 +106,7 @@ impl ToHoverContent for VariableInfo {
 
 impl ToHoverContent for TypeCtorInfo {
     fn to_hover_content(self) -> HoverContents {
-        let TypeCtorInfo { name } = self;
+        let TypeCtorInfo { name, .. } = self;
         let header = MarkedString::String(format!("Type constructor: `{}`", name));
         HoverContents::Array(vec![header])
     }

--- a/util/lsp/src/lib.rs
+++ b/util/lsp/src/lib.rs
@@ -3,6 +3,7 @@ mod codeactions;
 mod conversion;
 mod diagnostics;
 mod format;
+mod gotodefinition;
 mod hover;
 mod server;
 

--- a/util/lsp/src/server.rs
+++ b/util/lsp/src/server.rs
@@ -68,6 +68,13 @@ impl LanguageServer for Server {
         self.send_diagnostics(text_document.uri, diags).await;
     }
 
+    async fn goto_definition(
+        &self,
+        params: GotoDefinitionParams,
+    ) -> jsonrpc::Result<Option<GotoDefinitionResponse>> {
+        super::gotodefinition::goto_definition(self, params).await
+    }
+
     async fn hover(&self, params: HoverParams) -> jsonrpc::Result<Option<Hover>> {
         super::hover::hover(self, params).await
     }


### PR DESCRIPTION
Implements the jump-to-definition feature for `TypCtor`, `Call` and `DotCall` in the program.
The ability to have access to the decl hashmap in the collector will also enable the feature to show the docstrings on hover, but that is for another PR :)