### PR TITLE
Reduce duplication in definition of contexts

### DIFF
--- a/lang/syntax/src/ctx/context.rs
+++ b/lang/syntax/src/ctx/context.rs
@@ -1,0 +1,108 @@
+//! Variable context
+//!
+//! Tracks locally bound variables
+
+use crate::{
+    ast::{Idx, Leveled, Lvl, Shift, ShiftRange, Var},
+    ctx::{Context, LevelCtx},
+};
+
+use super::ContextElem;
+
+#[derive(Debug, Clone)]
+pub struct GenericContext<A> {
+    pub bound: Vec<Vec<A>>,
+}
+
+impl<A: Shift> GenericContext<A> {
+    pub fn empty() -> Self {
+        Self { bound: vec![] }
+    }
+
+    pub fn levels(&self) -> LevelCtx {
+        let bound: Vec<_> = self.bound.iter().map(|inner| inner.len()).collect();
+        LevelCtx::from(bound)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &[A]> {
+        self.bound.iter().map(|inner| &inner[..])
+    }
+
+    fn shift<R: ShiftRange>(&mut self, range: R, by: (isize, isize)) {
+        for lvl in 0..self.bound.len() {
+            self.shift_at_lvl(range.clone(), lvl, by)
+        }
+    }
+
+    fn shift_at_lvl<R: ShiftRange>(&mut self, range: R, lvl: usize, by: (isize, isize)) {
+        for i in 0..self.bound[lvl].len() {
+            self.bound[lvl][i] = self.bound[lvl][i].shift_in_range(range.clone(), by);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.bound.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bound.is_empty()
+    }
+}
+
+impl<A: Clone + Shift> Context for GenericContext<A> {
+    type ElemIn = A;
+
+    type ElemOut = A;
+
+    type Var = Var;
+
+    fn lookup<V: Into<Self::Var>>(&self, idx: V) -> Self::ElemOut {
+        let lvl = self.var_to_lvl(idx.into());
+        self.bound
+            .get(lvl.fst)
+            .and_then(|ctx| ctx.get(lvl.snd))
+            .unwrap_or_else(|| panic!("Unbound variable {lvl}"))
+            .clone()
+    }
+
+    fn push_telescope(&mut self) {
+        self.shift(0.., (1, 0));
+        self.bound.push(vec![]);
+    }
+
+    fn pop_telescope(&mut self) {
+        self.bound.pop().unwrap();
+        self.shift(0.., (-1, 0));
+    }
+
+    fn push_binder(&mut self, elem: Self::ElemIn) {
+        self.bound.last_mut().expect("Cannot push without calling level_inc_fst first").push(elem);
+        self.shift_at_lvl(0..1, self.bound.len() - 1, (0, 1));
+    }
+
+    fn pop_binder(&mut self, _elem: Self::ElemIn) {
+        let err = "Cannot pop from empty context";
+        self.bound.last_mut().expect(err).pop().expect(err);
+        self.shift_at_lvl(0..1, self.bound.len() - 1, (0, -1));
+    }
+}
+
+impl<A: Clone + Shift> ContextElem<GenericContext<A>> for &A {
+    fn as_element(&self) -> <GenericContext<A> as Context>::ElemIn {
+        (*self).clone()
+    }
+}
+
+impl<A> Leveled for GenericContext<A> {
+    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
+        let fst = self.bound.len() - 1 - idx.fst;
+        let snd = self.bound[fst].len() - 1 - idx.snd;
+        Lvl { fst, snd }
+    }
+
+    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
+        let fst = self.bound.len() - 1 - lvl.fst;
+        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
+        Idx { fst, snd }
+    }
+}

--- a/lang/syntax/src/ctx/levels.rs
+++ b/lang/syntax/src/ctx/levels.rs
@@ -1,14 +1,3 @@
-use std::fmt;
-
-// use data::string::comma_separated;
-fn comma_separated<I: IntoIterator<Item = String>>(iter: I) -> String {
-    separated(", ", iter)
-}
-fn separated<I: IntoIterator<Item = String>>(s: &str, iter: I) -> String {
-    let vec: Vec<_> = iter.into_iter().collect();
-    vec.join(s)
-}
-
 use crate::ast::*;
 
 use super::def::*;
@@ -99,11 +88,5 @@ impl Leveled for LevelCtx {
         let fst = self.bound.len() - 1 - lvl.fst;
         let snd = self.bound[lvl.fst] - 1 - lvl.snd;
         Idx { fst, snd }
-    }
-}
-
-impl fmt::Display for LevelCtx {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}]", comma_separated(self.bound.iter().map(ToString::to_string)))
     }
 }

