### PR TITLE
Remove match

### DIFF
--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -263,9 +263,9 @@ impl Eval for Match {
     type Val = val::Match;
 
     fn eval(&self, prg: &Module, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let Match { span, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
 
-        Ok(val::Match { span: *span, cases: cases.eval(prg, env)?, omit_absurd: *omit_absurd })
+        Ok(val::Match { cases: cases.eval(prg, env)?, omit_absurd: *omit_absurd })
     }
 }
 

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -591,22 +591,20 @@ impl ReadBack for Hole {
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
 pub struct Match {
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub span: Option<Span>,
     pub cases: Vec<Case>,
     pub omit_absurd: bool,
 }
 
 impl Shift for Match {
     fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
-        let Match { span, cases, omit_absurd } = self;
-        Match { span: *span, cases: cases.shift_in_range(range, by), omit_absurd: *omit_absurd }
+        let Match { cases, omit_absurd } = self;
+        Match { cases: cases.shift_in_range(range, by), omit_absurd: *omit_absurd }
     }
 }
 
 impl Print for Match {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let Match { span: _, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
         let sep = alloc.text(COMMA).append(alloc.hardline());
         alloc
             .hardline()
@@ -626,8 +624,8 @@ impl ReadBack for Match {
     type Nf = ast::Match;
 
     fn read_back(&self, prg: &ast::Module) -> Result<Self::Nf, TypeError> {
-        let Match { span, cases, omit_absurd } = self;
-        Ok(ast::Match { span: *span, cases: cases.read_back(prg)?, omit_absurd: *omit_absurd })
+        let Match { cases, omit_absurd } = self;
+        Ok(ast::Match { cases: cases.read_back(prg)?, omit_absurd: *omit_absurd })
     }
 }
 

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -22,7 +22,7 @@ use crate::result::TypeError;
 
 impl CheckInfer for LocalComatch {
     fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
-        let LocalComatch { span, name, is_lambda_sugar, body, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
         let typ_app_nf = t.expect_typ_app()?;
         let typ_app = typ_app_nf.infer(prg, ctx)?;
 
@@ -36,19 +36,21 @@ impl CheckInfer for LocalComatch {
         }
 
         let wd = WithDestructee {
-            inner: body,
+            cases,
+            omit_absurd: *omit_absurd,
             label: None,
             n_label_args: 0,
             destructee: typ_app_nf.clone(),
         };
-        let body_out = wd.infer_wd(prg, ctx)?;
+        let (cases, omit_absurd) = wd.infer_wd(prg, ctx)?;
 
         Ok(LocalComatch {
             span: *span,
             ctx: Some(ctx.vars.clone()),
             name: name.clone(),
             is_lambda_sugar: *is_lambda_sugar,
-            body: body_out,
+            cases,
+            omit_absurd,
             inferred_type: Some(typ_app),
         })
     }
@@ -59,7 +61,8 @@ impl CheckInfer for LocalComatch {
 }
 
 pub struct WithDestructee<'a> {
-    pub inner: &'a Match,
+    pub cases: &'a Vec<Case>,
+    pub omit_absurd: bool,
     /// Name of the global codefinition that gets substituted for the destructor's self parameters
     pub label: Option<Ident>,
     pub n_label_args: usize,
@@ -68,8 +71,8 @@ pub struct WithDestructee<'a> {
 
 /// Infer a copattern match
 impl<'a> WithDestructee<'a> {
-    pub fn infer_wd(&self, prg: &Module, ctx: &mut Ctx) -> Result<Match, TypeError> {
-        let Match { cases, omit_absurd } = &self.inner;
+    pub fn infer_wd(&self, prg: &Module, ctx: &mut Ctx) -> Result<(Vec<Case>, bool), TypeError> {
+        let WithDestructee { cases, omit_absurd, .. } = &self;
 
         // Check that this comatch is on a codata type
         let codata = prg.codata(&self.destructee.name, self.destructee.span())?;
@@ -186,7 +189,7 @@ impl<'a> WithDestructee<'a> {
             }
         }
 
-        Ok(Match { cases: cases_out, omit_absurd: *omit_absurd })
+        Ok((cases_out, *omit_absurd))
     }
 }
 

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -27,7 +27,7 @@ use crate::result::TypeError;
 
 impl CheckInfer for LocalMatch {
     fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
-        let LocalMatch { span, name, on_exp, motive, body, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, cases, omit_absurd, .. } = self;
         let on_exp_out = on_exp.infer(prg, ctx)?;
         let typ_app_nf = on_exp_out
             .typ()
@@ -83,8 +83,9 @@ impl CheckInfer for LocalMatch {
             }
         };
 
-        let body_out = WithScrutinee { inner: body, scrutinee: typ_app_nf.clone() }
-            .check_ws(prg, ctx, body_t)?;
+        let (cases, omit_absurd) =
+            WithScrutinee { cases, omit_absurd: *omit_absurd, scrutinee: typ_app_nf.clone() }
+                .check_ws(prg, ctx, body_t)?;
 
         Ok(LocalMatch {
             span: *span,
@@ -93,7 +94,8 @@ impl CheckInfer for LocalMatch {
             on_exp: on_exp_out,
             motive: motive_out,
             ret_typ: ret_typ_out.into(),
-            body: body_out,
+            cases,
+            omit_absurd,
             inferred_type: Some(typ_app),
         })
     }
@@ -104,14 +106,20 @@ impl CheckInfer for LocalMatch {
 }
 
 pub struct WithScrutinee<'a> {
-    pub inner: &'a Match,
+    pub cases: &'a Vec<Case>,
+    pub omit_absurd: bool,
     pub scrutinee: TypCtor,
 }
 
 /// Check a pattern match
 impl<'a> WithScrutinee<'a> {
-    pub fn check_ws(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Match, TypeError> {
-        let Match { cases, omit_absurd } = &self.inner;
+    pub fn check_ws(
+        &self,
+        prg: &Module,
+        ctx: &mut Ctx,
+        t: Rc<Exp>,
+    ) -> Result<(Vec<Case>, bool), TypeError> {
+        let WithScrutinee { cases, omit_absurd, .. } = &self;
 
         // Check that this match is on a data type
         let data = prg.data(&self.scrutinee.name, self.scrutinee.span())?;
@@ -187,7 +195,7 @@ impl<'a> WithScrutinee<'a> {
             }
         }
 
-        Ok(Match { cases: cases_out, omit_absurd: *omit_absurd })
+        Ok((cases_out, *omit_absurd))
     }
 }
 

--- a/lang/lifting/src/fv.rs
+++ b/lang/lifting/src/fv.rs
@@ -100,7 +100,7 @@ impl FV for Hole {
 
 impl FV for Match {
     fn visit_fv(&self, v: &mut USTVisitor) {
-        let Match { span: _, cases, omit_absurd: _ } = self;
+        let Match { cases, omit_absurd: _ } = self;
         for case in cases {
             case.visit_fv(v)
         }

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -243,9 +243,9 @@ impl Lift for Match {
     type Target = Match;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Match { span, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
 
-        Match { span: *span, cases: cases.lift(ctx), omit_absurd: *omit_absurd }
+        Match { cases: cases.lift(ctx), omit_absurd: *omit_absurd }
     }
 }
 

--- a/lang/lowering/src/lower/decls.rs
+++ b/lang/lowering/src/lower/decls.rs
@@ -233,13 +233,22 @@ impl Lower for cst::decls::Def {
     type Target = ast::Def;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::decls::Def { span, doc, name, attr, params, scrutinee, ret_typ, body } = self;
+        let cst::decls::Def {
+            span,
+            doc,
+            name,
+            attr,
+            params,
+            scrutinee,
+            ret_typ,
+            cases,
+            omit_absurd,
+        } = self;
 
         let self_param: cst::decls::SelfParam = scrutinee.clone().into();
 
         lower_telescope(params, ctx, |ctx, params| {
-            let body = body.lower(ctx)?;
-
+            let cases = cases.lower(ctx)?;
             lower_self_param(&self_param, ctx, |ctx, self_param| {
                 Ok(ast::Def {
                     span: Some(*span),
@@ -249,7 +258,7 @@ impl Lower for cst::decls::Def {
                     params,
                     self_param,
                     ret_typ: ret_typ.lower(ctx)?,
-                    body,
+                    body: ast::Match { cases, omit_absurd: *omit_absurd },
                 })
             })
         })
@@ -260,7 +269,7 @@ impl Lower for cst::decls::Codef {
     type Target = ast::Codef;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::decls::Codef { span, doc, name, attr, params, typ, body, .. } = self;
+        let cst::decls::Codef { span, doc, name, attr, params, typ, cases, omit_absurd, .. } = self;
 
         lower_telescope(params, ctx, |ctx, params| {
             Ok(ast::Codef {
@@ -270,7 +279,7 @@ impl Lower for cst::decls::Codef {
                 attr: attr.lower(ctx)?,
                 params,
                 typ: typ.lower(ctx)?,
-                body: body.lower(ctx)?,
+                body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
             })
         })
     }

--- a/lang/lowering/src/lower/decls.rs
+++ b/lang/lowering/src/lower/decls.rs
@@ -258,7 +258,8 @@ impl Lower for cst::decls::Def {
                     params,
                     self_param,
                     ret_typ: ret_typ.lower(ctx)?,
-                    body: ast::Match { cases, omit_absurd: *omit_absurd },
+                    cases,
+                    omit_absurd: *omit_absurd,
                 })
             })
         })
@@ -279,7 +280,8 @@ impl Lower for cst::decls::Codef {
                 attr: attr.lower(ctx)?,
                 params,
                 typ: typ.lower(ctx)?,
-                body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
+                cases: cases.lower(ctx)?,
+                omit_absurd: *omit_absurd,
             })
         })
     }

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -37,16 +37,6 @@ impl Lower for cst::exp::Exp {
     }
 }
 
