### PR TITLE
Fix 230

### DIFF
--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -64,6 +64,7 @@ impl<T: ReadBack> ReadBack for Option<T> {
 #[derivative(Eq, PartialEq, Hash)]
 pub enum Val {
     TypCtor(TypCtor),
+    // A call is only a value if it is a constructor or a codefinition.
     Call(Call),
     TypeUniv(TypeUniv),
     LocalComatch(LocalComatch),
@@ -317,6 +318,9 @@ pub enum Neu {
     DotCall(DotCall),
     LocalMatch(LocalMatch),
     Hole(Hole),
+    /// A call which corresponds to an opaque let-bound definition on the toplevel
+    /// cannot be inlined and must therefore block computation.
+    OpaqueCall(OpaqueCall),
 }
 
 impl Shift for Neu {
@@ -326,6 +330,7 @@ impl Shift for Neu {
             Neu::DotCall(e) => e.shift_in_range(range, by).into(),
             Neu::LocalMatch(e) => e.shift_in_range(range, by).into(),
             Neu::Hole(e) => e.shift_in_range(range, by).into(),
+            Neu::OpaqueCall(e) => e.shift_in_range(range, by).into(),
         }
     }
 }
@@ -337,6 +342,7 @@ impl<'a> Print<'a> for Neu {
             Neu::DotCall(e) => e.print(cfg, alloc),
             Neu::LocalMatch(e) => e.print(cfg, alloc),
             Neu::Hole(e) => e.print(cfg, alloc),
+            Neu::OpaqueCall(e) => e.print(cfg, alloc),
         }
     }
 }
@@ -356,6 +362,7 @@ impl ReadBack for Neu {
             Neu::DotCall(e) => e.read_back(prg)?.into(),
             Neu::LocalMatch(e) => e.read_back(prg)?.into(),
             Neu::Hole(e) => e.read_back(prg)?.into(),
+            Neu::OpaqueCall(e) => e.read_back(prg)?.into(),
         };
         Ok(res)
     }
@@ -679,6 +686,61 @@ impl ReadBack for Case {
             name: name.clone(),
             params: params.clone(),
             body: body.read_back(prg)?,
+        })
+    }
+}
+
+// OpaqueCall
+//
+//
+
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+pub struct OpaqueCall {
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    pub span: Option<Span>,
+    pub kind: ast::CallKind,
+    pub name: ast::Ident,
+    pub args: Args,
+}
+
+impl Shift for OpaqueCall {
+    fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
+        let OpaqueCall { span, kind, name, args } = self;
+        OpaqueCall {
+            span: *span,
+            kind: *kind,
+            name: name.clone(),
+            args: args.shift_in_range(range, by),
+        }
+    }
+}
+
+impl<'a> Print<'a> for OpaqueCall {
+    fn print(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
+        let OpaqueCall { span: _, kind: _, name, args } = self;
+        let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
+        alloc.ctor(name).append(psubst)
+    }
+}
+
+impl From<OpaqueCall> for Neu {
+    fn from(value: OpaqueCall) -> Self {
+        Neu::OpaqueCall(value)
+    }
+}
+
+impl ReadBack for OpaqueCall {
+    type Nf = ast::Call;
+
+    fn read_back(&self, prg: &ast::Module) -> Result<Self::Nf, TypeError> {
+        let OpaqueCall { span, kind, name, args } = self;
+        Ok(ast::Call {
+            span: *span,
+            kind: *kind,
+            name: name.clone(),
+            args: ast::Args { args: args.read_back(prg)? },
+            inferred_type: None,
         })
     }
 }

--- a/test/suites/success/Regression-230.pol
+++ b/test/suites/success/Regression-230.pol
@@ -1,0 +1,15 @@
+data Nat { Z, S(n: Nat) }
+
+def Nat.add(m: Nat): Nat {
+    Z => m,
+    S(n) => S(n.add(m))
+}
+
+let two: Nat {S(S(Z))}
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x)
+}
+
+-- The "two" is opaque, so shouldn't be normalized, but the expressions should be equal nonetheless.
+let foo : Eq(Nat, two.add(S(S(Z))), two.add(S(S(Z)))) { Refl(Nat, two.add(S(S(Z))))}

--- a/test/suites/success/Regression-230b.pol
+++ b/test/suites/success/Regression-230b.pol
@@ -1,0 +1,15 @@
+data Nat { Z, S(n: Nat) }
+
+def Nat.add(m: Nat): Nat {
+    Z => m,
+    S(n) => S(n.add(m))
+}
+
+#[transparent]
+let two: Nat {S(S(Z))}
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x)
+}
+
+let foo : Eq(Nat, two.add(S(S(Z))), S(S(S(S(Z))))) { Refl(Nat, two.add(S(S(Z))))}


### PR DESCRIPTION
Fixes #230 

The gist is that a call to an opaque let-bound definition was not handled correctly: Such a call must be turned into a neutral. I have added an additional constructor for the neutral case and changed the  `eval` function accordingly.