--- a/lang/syntax/src/ctx/mod.rs
+++ b/lang/syntax/src/ctx/mod.rs
@@ -1,5 +1,7 @@
+pub mod context;
 mod def;
 mod levels;
+
 pub mod map_idx;
 pub mod values;
 

--- a/lang/syntax/src/ctx/mod.rs
+++ b/lang/syntax/src/ctx/mod.rs
@@ -1,7 +1,6 @@
 pub mod context;
 mod def;
 mod levels;
-
 pub mod map_idx;
 pub mod values;
 

--- a/lang/syntax/src/ctx/values.rs
+++ b/lang/syntax/src/ctx/values.rs
@@ -6,109 +6,12 @@ use std::rc::Rc;
 
 use crate::ast::traits::Shift;
 use crate::ast::*;
-use crate::ctx::{Context, LevelCtx};
 
-use super::ContextElem;
+use super::context::GenericContext;
 
-#[derive(Debug, Clone)]
-pub struct TypeCtx {
-    pub bound: Vec<Vec<Binder>>,
-}
+pub type TypeCtx = GenericContext<Binder>;
 
 impl TypeCtx {
-    pub fn empty() -> Self {
-        Self { bound: vec![] }
-    }
-
-    pub fn levels(&self) -> LevelCtx {
-        let bound: Vec<_> = self.bound.iter().map(|inner| inner.len()).collect();
-        LevelCtx::from(bound)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &[Binder]> {
-        self.bound.iter().map(|inner| &inner[..])
-    }
-
-    fn shift<R: ShiftRange>(&mut self, range: R, by: (isize, isize)) {
-        for lvl in 0..self.bound.len() {
-            self.shift_at_lvl(range.clone(), lvl, by)
-        }
-    }
-
-    fn shift_at_lvl<R: ShiftRange>(&mut self, range: R, lvl: usize, by: (isize, isize)) {
-        for i in 0..self.bound[lvl].len() {
-            self.bound[lvl][i] = self.bound[lvl][i].shift_in_range(range.clone(), by);
-        }
-    }
-}
-
-impl Context for TypeCtx {
-    type ElemIn = Binder;
-
-    type ElemOut = Binder;
-
-    type Var = Var;
-
-    fn lookup<V: Into<Self::Var>>(&self, idx: V) -> Self::ElemOut {
-        let lvl = self.var_to_lvl(idx.into());
-        self.bound
-            .get(lvl.fst)
-            .and_then(|ctx| ctx.get(lvl.snd))
-            .unwrap_or_else(|| panic!("Unbound variable {lvl}"))
-            .clone()
-    }
-
-    fn push_telescope(&mut self) {
-        self.shift(0.., (1, 0));
-        self.bound.push(vec![]);
-    }
-
-    fn pop_telescope(&mut self) {
-        self.bound.pop().unwrap();
-        self.shift(0.., (-1, 0));
-    }
-
-    fn push_binder(&mut self, elem: Self::ElemIn) {
-        self.bound.last_mut().expect("Cannot push without calling level_inc_fst first").push(elem);
-        self.shift_at_lvl(0..1, self.bound.len() - 1, (0, 1));
-    }
-
-    fn pop_binder(&mut self, _elem: Self::ElemIn) {
-        let err = "Cannot pop from empty context";
-        self.bound.last_mut().expect(err).pop().expect(err);
-        self.shift_at_lvl(0..1, self.bound.len() - 1, (0, -1));
-    }
-}
-
-impl ContextElem<TypeCtx> for &Binder {
-    fn as_element(&self) -> <TypeCtx as Context>::ElemIn {
-        (*self).clone()
-    }
-}
-
-impl Leveled for TypeCtx {
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.bound.len() - 1 - idx.fst;
-        let snd = self.bound[fst].len() - 1 - idx.snd;
-        Lvl { fst, snd }
-    }
-
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.bound.len() - 1 - lvl.fst;
-        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
-        Idx { fst, snd }
-    }
-}
-
-impl TypeCtx {
-    pub fn len(&self) -> usize {
-        self.bound.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.bound.is_empty()
-    }
-
     pub fn map_failable<E, F>(&self, f: F) -> Result<Self, E>
     where
         F: Fn(&Rc<Exp>) -> Result<Rc<Exp>, E>,


### PR DESCRIPTION
Here is the basic idea:
```rust
pub struct GenericContext<A> { bound: Vec<Vec<A>> }
pub type TypeCtx = GenericContext<Binder>;
pub type LevelCtx = GenericContext<()>;
```

This allows to remove a lot of duplication and inefficiencies, since we currently compute the LevelCtx from the TypeCtx because the latter doesn't implement `Leveled`. 