-impl Lower for cst::exp::Match {
-    type Target = ast::Match;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Match { cases, omit_absurd } = self;
-
-        Ok(ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd })
-    }
-}
-
 fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ast::TelescopeInst) -> Result<T, LoweringError>>(
     tel_inst: &[cst::exp::BindingSite],
     ctx: &mut Ctx,
@@ -197,7 +187,7 @@ impl Lower for cst::exp::LocalMatch {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalMatch { span, name, on_exp, motive, body } = self;
+        let cst::exp::LocalMatch { span, name, on_exp, motive, cases, omit_absurd } = self;
         Ok(ast::LocalMatch {
             span: Some(*span),
             ctx: None,
@@ -205,7 +195,7 @@ impl Lower for cst::exp::LocalMatch {
             on_exp: on_exp.lower(ctx)?,
             motive: motive.lower(ctx)?,
             ret_typ: None,
-            body: body.lower(ctx)?,
+            body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
             inferred_type: None,
         }
         .into())
@@ -216,13 +206,13 @@ impl Lower for cst::exp::LocalComatch {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalComatch { span, name, is_lambda_sugar, body } = self;
+        let cst::exp::LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd } = self;
         Ok(ast::LocalComatch {
             span: Some(*span),
             ctx: None,
             name: ctx.unique_label(name.to_owned(), span)?,
             is_lambda_sugar: *is_lambda_sugar,
-            body: body.lower(ctx)?,
+            body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
             inferred_type: None,
         }
         .into())
@@ -293,19 +283,17 @@ impl Lower for cst::exp::Lam {
             span: *span,
             name: None,
             is_lambda_sugar: true,
-            body: cst::exp::Match {
-                cases: vec![cst::exp::Case {
-                    span: *span,
-                    name: Ident { id: "ap".to_owned() },
-                    params: vec![
-                        cst::exp::BindingSite::Wildcard { span: Default::default() },
-                        cst::exp::BindingSite::Wildcard { span: Default::default() },
-                        var.clone(),
-                    ],
-                    body: Some(body.clone()),
-                }],
-                omit_absurd: false,
-            },
+            cases: vec![cst::exp::Case {
+                span: *span,
+                name: Ident { id: "ap".to_owned() },
+                params: vec![
+                    cst::exp::BindingSite::Wildcard { span: Default::default() },
+                    cst::exp::BindingSite::Wildcard { span: Default::default() },
+                    var.clone(),
+                ],
+                body: Some(body.clone()),
+            }],
+            omit_absurd: false,
         });
         comatch.lower(ctx)
     }

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -195,7 +195,8 @@ impl Lower for cst::exp::LocalMatch {
             on_exp: on_exp.lower(ctx)?,
             motive: motive.lower(ctx)?,
             ret_typ: None,
-            body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
+            cases: cases.lower(ctx)?,
+            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
         .into())
@@ -212,7 +213,8 @@ impl Lower for cst::exp::LocalComatch {
             ctx: None,
             name: ctx.unique_label(name.to_owned(), span)?,
             is_lambda_sugar: *is_lambda_sugar,
-            body: ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd },
+            cases: cases.lower(ctx)?,
+            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
         .into())

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -41,9 +41,9 @@ impl Lower for cst::exp::Match {
     type Target = ast::Match;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Match { span, cases, omit_absurd } = self;
+        let cst::exp::Match { cases, omit_absurd } = self;
 
-        Ok(ast::Match { span: Some(*span), cases: cases.lower(ctx)?, omit_absurd: *omit_absurd })
+        Ok(ast::Match { cases: cases.lower(ctx)?, omit_absurd: *omit_absurd })
     }
 }
 
