### PR TITLE
Add a custom lexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1293,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.3",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loom"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1677,7 @@ dependencies = [
  "lalrpop 0.19.9",
  "lalrpop 0.20.2",
  "lalrpop-util 0.20.2",
+ "logos",
  "miette",
  "num-bigint",
  "thiserror",

--- a/lang/parser/Cargo.toml
+++ b/lang/parser/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# lexer generator
+logos = "0.14.0"
 # parser generator
 lalrpop = "0.20"
 lalrpop-util = "0.20"

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -5,6 +5,7 @@ use num_bigint::BigUint;
 use crate::cst::exp::*;
 use crate::cst::decls::*;
 use crate::cst::ident::*;
+use crate::lexer::{Token, LexicalError};
 
 use super::util::span;
 
@@ -12,26 +13,66 @@ use super::util::span;
 grammar;
 
 // Tokens
-match {
-    // Symbols
-    "(", ")", "{", "}", "[", "]", ";", ":=", "=>", ",", ":", ".", "?",
-    "->", "\\", "#",
-    // Names
-    "_",
-    r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*",
-    r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*",
-    // Literals
-    r"0|[1-9][0-9]*",
+extern {
+  type Location = usize;
+  type Error = LexicalError;
+
+  enum Token {
     // Keywords
-    "data", "codata",
-    "def", "codef", "let",
-    "match", "as", "comatch",
-    "absurd", "..absurd",
-    "Type",
-    // Comments and whitespace
-    r"\s*" => { }, // Skip whitespace
-    r"-- \|[^\n\r]*[\n\r]*", // Don't skip doc-comments
-    r"--(([^ \n\r]| [^\|\n\r])[^\n\r]*)?[\n\r]*" => { }, // Skip `--` comments
+    //
+    //
+    "data" => Token::Data,
+    "codata" => Token::Codata,
+    "def" => Token::Def,
+    "codef" => Token::Codef,
+    "let" => Token::Let,
+    "match" => Token::Match,
+    "as" => Token::As,
+    "comatch" => Token::Comatch,
+    "absurd" => Token::Absurd,
+    "..absurd" => Token::DotsAbsurd,
+    "Type" => Token::Type,
+
+    // Parens, Braces and Brackets
+    //
+    //
+    "(" => Token::LParen,
+    ")" => Token::RParen,
+    "{" => Token::LBrace,
+    "}" => Token::RBrace,
+    "[" => Token::LBracket,
+    "]" => Token::RBracket,
+
+    // Symbols
+    //
+    //
+    ";" => Token::Semicolon,
+    ":=" => Token::ColonEq,
+    "=>" => Token::DoubleRightArrow,
+    "," => Token::Comma,
+    ":" => Token::Colon,
+    "." => Token::Dot,
+    "?" => Token::QuestionMark,
+    "->" => Token::RightArrow,
+    "\\" => Token::Backslash,
+    "#" => Token::Hash,
+    "_" => Token::Underscore,
+
+    // Names
+    //
+    //
+    "UpperCaseName" => Token::UpperCaseName(<String>),
+    "LowerCaseName" => Token::LowerCaseName(<String>),
+
+    // Literals
+    //
+    //
+    "NumLit" => Token::NumLit(<BigUint>),
+
+    // Comments and DocComments
+    "Comment" => Token::Comment,
+    "DocComment" => Token::DocComment(<String>),
+  }
 }
 
 // Utils
@@ -76,13 +117,13 @@ OptTelescopeInst: Vec<BindingSite> = <params: Parens<Comma<BindingSite>>?> => pa
 Args: Vec<Rc<Exp>> = ParenthesizedArgs<Exp>;
 OptArgs: Vec<Rc<Exp>> = OptParenthesizedArgs<Exp>;
 
-Attr: String = <s:r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*"> => s.to_owned();
+Attr: String = <s:"LowerCaseName"> => s.to_owned();
 Attributes: Attributes = "#" <attrs: BracketedArgs<Attr>> => Attributes { attrs };
 OptAttributes: Attributes = <attr: Attributes? > => attr.unwrap_or_default();
 
 OmitAbsurd: bool = <absurd: "..absurd"?> => absurd.is_some();
 
-DocCommentHelper: String = <doc: r"-- \|[^\n\r]*[\n\r]*"> => doc.strip_prefix("-- |").unwrap().trim().to_owned();
+DocCommentHelper: String = <doc: "DocComment"> => doc.strip_prefix("-- |").unwrap().trim().to_owned();
 DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 
 // Modules
@@ -235,8 +276,8 @@ TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>
 Hole: Hole = <l: @L> "?" <r: @R> =>
   Hole { span: span(l, r) };
 
-NatLit: NatLit = <l: @L> <s: r"0|[1-9][0-9]*"> <r: @R> =>
-  NatLit { span: span(l, r), val: BigUint::parse_bytes(s.as_ref(), 10).unwrap() };
+NatLit: NatLit = <l: @L> <n: "NumLit"> <r: @R> =>
+  NatLit { span: span(l, r), val: n };
 
 // Helpers
 //
@@ -257,5 +298,5 @@ Ident: Ident = {
     <s: LowerIdent> => s.to_owned(),
     <s: UpperIdent> => s.to_owned(),
 }
-LowerIdent: Ident = <s:r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*"> => Ident { id: s.to_owned() };
-UpperIdent: Ident = <s:r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*"> => Ident { id: s.to_owned() };
+LowerIdent: Ident = <s: "LowerCaseName" > => Ident { id: s.to_owned() };
+UpperIdent: Ident = <s: "UpperCaseName"> => Ident { id: s.to_owned() };

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -69,8 +69,7 @@ extern {
     //
     "NumLit" => Token::NumLit(<BigUint>),
 
-    // Comments and DocComments
-    "Comment" => Token::Comment,
+    // DocComments
     "DocComment" => Token::DocComment(<String>),
   }
 }

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -16,7 +16,7 @@ impl fmt::Display for LexicalError {
 }
 
 #[derive(Logos, Clone, Debug, PartialEq)]
-#[logos(skip r"\s*", error = LexicalError)]
+#[logos(skip r"\s*", skip r"--(([^ \n\r]| [^\|\n\r])[^\n\r]*)?[\n\r]*", error = LexicalError)]
 pub enum Token {
     // Keywords
     //
@@ -100,11 +100,9 @@ pub enum Token {
     #[regex(r"0|[1-9][0-9]*", |lex| BigUint::parse_bytes(lex.slice().as_ref(), 10).unwrap())]
     NumLit(BigUint),
 
-    // Comments and DocComments
+    // DocComments
     //
     //
-    #[regex(r"--(([^ \n\r]| [^\|\n\r])[^\n\r]*)?[\n\r]*")]
-    Comment,
     #[regex(r"-- \|[^\n\r]*[\n\r]*", |lex| lex.slice().to_string())]
     DocComment(String),
 }

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -1,0 +1,100 @@
+use logos::Logos;
+
+#[derive(Logos, Debug, PartialEq)]
+pub enum Token {
+    // Keywords
+    //
+    //
+    #[token("data")]
+    Data,
+    #[token("codata")]
+    Codata,
+    #[token("def")]
+    Def,
+    #[token("codef")]
+    Codef,
+    #[token("let")]
+    Let,
+    #[token("match")]
+    Match,
+    #[token("as")]
+    As,
+    #[token("comatch")]
+    Comatch,
+    #[token("absurd")]
+    Absurd,
+    #[token("..absurd")]
+    DotsAbsurd,
+    #[token("Type")]
+    Type,
+
+    // Parens, Braces and Brackets
+    //
+    //
+    #[token("(")]
+    LParen,
+    #[token(")")]
+    RParen,
+    #[token("{")]
+    LBrace,
+    #[token("}")]
+    RBrace,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
+
+    // Symbols
+    //
+    //
+    #[token(";")]
+    Semicolon,
+    #[token(":=")]
+    ColonEq,
+    #[token("=>")]
+    DoubleRightArrow,
+    #[token(",")]
+    Comma,
+    #[token(":")]
+    Colon,
+    #[token(".")]
+    Dot,
+    #[token("?")]
+    QuestionMark,
+    #[token("->")]
+    RightArrow,
+    #[token("\\")]
+    Backslash,
+    #[token("#")]
+    Hash,
+    #[token("_")]
+    Underscore,
+
+    // Names
+    //
+    //
+    #[regex(r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*")]
+    UpperCaseName,
+    #[regex(r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*")]
+    LowerCaseName,
+
+    // Literals
+    //
+    //
+    #[regex(r"0|[1-9][0-9]*")]
+    NumLit,
+
+    // Comments and DocComments
+    //
+    //
+    #[regex(r"--(([^ \n\r]| [^\|\n\r])[^\n\r]*)?[\n\r]*")]
+    Comment,
+    #[regex(r"-- \|[^\n\r]*[\n\r]*")]
+    DocComment,
+
+    // Whitespace
+    //
+    //
+    #[regex(r"\s*")]
+    Whitespace,
+}

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -9,7 +9,13 @@ pub enum LexicalError {
     InvalidToken,
 }
 
-#[derive(Logos, Debug, PartialEq)]
+impl fmt::Display for LexicalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[derive(Logos, Clone, Debug, PartialEq)]
 #[logos(skip r"\s*", error = LexicalError)]
 pub enum Token {
     // Keywords
@@ -99,8 +105,8 @@ pub enum Token {
     //
     #[regex(r"--(([^ \n\r]| [^\|\n\r])[^\n\r]*)?[\n\r]*")]
     Comment,
-    #[regex(r"-- \|[^\n\r]*[\n\r]*")]
-    DocComment,
+    #[regex(r"-- \|[^\n\r]*[\n\r]*", |lex| lex.slice().to_string())]
+    DocComment(String),
 }
 
 impl fmt::Display for Token {

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -1,10 +1,16 @@
 use std::fmt;
 
-use logos::Logos;
+use logos::{Logos, SpannedIter};
 use num_bigint::BigUint;
 
+#[derive(Default, Debug, Clone, PartialEq)]
+pub enum LexicalError {
+    #[default]
+    InvalidToken,
+}
+
 #[derive(Logos, Debug, PartialEq)]
-#[logos(skip r"\s*")] // Ignore this regex pattern between tokens
+#[logos(skip r"\s*", error = LexicalError)]
 pub enum Token {
     // Keywords
     //
@@ -100,5 +106,27 @@ pub enum Token {
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
+
+pub struct Lexer<'input> {
+    // instead of an iterator over characters, we have a token iterator
+    token_stream: SpannedIter<'input, Token>,
+}
+
+impl<'input> Lexer<'input> {
+    pub fn new(input: &'input str) -> Self {
+        // the Token::lexer() method is provided by the Logos trait
+        Self { token_stream: Token::lexer(input).spanned() }
+    }
+}
+
+impl<'input> Iterator for Lexer<'input> {
+    type Item = Spanned<Token, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.token_stream.next().map(|(token, span)| Ok((span.start, token?, span.end)))
     }
 }

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -1,6 +1,10 @@
+use std::fmt;
+
 use logos::Logos;
+use num_bigint::BigUint;
 
 #[derive(Logos, Debug, PartialEq)]
+#[logos(skip r"\s*")] // Ignore this regex pattern between tokens
 pub enum Token {
     // Keywords
     //
@@ -73,16 +77,16 @@ pub enum Token {
     // Names
     //
     //
-    #[regex(r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*")]
-    UpperCaseName,
-    #[regex(r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*")]
-    LowerCaseName,
+    #[regex(r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*", |lex| lex.slice().to_string())]
+    UpperCaseName(String),
+    #[regex(r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*", |lex| lex.slice().to_string())]
+    LowerCaseName(String),
 
     // Literals
     //
     //
-    #[regex(r"0|[1-9][0-9]*")]
-    NumLit,
+    #[regex(r"0|[1-9][0-9]*", |lex| BigUint::parse_bytes(lex.slice().as_ref(), 10).unwrap())]
+    NumLit(BigUint),
 
     // Comments and DocComments
     //
@@ -91,10 +95,10 @@ pub enum Token {
     Comment,
     #[regex(r"-- \|[^\n\r]*[\n\r]*")]
     DocComment,
+}
 
-    // Whitespace
-    //
-    //
-    #[regex(r"\s*")]
-    Whitespace,
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -5,16 +5,21 @@ mod result;
 
 use std::rc::Rc;
 
+use lexer::Lexer;
 use url::Url;
 
 use grammar::cst::{DeclsParser, ExpParser};
 pub use result::*;
 
 pub fn parse_exp(s: &str) -> Result<Rc<cst::exp::Exp>, ParseError> {
-    ExpParser::new().parse(s).map_err(From::from)
+    let lexer = Lexer::new(s);
+    let parser = ExpParser::new();
+    parser.parse(lexer).map_err(From::from)
 }
 
 pub fn parse_module(uri: Url, s: &str) -> Result<cst::decls::Module, ParseError> {
-    let items = DeclsParser::new().parse(s)?;
+    let lexer = Lexer::new(s);
+    let parser = DeclsParser::new();
+    let items = parser.parse(lexer)?;
     Ok(cst::decls::Module { uri, items })
 }

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cst;
 mod grammar;
+mod lexer;
 mod result;
 
 use std::rc::Rc;

--- a/lang/parser/src/result.rs
+++ b/lang/parser/src/result.rs
@@ -1,4 +1,3 @@
-
 use miette::{Diagnostic, SourceOffset, SourceSpan};
 use thiserror::Error;
 

--- a/lang/parser/src/result.rs
+++ b/lang/parser/src/result.rs
@@ -1,7 +1,8 @@
-use lalrpop_util::lexer::Token;
 
 use miette::{Diagnostic, SourceOffset, SourceSpan};
 use thiserror::Error;
+
+use crate::lexer::{LexicalError, Token};
 
 fn separated<I: IntoIterator<Item = String>>(s: &str, iter: I) -> String {
     let vec: Vec<_> = iter.into_iter().collect();
@@ -51,11 +52,11 @@ pub enum ParseError {
     },
     #[error("{error}")]
     #[diagnostic(code("P-005"))]
-    User { error: String },
+    User { error: LexicalError },
 }
 
-impl From<lalrpop_util::ParseError<usize, Token<'_>, &'static str>> for ParseError {
-    fn from(err: lalrpop_util::ParseError<usize, Token<'_>, &'static str>) -> Self {
+impl From<lalrpop_util::ParseError<usize, Token, LexicalError>> for ParseError {
+    fn from(err: lalrpop_util::ParseError<usize, Token, LexicalError>) -> Self {
         use lalrpop_util::ParseError::*;
         match err {
             InvalidToken { location } => ParseError::InvalidToken { location: location.into() },
@@ -81,7 +82,7 @@ trait ToMietteExt {
     fn span(&self) -> SourceSpan;
 }
 
-impl ToMietteExt for (usize, Token<'_>, usize) {
+impl ToMietteExt for (usize, Token, usize) {
     fn span(&self) -> SourceSpan {
         (self.0, self.2 - self.0).into()
     }

--- a/test/suites/fail-parse/P-001.expected
+++ b/test/suites/fail-parse/P-001.expected
@@ -1,1 +1,1 @@
-Invalid token
+InvalidToken

--- a/test/suites/fail-parse/P-002.expected
+++ b/test/suites/fail-parse/P-002.expected
@@ -1,1 +1,1 @@
-Unexpected end of file. Expected "}", r#"-- \\|[^\\n\\r]*[\\n\\r]*"#, r#"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*"#
+Unexpected end of file. Expected "DocComment", "UpperCaseName", "}"

--- a/test/suites/fail-parse/P-003.expected
+++ b/test/suites/fail-parse/P-003.expected
@@ -1,1 +1,1 @@
-Unexpected "foo", expected r#"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*"#
+Unexpected "LowerCaseName("foo")", expected "UpperCaseName"


### PR DESCRIPTION
In order to use namespaced identifiers `foo::bar::baz` we have to rewrite the lexer. The current lexer which is hardwired into `lalrpop` automatically skips whitespace, but we dont want to accept whitespace between the tokens from the example: `"foo" + "::" + "bar" + "::" + "baz"`, i.e. we don't want to accept `foo :: bar:: baz` or something like it.

I just followed the LALRPOP tutorial here: http://lalrpop.github.io/lalrpop/lexer_tutorial/005_external_lib.html