### PR TITLE
Remove debug option

### DIFF
--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -15,8 +15,6 @@ pub struct Args {
     #[clap(long)]
     filter: Option<String>,
     #[clap(long, num_args = 0)]
-    debug: bool,
-    #[clap(long, num_args = 0)]
     update_expected: bool,
 }
 

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     env_logger::builder().format_timestamp(None).format_level(false).format_target(false).init();
     let args = Args::parse();
     let runner = runner::Runner::load(crate::TEST_SUITES_PATH, crate::EXAMPLES_PATH);
-    let res = runner.run(&args);
+    let mut res = runner.run(&args);
     if args.update_expected {
         res.update_expected();
         println!("Updated expected outputs.");

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -125,17 +125,6 @@ where
     }
 }
 
-impl Report {
-    pub fn print(&self) {
-        for PhaseReport { name, output } in &self.phases {
-            println!("phase {name}:");
-            println!();
-            println!("{output}");
-            println!();
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum Failure {
     Mismatch {

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -8,7 +8,10 @@ use parser::cst;
 use renaming::Rename;
 use syntax::ast::Module;
 
-use crate::suites::{self, Case};
+use crate::{
+    runner::CaseResult,
+    suites::{self, Case},
+};
 
 pub trait Phase {
     type In;
@@ -25,15 +28,11 @@ pub trait Phase {
 /// The struct is parameterized over the output type of the last phase that
 /// has been run.
 pub struct PartialRun<O> {
-    /// The result of the last run.
+    case: Case,
+    /// The result of the last run phase.
     result: Result<O, PhasesError>,
     /// A textual report about all the previously run phases.
     report_phases: Vec<PhaseReport>,
-}
-
-pub struct Report {
-    pub phases: Vec<PhaseReport>,
-    pub result: Result<String, Failure>,
 }
 
 pub struct PhaseReport {
@@ -46,8 +45,8 @@ where
     O: TestOutput,
 {
     /// Start a new partial run for a testcase with the initial input.
-    pub fn start(input: O) -> PartialRun<O> {
-        PartialRun { result: Ok(input), report_phases: vec![] }
+    pub fn start(case: Case, input: O) -> PartialRun<O> {
+        PartialRun { case, result: Ok(input), report_phases: vec![] }
     }
 
     /// Extend this partial run by running one additional phase.
@@ -103,17 +102,17 @@ where
                         return Err(PhasesError::Mismatch { expected, actual });
                     }
                 }
-                Err(PhasesError::AsExpected { err: Box::new(err) })
+                Err(PhasesError::AsExpected)
             }
         });
 
-        PartialRun { result, report_phases: self.report_phases }
+        PartialRun { case: self.case, result, report_phases: self.report_phases }
     }
 
-    pub fn report(self) -> Report {
+    pub fn report(self) -> CaseResult {
         let result = match self.result {
-            Ok(out) => Ok(out.test_output()),
-            Err(PhasesError::AsExpected { err }) => Ok(format!("{err:?}")),
+            Ok(_) => Ok(()),
+            Err(PhasesError::AsExpected { .. }) => Ok(()),
             Err(PhasesError::Mismatch { expected, actual }) => {
                 Err(Failure::Mismatch { expected, actual })
             }
@@ -121,7 +120,7 @@ where
             Err(PhasesError::ExpectedSuccess { got }) => Err(Failure::ExpectedSuccess { got }),
         };
 
-        Report { result, phases: self.report_phases }
+        CaseResult { result, case: self.case }
     }
 }
 
@@ -155,7 +154,7 @@ impl fmt::Display for Failure {
 }
 
 enum PhasesError {
-    AsExpected { err: Box<dyn Error> },
+    AsExpected,
     Mismatch { expected: String, actual: String },
     ExpectedFailure { got: String },
     ExpectedSuccess { got: Box<dyn Error> },

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -35,6 +35,7 @@ pub struct PartialRun<O> {
     report_phases: Vec<PhaseReport>,
 }
 
+#[allow(dead_code)]
 pub struct PhaseReport {
     pub name: &'static str,
     pub output: String,
@@ -50,12 +51,7 @@ where
     }
 
     /// Extend this partial run by running one additional phase.
-    pub fn then<O2, E, P>(
-        mut self,
-        config: &suites::Config,
-        case: &Case,
-        phase: P,
-    ) -> PartialRun<O2>
+    pub fn then<O2, E, P>(mut self, config: &suites::Config, phase: P) -> PartialRun<O2>
     where
         O2: TestOutput,
         E: Error + 'static,
@@ -68,7 +64,7 @@ where
         // whether there is an expected error output.
         let output = config.fail.as_ref().and_then(|fail| {
             if fail == phase.name() {
-                case.expected()
+                self.case.expected()
             } else {
                 None
             }

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -90,10 +90,6 @@ impl Runner {
 
             let report = self.run_case(&suite.config, case);
 
-            if args.debug {
-                report.print();
-            }
-
             let result = CaseResult { case: case.clone(), result: report.result };
             results.push(result);
         }

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -146,8 +146,8 @@ impl RunResult {
         self.results.iter().flat_map(|suite_res| suite_res.results.iter())
     }
 
-    pub fn print(&self) {
-        for suite in &self.results {
+    pub fn print(&mut self) {
+        for suite in &mut self.results {
             suite.print()
         }
         println!(
@@ -175,11 +175,12 @@ pub struct SuiteResult {
 }
 
 impl SuiteResult {
-    pub fn print(&self) {
+    pub fn print(&mut self) {
         let SuiteResult { suite, results, executed_cases, failed_cases } = self;
         println!("Suite \"{}\":", suite.name);
+        results.sort_by(|x, y| x.case.name.cmp(&y.case.name));
         results.iter().for_each(|x| x.print());
-        println!("{}/{} successful", executed_cases - failed_cases, executed_cases);
+        println!("{}/{} successful", *executed_cases - *failed_cases, executed_cases);
         println!();
     }
 }

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -97,12 +97,12 @@ impl Runner {
     }
 
     /// Run one individual testcase within a testsuite
-    pub fn run_case(&self, config: &suites::Config, case: &Case) -> Report {
+    pub fn run_case(&self, config: &suites::Config, case: &Case) -> CaseResult {
         let canonicalized_path = case.path.clone().canonicalize().unwrap();
         let uri = Url::from_file_path(canonicalized_path).unwrap();
         let input = (uri, case.content().unwrap());
 
-        PartialRun::start(input)
+        PartialRun::start(case.clone(), input)
             .then(config, case, Parse::new("parse"))
             .then(config, case, Lower::new("lower"))
             .then(config, case, Check::new("check"))
@@ -189,6 +189,6 @@ impl SuiteResult {
 //
 
 pub struct CaseResult {
-    case: Case,
-    result: Result<String, Failure>,
+    pub case: Case,
+    pub result: Result<(), Failure>,
 }


### PR DESCRIPTION
Removed the debug functionality and the `Report` type which is no longer necessary. Changes how the results are printed on the command line. Example output:
```console
Suite "fail-check":
    - 005                                      ✓
    - Regression-86                            ✓
    - 002                                      ✓
    - 003                                      ✓
    - 004                                      ✓
    - 001                                      ✓
6/6 successful

Suite "success":
    - Regression-230b                          ✓
    - 015                                      ✓
    - 005                                      ✓
    - 009                                      ✓
    - Regression-137                           ✓
    - Regression-230                           ✓
    - 013                                      ✓
    - 002                                      ✓
    - 014                                      ✓
    - 003                                      ✓
    - 007                                      ✓
    - 008                                      ✓
    - 011                                      ✓
    - 006                                      ✓
    - 012                                      ✓
    - 004                                      ✓
    - 010                                      ✓
    - 001                                      ✓
18/18 successful

Suite "examples":
    - vect                                     ✓
    - ExpressionsCaseStudy                     ✓
    - stlc_bool                                ✓
    - ParigotEncoding                          ✓
    - evalorder                                ✓
    - classical_logic                          ✓
    - absurd                                   ✓
    - example                                  ✓
    - local_matches                            ✓
    - pi                                       ✓
    - FuStumpEncoding                          ✓
    - buffer                                   ✓
    - ChurchEncoding                           ✓
    - stlc                                     ✓
    - colist                                   ✓
    - eq                                       ✓
    - simple                                   ✓
    - ScottEncoding                            ✓
    - strong_existentials                      ✓
    - gadt                                     ✓
    - functor                                  ✓
    - refinement                               ✓
    - boolrep                                  ✓
    - neg_inverse                              ✓
    - motive                                   ✓
    - typedhole                                ✓
    - arith                                    ✓
    - comatches                                ✓
    - Webserver                                ✓
    - setoid                                   ✓
    - covect                                   ✓
    - stream                                   ✓
32/32 successful

Suite "fail-parse":
    - P-001                                    ✗

    Expected failure, got Module { uri: Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/home/david/polarity/polarity/test/suites/fail-parse/P-001.pol", query: None, fragment: None }, items: [] }

    - Regression-underscore-expr               ✓
    - P-003                                    ✓
    - P-002                                    ✓
3/4 successful

Suite "fail-lower":
    - L-002-04                                 ✓
    - L-002-02                                 ✓
    - L-004                                    ✓
    - L-002-05                                 ✓
    - L-002-03                                 ✓
    - L-005                                    ✓
    - L-003                                    ✓
    - L-001                                    ✓
    - L-002-01                                 ✓
9/9 successful

In total: 68/69 successful

```