@@ -294,7 +294,6 @@ impl Lower for cst::exp::Lam {
             name: None,
             is_lambda_sugar: true,
             body: cst::exp::Match {
-                span: *span,
                 cases: vec![cst::exp::Case {
                     span: *span,
                     name: Ident { id: "ap".to_owned() },

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -144,7 +144,8 @@ pub struct Def {
     pub params: Telescope,
     pub scrutinee: Scrutinee,
     pub ret_typ: Rc<exp::Exp>,
-    pub body: exp::Match,
+    pub cases: Vec<exp::Case>,
+    pub omit_absurd: bool,
 }
 
 /// Scrutinee within a toplevel definition
@@ -180,7 +181,8 @@ pub struct Codef {
     pub attr: Attributes,
     pub params: Telescope,
     pub typ: TypApp,
-    pub body: exp::Match,
+    pub cases: Vec<exp::Case>,
+    pub omit_absurd: bool,
 }
 
 /// Toplevel let-bound expression.

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -12,12 +12,6 @@ pub enum BindingSite {
 }
 
 #[derive(Debug, Clone)]
-pub struct Match {
-    pub cases: Vec<Case>,
-    pub omit_absurd: bool,
-}
-
-#[derive(Debug, Clone)]
 pub struct Case {
     pub span: Span,
     pub name: Ident,
@@ -73,7 +67,8 @@ pub struct LocalMatch {
     pub name: Option<Ident>,
     pub on_exp: Rc<Exp>,
     pub motive: Option<Motive>,
-    pub body: Match,
+    pub cases: Vec<Case>,
+    pub omit_absurd: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -81,7 +76,8 @@ pub struct LocalComatch {
     pub span: Span,
     pub name: Option<Ident>,
     pub is_lambda_sugar: bool,
-    pub body: Match,
+    pub cases: Vec<Case>,
+    pub omit_absurd: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -13,7 +13,6 @@ pub enum BindingSite {
 
 #[derive(Debug, Clone)]
 pub struct Match {
-    pub span: Span,
     pub cases: Vec<Case>,
     pub omit_absurd: bool,
 }

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -123,18 +123,18 @@ Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name
 
 // Toplevel definition
 Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <body: Match> "}" <r: @R> =>
-  Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, body };
+  Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases: body.0, omit_absurd: body.1 };
 
 // Toplevel codefinition
 Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <body: Match> "}" <r: @R> =>
-  Codef { span: span(l, r), doc, name, attr, params, typ, body };
+  Codef { span: span(l, r), doc, name, attr, params, typ, cases: body.0, omit_absurd: body.1 };
 
 // Toplevel let binding
 Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: LowerIdent><params: OptTelescope> ":" <typ: Exp> "{" <body: Exp> "}" <r: @R> =>
   Let { span: span(l,r), doc, name, attr, params, typ, body };
 
-pub Match : Match = {
-    <cases: Comma<Case>> <omit_absurd: OmitAbsurd> => Match { cases, omit_absurd },
+pub Match : (Vec<Case>, bool) = {
+    <cases: Comma<Case>> <omit_absurd: OmitAbsurd> => (cases, omit_absurd),
 }
 
 pub Case : Case = {
@@ -218,7 +218,7 @@ DotCall: DotCall = <l: @L> <exp: Ops> "." <name: Ident> <args: OptArgs> <r: @R> 
   DotCall { span: span(l, r), exp, name, args };
 
 LocalMatch: LocalMatch = <l: @L> <on_exp: Ops> "." "match" <name: Ident?> <motive: Motive?> "{" <body: Match> "}" <r: @R> =>
-  LocalMatch { span: span(l, r), name, on_exp, motive, body };
+  LocalMatch { span: span(l, r), name, on_exp, motive, cases: body.0, omit_absurd: body.1 };
 
 CallWithArgs: Call = <l: @L> <name: Ident> <args: Args> <r: @R> =>
   Call { span: span(l, r), name, args };
@@ -227,7 +227,7 @@ CallWithoutArgs: Call = <l: @L> <name: Ident> <r: @R> =>
   Call { span: span(l, r), name, args: vec![] };
 
 LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <body: Match> "}" <r: @R> =>
-  LocalComatch { span: span(l, r), name, is_lambda_sugar: false, body };
+  LocalComatch { span: span(l, r), name, is_lambda_sugar: false, cases: body.0, omit_absurd: body.1 };
 
 TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>
   TypeUniv { span: span(l, r) };

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -134,7 +134,7 @@ Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: LowerId
   Let { span: span(l,r), doc, name, attr, params, typ, body };
 
 pub Match : Match = {
-    <l: @L> <cases: Comma<Case>> <omit_absurd: OmitAbsurd> <r: @R> => Match { span: span(l, r), cases, omit_absurd },
+    <cases: Comma<Case>> <omit_absurd: OmitAbsurd> => Match { cases, omit_absurd },
 }
 
 pub Case : Case = {

--- a/lang/printer/src/generic.rs
+++ b/lang/printer/src/generic.rs
@@ -273,7 +273,7 @@ impl Print for Dtor {
 
 impl Print for Match {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let Match { span: _, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
         match cases.len() {
             0 => {
                 if *omit_absurd {

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -149,7 +149,7 @@ impl CollectInfo for Codata {
 
 impl CollectInfo for Def {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Def { name, span, self_param, body, params, ret_typ, .. } = self;
+        let Def { name, span, self_param, cases, params, ret_typ, .. } = self;
         if let Some(span) = span {
             // Add Item
             let item = Item::Def { name: name.clone(), type_name: self_param.typ.name.clone() };
@@ -160,7 +160,7 @@ impl CollectInfo for Def {
         };
 
         self_param.collect_info(collector);
-        body.collect_info(collector);
+        cases.collect_info(collector);
         params.collect_info(collector);
         ret_typ.collect_info(collector);
     }
@@ -168,7 +168,7 @@ impl CollectInfo for Def {
 
 impl CollectInfo for Codef {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Codef { name, span, typ, body, params, .. } = self;
+        let Codef { name, span, typ, cases, params, .. } = self;
         if let Some(span) = span {
             // Add item
             let item = Item::Codef { name: name.clone(), type_name: typ.name.clone() };
@@ -178,7 +178,7 @@ impl CollectInfo for Codef {
             collector.add_info(*span, info);
         }
         typ.collect_info(collector);
-        body.collect_info(collector);
+        cases.collect_info(collector);
         params.collect_info(collector)
     }
 }
@@ -390,7 +390,7 @@ impl CollectInfo for Anno {
 
 impl CollectInfo for LocalMatch {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let LocalMatch { span, on_exp, ret_typ, body, inferred_type, .. } = self;
+        let LocalMatch { span, on_exp, ret_typ, cases, inferred_type, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
             // Add info
             let info = LocalMatchInfo { typ: typ.print_to_string(None) };
@@ -398,28 +398,19 @@ impl CollectInfo for LocalMatch {
         }
         on_exp.collect_info(collector);
         ret_typ.collect_info(collector);
-        body.collect_info(collector)
+        cases.collect_info(collector)
     }
 }
 
 impl CollectInfo for LocalComatch {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let LocalComatch { span, body, inferred_type, .. } = self;
+        let LocalComatch { span, cases, inferred_type, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
             // Add info
             let info = LocalComatchInfo { typ: typ.print_to_string(None) };
             collector.add_info(*span, info)
         }
-        body.collect_info(collector)
-    }
-}
-
-impl CollectInfo for Match {
-    fn collect_info(&self, collector: &mut InfoCollector) {
-        let Match { cases, .. } = self;
-        for case in cases.iter() {
-            case.collect_info(collector)
-        }
+        cases.collect_info(collector)
     }
 }
 

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -362,9 +362,9 @@ impl Rename for Anno {
 
 impl Rename for Match {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Match { span, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
 
-        Match { span, cases: cases.rename_in_ctx(ctx), omit_absurd }
+        Match { cases: cases.rename_in_ctx(ctx), omit_absurd }
     }
 }
 

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -115,12 +115,12 @@ impl Rename for Dtor {
 
 impl Rename for Def {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Def { span, doc, name, attr, params, self_param, ret_typ, body } = self;
+        let Def { span, doc, name, attr, params, self_param, ret_typ, cases, omit_absurd } = self;
 
         let new_params = params.rename_in_ctx(ctx);
         ctx.bind_iter(new_params.params.clone().into_iter(), |new_ctx| {
             let new_self = self_param.rename_in_ctx(new_ctx);
-            let new_body = body.rename_in_ctx(new_ctx);
+            let new_cases = cases.rename_in_ctx(new_ctx);
 
             new_ctx.bind_single(new_self.clone(), |new_ctx| {
                 let new_ret = ret_typ.rename_in_ctx(new_ctx);
@@ -132,7 +132,8 @@ impl Rename for Def {
                     params: new_params,
                     self_param: new_self,
                     ret_typ: new_ret,
-                    body: new_body,
+                    cases: new_cases,
+                    omit_absurd,
                 }
             })
         })
@@ -141,16 +142,25 @@ impl Rename for Def {
 
 impl Rename for Codef {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Codef { span, doc, name, attr, params, typ, body } = self;
+        let Codef { span, doc, name, attr, params, typ, cases, omit_absurd } = self;
 
         let new_params = params.rename_in_ctx(ctx);
 
         ctx.bind_iter(new_params.params.clone().into_iter(), |new_ctx| {
             let new_typ = typ.rename_in_ctx(new_ctx);
 
-            let new_body = body.rename_in_ctx(new_ctx);
+            let new_cases = cases.rename_in_ctx(new_ctx);
 
-            Codef { span, doc, name, attr, params: new_params, typ: new_typ, body: new_body }
+            Codef {
+                span,
+                doc,
+                name,
+                attr,
+                params: new_params,
+                typ: new_typ,
+                cases: new_cases,
+                omit_absurd,
+            }
         })
     }
 }
@@ -301,13 +311,14 @@ impl Rename for Variable {
 
 impl Rename for LocalComatch {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let LocalComatch { span, name, is_lambda_sugar, body, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
         LocalComatch {
             span,
             ctx: None,
             name,
             is_lambda_sugar,
-            body: body.rename_in_ctx(ctx),
+            cases: cases.rename_in_ctx(ctx),
+            omit_absurd,
             inferred_type: None,
         }
     }
@@ -327,7 +338,7 @@ impl Rename for Hole {
 }
 impl Rename for LocalMatch {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let LocalMatch { span, name, on_exp, motive, ret_typ, body, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, ret_typ, cases, omit_absurd, .. } = self;
         LocalMatch {
             span,
             ctx: None,
@@ -335,7 +346,8 @@ impl Rename for LocalMatch {
             on_exp: on_exp.rename_in_ctx(ctx),
             motive: motive.rename_in_ctx(ctx),
             ret_typ: ret_typ.rename_in_ctx(ctx),
-            body: body.rename_in_ctx(ctx),
+            cases: cases.rename_in_ctx(ctx),
+            omit_absurd,
             inferred_type: None,
         }
     }
@@ -357,14 +369,6 @@ impl Rename for Anno {
             typ: typ.rename_in_ctx(ctx),
             normalized_type: normalized_type.map(|e| e.rename_in_ctx(ctx)),
         }
-    }
-}
-
-impl Rename for Match {
-    fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Match { cases, omit_absurd } = self;
-
-        Match { cases: cases.rename_in_ctx(ctx), omit_absurd }
     }
 }
 

--- a/lang/syntax/src/ast/decls.rs
+++ b/lang/syntax/src/ast/decls.rs
@@ -217,7 +217,8 @@ pub struct Def {
     pub params: Telescope,
     pub self_param: SelfParam,
     pub ret_typ: Rc<Exp>,
-    pub body: Match,
+    pub cases: Vec<Case>,
+    pub omit_absurd: bool,
 }
 
 impl Def {
@@ -245,7 +246,8 @@ pub struct Codef {
     pub attr: Attributes,
     pub params: Telescope,
     pub typ: TypCtor,
-    pub body: Match,
+    pub cases: Vec<Case>,
+    pub omit_absurd: bool,
 }
 
 impl Codef {

--- a/lang/syntax/src/ast/exp.rs
+++ b/lang/syntax/src/ast/exp.rs
@@ -867,16 +867,14 @@ impl Substitutable for Hole {
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
 pub struct Match {
-    #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub span: Option<Span>,
     pub cases: Vec<Case>,
     pub omit_absurd: bool,
 }
 
 impl Shift for Match {
     fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
-        let Match { span, cases, omit_absurd } = self;
-        Match { span: *span, cases: cases.shift_in_range(range, by), omit_absurd: *omit_absurd }
+        let Match { cases, omit_absurd } = self;
+        Match { cases: cases.shift_in_range(range, by), omit_absurd: *omit_absurd }
     }
 }
 
@@ -890,9 +888,8 @@ impl Occurs for Match {
 impl Substitutable for Match {
     type Result = Match;
     fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self {
-        let Match { span, cases, omit_absurd } = self;
+        let Match { cases, omit_absurd } = self;
         Match {
-            span: *span,
             cases: cases.iter().map(|case| case.subst(ctx, by)).collect(),
             omit_absurd: *omit_absurd,
         }

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -180,7 +180,7 @@ impl BuildMatrix for ast::Def {
         })?;
         xdata.dtors.insert(self.name.clone(), self.to_dtor());
 
-        let ast::Match { cases, .. } = &self.body;
+        let cases = &self.cases;
 
         for case in cases {
             let ast::Case { name, body, .. } = case;
@@ -200,7 +200,7 @@ impl BuildMatrix for ast::Codef {
         })?;
         xdata.ctors.insert(self.name.clone(), self.to_ctor());
 
-        let ast::Match { cases, .. } = &self.body;
+        let cases = &self.cases;
 
         for case in cases {
             let ast::Case { name, body, .. } = case;
@@ -263,7 +263,8 @@ impl XData {
                     params: dtor.params.clone(),
                     self_param: dtor.self_param.clone(),
                     ret_typ: dtor.ret_typ.clone(),
-                    body: ast::Match { cases, omit_absurd },
+                    cases,
+                    omit_absurd,
                 }
             })
             .collect();
@@ -322,7 +323,8 @@ impl XData {
                     attr: Attributes::default(),
                     params: ctor.params.clone(),
                     typ: ctor.typ.clone(),
-                    body: ast::Match { cases, omit_absurd },
+                    cases,
+                    omit_absurd,
                 }
             })
             .collect();

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -263,7 +263,7 @@ impl XData {
                     params: dtor.params.clone(),
                     self_param: dtor.self_param.clone(),
                     ret_typ: dtor.ret_typ.clone(),
-                    body: ast::Match { cases, span: None, omit_absurd },
+                    body: ast::Match { cases, omit_absurd },
                 }
             })
             .collect();
@@ -322,7 +322,7 @@ impl XData {
                     attr: Attributes::default(),
                     params: ctor.params.clone(),
                     typ: ctor.typ.clone(),
-                    body: ast::Match { cases, span: None, omit_absurd },
+                    body: ast::Match { cases, omit_absurd },
                 }
             })
             .collect();


### PR DESCRIPTION
Removes the `Match` construct from the AST and CST. The `Match` construct was just a wrapper around a vector of `Case` and the `omit_absurd` boolean.
This leads to unnecessary indirection and makes the code harder to understand, especially since `Match` is not a semantic concept of our domain, i.e. it does not have any independent meaning outside of a `LocalMatch` or `LocalComatch`. 