### PR TITLE
Remove the omit_absurd feature

### DIFF
--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -175,7 +175,7 @@ impl Eval for LocalMatch {
     type Val = Rc<Val>;
 
     fn eval(&self, prg: &Module, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let LocalMatch { name: match_name, on_exp, cases, omit_absurd, .. } = self;
+        let LocalMatch { name: match_name, on_exp, cases, .. } = self;
         let on_exp = on_exp.eval(prg, env)?;
         let cases = cases.eval(prg, env)?;
         match (*on_exp).clone() {
@@ -188,7 +188,6 @@ impl Eval for LocalMatch {
                     name: match_name.to_owned(),
                     on_exp: Rc::new(exp),
                     cases,
-                    omit_absurd: *omit_absurd,
                 }
                 .into(),
             ))),
@@ -201,14 +200,13 @@ impl Eval for LocalComatch {
     type Val = Rc<Val>;
 
     fn eval(&self, prg: &Module, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
         Ok(Rc::new(
             val::LocalComatch {
                 span: *span,
                 name: name.clone(),
                 is_lambda_sugar: *is_lambda_sugar,
                 cases: cases.eval(prg, env)?,
-                omit_absurd: *omit_absurd,
             }
             .into(),
         ))

--- a/lang/elaborator/src/typechecker/decls/codefinition.rs
+++ b/lang/elaborator/src/typechecker/decls/codefinition.rs
@@ -33,7 +33,10 @@ impl CheckToplevel for Codef {
                 n_label_args: params.len(),
                 destructee: typ_nf.expect_typ_app()?,
             };
+
+            wd.check_exhaustiveness(prg)?;
             let cases = wd.infer_wd(prg, ctx)?;
+
             Ok(Codef {
                 span: *span,
                 doc: doc.clone(),

--- a/lang/elaborator/src/typechecker/decls/codefinition.rs
+++ b/lang/elaborator/src/typechecker/decls/codefinition.rs
@@ -22,19 +22,18 @@ impl CheckToplevel for Codef {
     fn check_wf(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         trace!("Checking well-formedness of codefinition: {}", self.name);
 
-        let Codef { span, doc, name, attr, params, typ, cases, omit_absurd } = self;
+        let Codef { span, doc, name, attr, params, typ, cases } = self;
 
         params.infer_telescope(prg, ctx, |ctx, params_out| {
             let typ_out = typ.check(prg, ctx, Rc::new(TypeUniv::new().into()))?;
             let typ_nf = typ.normalize(prg, &mut ctx.env())?;
             let wd = WithDestructee {
                 cases,
-                omit_absurd: *omit_absurd,
                 label: Some(name.to_owned()),
                 n_label_args: params.len(),
                 destructee: typ_nf.expect_typ_app()?,
             };
-            let (cases, omit_absurd) = wd.infer_wd(prg, ctx)?;
+            let cases = wd.infer_wd(prg, ctx)?;
             Ok(Codef {
                 span: *span,
                 doc: doc.clone(),
@@ -43,7 +42,6 @@ impl CheckToplevel for Codef {
                 params: params_out,
                 typ: typ_out,
                 cases,
-                omit_absurd,
             })
         })
     }

--- a/lang/elaborator/src/typechecker/decls/definition.rs
+++ b/lang/elaborator/src/typechecker/decls/definition.rs
@@ -30,8 +30,9 @@ impl CheckToplevel for Def {
                     Ok((ret_typ_out, ret_typ_nf, self_param_out))
                 })?;
 
-            let cases = WithScrutinee { cases, scrutinee: self_param_nf.expect_typ_app()? }
-                .check_ws(prg, ctx, ret_typ_nf)?;
+            let ws = WithScrutinee { cases, scrutinee: self_param_nf.expect_typ_app()? };
+            ws.check_exhaustiveness(prg)?;
+            let cases = ws.check_ws(prg, ctx, ret_typ_nf)?;
             Ok(Def {
                 span: *span,
                 doc: doc.clone(),

--- a/lang/elaborator/src/typechecker/decls/definition.rs
+++ b/lang/elaborator/src/typechecker/decls/definition.rs
@@ -18,7 +18,7 @@ impl CheckToplevel for Def {
     fn check_wf(&self, prg: &Module, ctx: &mut Ctx) -> Result<Self, TypeError> {
         trace!("Checking well-formedness of definition: {}", self.name);
 
-        let Def { span, doc, name, attr, params, self_param, ret_typ, cases, omit_absurd } = self;
+        let Def { span, doc, name, attr, params, self_param, ret_typ, cases } = self;
 
         params.infer_telescope(prg, ctx, |ctx, params_out| {
             let self_param_nf = self_param.typ.normalize(prg, &mut ctx.env())?;
@@ -30,12 +30,8 @@ impl CheckToplevel for Def {
                     Ok((ret_typ_out, ret_typ_nf, self_param_out))
                 })?;
 
-            let (cases, omit_absurd) = WithScrutinee {
-                cases,
-                omit_absurd: *omit_absurd,
-                scrutinee: self_param_nf.expect_typ_app()?,
-            }
-            .check_ws(prg, ctx, ret_typ_nf)?;
+            let cases = WithScrutinee { cases, scrutinee: self_param_nf.expect_typ_app()? }
+                .check_ws(prg, ctx, ret_typ_nf)?;
             Ok(Def {
                 span: *span,
                 doc: doc.clone(),
@@ -45,7 +41,6 @@ impl CheckToplevel for Def {
                 self_param: self_param_out,
                 ret_typ: ret_typ_out,
                 cases,
-                omit_absurd,
             })
         })
     }

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -22,7 +22,7 @@ use crate::result::TypeError;
 
 impl CheckInfer for LocalComatch {
     fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
-        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
         let typ_app_nf = t.expect_typ_app()?;
         let typ_app = typ_app_nf.infer(prg, ctx)?;
 
@@ -35,14 +35,9 @@ impl CheckInfer for LocalComatch {
             });
         }
 
-        let wd = WithDestructee {
-            cases,
-            omit_absurd: *omit_absurd,
-            label: None,
-            n_label_args: 0,
-            destructee: typ_app_nf.clone(),
-        };
-        let (cases, omit_absurd) = wd.infer_wd(prg, ctx)?;
+        let wd =
+            WithDestructee { cases, label: None, n_label_args: 0, destructee: typ_app_nf.clone() };
+        let cases = wd.infer_wd(prg, ctx)?;
 
         Ok(LocalComatch {
             span: *span,
@@ -50,7 +45,6 @@ impl CheckInfer for LocalComatch {
             name: name.clone(),
             is_lambda_sugar: *is_lambda_sugar,
             cases,
-            omit_absurd,
             inferred_type: Some(typ_app),
         })
     }
@@ -62,7 +56,6 @@ impl CheckInfer for LocalComatch {
 
 pub struct WithDestructee<'a> {
     pub cases: &'a Vec<Case>,
-    pub omit_absurd: bool,
     /// Name of the global codefinition that gets substituted for the destructor's self parameters
     pub label: Option<Ident>,
     pub n_label_args: usize,
@@ -71,8 +64,8 @@ pub struct WithDestructee<'a> {
 
 /// Infer a copattern match
 impl<'a> WithDestructee<'a> {
-    pub fn infer_wd(&self, prg: &Module, ctx: &mut Ctx) -> Result<(Vec<Case>, bool), TypeError> {
-        let WithDestructee { cases, omit_absurd, .. } = &self;
+    pub fn infer_wd(&self, prg: &Module, ctx: &mut Ctx) -> Result<Vec<Case>, TypeError> {
+        let WithDestructee { cases, .. } = &self;
 
         // Check that this comatch is on a codata type
         let codata = prg.codata(&self.destructee.name, self.destructee.span())?;
@@ -92,7 +85,7 @@ impl<'a> WithDestructee<'a> {
         let mut dtors_missing = dtors_expected.difference(&dtors_actual).peekable();
         let mut dtors_exessive = dtors_actual.difference(&dtors_expected).peekable();
 
-        if (!omit_absurd && dtors_missing.peek().is_some())
+        if (dtors_missing.peek().is_some())
             || dtors_exessive.peek().is_some()
             || !dtors_duplicate.is_empty()
         {
@@ -105,25 +98,10 @@ impl<'a> WithDestructee<'a> {
         }
 
         // Add absurd cases for all omitted destructors
-        let mut cases: Vec<_> = cases.iter().cloned().map(|case| (case, false)).collect();
-
-        if *omit_absurd {
-            for name in dtors_missing.cloned() {
-                let Dtor { params, .. } = prg.dtor(&name, self.destructee.span)?;
-
-                let case = Case {
-                    span: self.destructee.span(),
-                    name,
-                    params: params.instantiate(),
-                    body: None,
-                };
-                cases.push((case, true));
-            }
-        }
-
+        let cases: Vec<Case> = cases.iter().cloned().collect();
         let mut cases_out = Vec::new();
 
-        for (case, omit) in cases {
+        for case in cases {
             // Build equations for this case
             let Dtor {
                 self_param: SelfParam { typ: TypCtor { args: def_args, .. }, .. },
@@ -183,13 +161,10 @@ impl<'a> WithDestructee<'a> {
 
             // Check the case given the equations
             let case_out = check_cocase(eqns, &case, prg, ctx, ret_typ_nf)?;
-
-            if !omit {
-                cases_out.push(case_out);
-            }
+            cases_out.push(case_out);
         }
 
-        Ok((cases_out, *omit_absurd))
+        Ok(cases_out)
     }
 }
 

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -27,7 +27,7 @@ use crate::result::TypeError;
 
 impl CheckInfer for LocalMatch {
     fn check(&self, prg: &Module, ctx: &mut Ctx, t: Rc<Exp>) -> Result<Self, TypeError> {
-        let LocalMatch { span, name, on_exp, motive, cases, omit_absurd, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, cases, .. } = self;
         let on_exp_out = on_exp.infer(prg, ctx)?;
         let typ_app_nf = on_exp_out
             .typ()
@@ -83,9 +83,8 @@ impl CheckInfer for LocalMatch {
             }
         };
 
-        let (cases, omit_absurd) =
-            WithScrutinee { cases, omit_absurd: *omit_absurd, scrutinee: typ_app_nf.clone() }
-                .check_ws(prg, ctx, body_t)?;
+        let cases =
+            WithScrutinee { cases, scrutinee: typ_app_nf.clone() }.check_ws(prg, ctx, body_t)?;
 
         Ok(LocalMatch {
             span: *span,
@@ -95,7 +94,6 @@ impl CheckInfer for LocalMatch {
             motive: motive_out,
             ret_typ: ret_typ_out.into(),
             cases,
-            omit_absurd,
             inferred_type: Some(typ_app),
         })
     }
@@ -107,7 +105,6 @@ impl CheckInfer for LocalMatch {
 
 pub struct WithScrutinee<'a> {
     pub cases: &'a Vec<Case>,
-    pub omit_absurd: bool,
     pub scrutinee: TypCtor,
 }
 
@@ -118,8 +115,8 @@ impl<'a> WithScrutinee<'a> {
         prg: &Module,
         ctx: &mut Ctx,
         t: Rc<Exp>,
-    ) -> Result<(Vec<Case>, bool), TypeError> {
-        let WithScrutinee { cases, omit_absurd, .. } = &self;
+    ) -> Result<Vec<Case>, TypeError> {
+        let WithScrutinee { cases, .. } = &self;
 
         // Check that this match is on a data type
         let data = prg.data(&self.scrutinee.name, self.scrutinee.span())?;
@@ -138,7 +135,7 @@ impl<'a> WithScrutinee<'a> {
         let mut ctors_missing = ctors_expected.difference(&ctors_actual).peekable();
         let mut ctors_undeclared = ctors_actual.difference(&ctors_expected).peekable();
 
-        if (!omit_absurd && ctors_missing.peek().is_some())
+        if (ctors_missing.peek().is_some())
             || ctors_undeclared.peek().is_some()
             || !ctors_duplicate.is_empty()
         {
@@ -150,26 +147,10 @@ impl<'a> WithScrutinee<'a> {
             ));
         }
 
-        // Add absurd cases for all omitted constructors
-        let mut cases: Vec<_> = cases.iter().cloned().map(|case| (case, false)).collect();
-
-        if *omit_absurd {
-            for name in ctors_missing.cloned() {
-                let Ctor { params, .. } = prg.ctor(&name, self.scrutinee.span())?;
-
-                let case = Case {
-                    span: self.scrutinee.span(),
-                    name,
-                    params: params.instantiate(),
-                    body: None,
-                };
-                cases.push((case, true));
-            }
-        }
-
+        let cases: Vec<_> = cases.iter().cloned().collect();
         let mut cases_out = Vec::new();
 
-        for (case, omit) in cases {
+        for case in cases {
             // Build equations for this case
             let Ctor { typ: TypCtor { args: def_args, .. }, params, .. } =
                 prg.ctor(&case.name, case.span)?;
@@ -189,13 +170,10 @@ impl<'a> WithScrutinee<'a> {
 
             // Check the case given the equations
             let case_out = check_case(eqns, &case, prg, ctx, t.clone())?;
-
-            if !omit {
-                cases_out.push(case_out);
-            }
+            cases_out.push(case_out);
         }
 
-        Ok((cases_out, *omit_absurd))
+        Ok(cases_out)
     }
 }
 

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -181,7 +181,7 @@ impl Lift for Def {
     type Target = Def;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Def { span, doc, name, attr, params, self_param, ret_typ, cases, omit_absurd } = self;
+        let Def { span, doc, name, attr, params, self_param, ret_typ, cases } = self;
 
         params.lift_telescope(ctx, |ctx, params| {
             let (self_param, ret_typ) = self_param.lift_telescope(ctx, |ctx, self_param| {
@@ -198,7 +198,6 @@ impl Lift for Def {
                 self_param,
                 ret_typ,
                 cases: cases.lift(ctx),
-                omit_absurd: *omit_absurd,
             }
         })
     }
@@ -208,7 +207,7 @@ impl Lift for Codef {
     type Target = Codef;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Codef { span, doc, name, attr, params, typ, cases, omit_absurd } = self;
+        let Codef { span, doc, name, attr, params, typ, cases } = self;
 
         params.lift_telescope(ctx, |ctx, params| Codef {
             span: *span,
@@ -218,7 +217,6 @@ impl Lift for Codef {
             params,
             typ: typ.lift(ctx),
             cases: cases.lift(ctx),
-            omit_absurd: *omit_absurd,
         })
     }
 }
@@ -379,17 +377,8 @@ impl Lift for LocalMatch {
     type Target = Exp;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let LocalMatch {
-            span,
-            ctx: type_ctx,
-            name,
-            on_exp,
-            motive,
-            ret_typ,
-            cases,
-            omit_absurd,
-            inferred_type,
-        } = self;
+        let LocalMatch { span, ctx: type_ctx, name, on_exp, motive, ret_typ, cases, inferred_type } =
+            self;
         ctx.lift_match(
             span,
             &inferred_type.clone().unwrap(),
@@ -399,7 +388,6 @@ impl Lift for LocalMatch {
             motive,
             ret_typ,
             cases,
-            omit_absurd,
         )
     }
 }
@@ -408,15 +396,8 @@ impl Lift for LocalComatch {
     type Target = Exp;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let LocalComatch {
-            span,
-            ctx: type_ctx,
-            name,
-            is_lambda_sugar,
-            cases,
-            omit_absurd,
-            inferred_type,
-        } = self;
+        let LocalComatch { span, ctx: type_ctx, name, is_lambda_sugar, cases, inferred_type } =
+            self;
         ctx.lift_comatch(
             span,
             &inferred_type.clone().unwrap(),
@@ -424,7 +405,6 @@ impl Lift for LocalComatch {
             name,
             *is_lambda_sugar,
             cases,
-            omit_absurd,
         )
     }
 }
@@ -542,7 +522,6 @@ impl Ctx {
         motive: &Option<Motive>,
         ret_typ: &Option<Rc<Exp>>,
         cases: &Vec<Case>,
-        omit_absurd: &bool,
     ) -> Exp {
         // Only lift local matches for the specified type
         if inferred_type.name != self.name {
@@ -555,7 +534,6 @@ impl Ctx {
                 motive: motive.lift(self),
                 ret_typ: None,
                 cases: cases.lift(self),
-                omit_absurd: *omit_absurd,
             });
         }
 
@@ -606,7 +584,6 @@ impl Ctx {
             },
             ret_typ: def_ret_typ,
             cases,
-            omit_absurd: *omit_absurd,
         };
 
         self.new_decls.push(Decl::Def(def));
@@ -631,7 +608,6 @@ impl Ctx {
         name: &Label,
         is_lambda_sugar: bool,
         cases: &Vec<Case>,
-        omit_absurd: &bool,
     ) -> Exp {
         // Only lift local matches for the specified type
         if inferred_type.name != self.name {
@@ -641,7 +617,6 @@ impl Ctx {
                 name: name.clone(),
                 is_lambda_sugar,
                 cases: cases.lift(self),
-                omit_absurd: *omit_absurd,
                 inferred_type: None,
             });
         }
@@ -671,7 +646,6 @@ impl Ctx {
             params: telescope,
             typ,
             cases,
-            omit_absurd: *omit_absurd,
         };
 
         self.new_decls.push(Decl::Codef(codef));

--- a/lang/lowering/src/lower/decls.rs
+++ b/lang/lowering/src/lower/decls.rs
@@ -233,17 +233,7 @@ impl Lower for cst::decls::Def {
     type Target = ast::Def;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::decls::Def {
-            span,
-            doc,
-            name,
-            attr,
-            params,
-            scrutinee,
-            ret_typ,
-            cases,
-            omit_absurd,
-        } = self;
+        let cst::decls::Def { span, doc, name, attr, params, scrutinee, ret_typ, cases } = self;
 
         let self_param: cst::decls::SelfParam = scrutinee.clone().into();
 
@@ -259,7 +249,6 @@ impl Lower for cst::decls::Def {
                     self_param,
                     ret_typ: ret_typ.lower(ctx)?,
                     cases,
-                    omit_absurd: *omit_absurd,
                 })
             })
         })
@@ -270,7 +259,7 @@ impl Lower for cst::decls::Codef {
     type Target = ast::Codef;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::decls::Codef { span, doc, name, attr, params, typ, cases, omit_absurd, .. } = self;
+        let cst::decls::Codef { span, doc, name, attr, params, typ, cases, .. } = self;
 
         lower_telescope(params, ctx, |ctx, params| {
             Ok(ast::Codef {
@@ -281,7 +270,6 @@ impl Lower for cst::decls::Codef {
                 params,
                 typ: typ.lower(ctx)?,
                 cases: cases.lower(ctx)?,
-                omit_absurd: *omit_absurd,
             })
         })
     }

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -187,7 +187,7 @@ impl Lower for cst::exp::LocalMatch {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalMatch { span, name, on_exp, motive, cases, omit_absurd } = self;
+        let cst::exp::LocalMatch { span, name, on_exp, motive, cases } = self;
         Ok(ast::LocalMatch {
             span: Some(*span),
             ctx: None,
@@ -196,7 +196,6 @@ impl Lower for cst::exp::LocalMatch {
             motive: motive.lower(ctx)?,
             ret_typ: None,
             cases: cases.lower(ctx)?,
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
         .into())
@@ -207,14 +206,13 @@ impl Lower for cst::exp::LocalComatch {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd } = self;
+        let cst::exp::LocalComatch { span, name, is_lambda_sugar, cases } = self;
         Ok(ast::LocalComatch {
             span: Some(*span),
             ctx: None,
             name: ctx.unique_label(name.to_owned(), span)?,
             is_lambda_sugar: *is_lambda_sugar,
             cases: cases.lower(ctx)?,
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
         .into())
@@ -295,7 +293,6 @@ impl Lower for cst::exp::Lam {
                 ],
                 body: Some(body.clone()),
             }],
-            omit_absurd: false,
         });
         comatch.lower(ctx)
     }

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -145,7 +145,6 @@ pub struct Def {
     pub scrutinee: Scrutinee,
     pub ret_typ: Rc<exp::Exp>,
     pub cases: Vec<exp::Case>,
-    pub omit_absurd: bool,
 }
 
 /// Scrutinee within a toplevel definition
@@ -182,7 +181,6 @@ pub struct Codef {
     pub params: Telescope,
     pub typ: TypApp,
     pub cases: Vec<exp::Case>,
-    pub omit_absurd: bool,
 }
 
 /// Toplevel let-bound expression.

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -68,7 +68,6 @@ pub struct LocalMatch {
     pub on_exp: Rc<Exp>,
     pub motive: Option<Motive>,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -77,7 +76,6 @@ pub struct LocalComatch {
     pub name: Option<Ident>,
     pub is_lambda_sugar: bool,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -30,7 +30,6 @@ extern {
     "as" => Token::As,
     "comatch" => Token::Comatch,
     "absurd" => Token::Absurd,
-    "..absurd" => Token::DotsAbsurd,
     "Type" => Token::Type,
     "implicit" => Token::Implicit,
 
@@ -121,8 +120,6 @@ Attr: String = <s:"LowerCaseName"> => s.to_owned();
 Attributes: Attributes = "#" <attrs: BracketedArgs<Attr>> => Attributes { attrs };
 OptAttributes: Attributes = <attr: Attributes? > => attr.unwrap_or_default();
 
-OmitAbsurd: bool = <absurd: "..absurd"?> => absurd.is_some();
-
 DocCommentHelper: String = <doc: "DocComment"> => doc.strip_prefix("-- |").unwrap().trim().to_owned();
 DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
 
@@ -163,20 +160,16 @@ Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name
   Codata { span: span(l, r), doc, name, attr, params, dtors };
 
 // Toplevel definition
-Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <body: Match> "}" <r: @R> =>
-  Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases: body.0, omit_absurd: body.1 };
+Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+  Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases };
 
 // Toplevel codefinition
-Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <body: Match> "}" <r: @R> =>
-  Codef { span: span(l, r), doc, name, attr, params, typ, cases: body.0, omit_absurd: body.1 };
+Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+  Codef { span: span(l, r), doc, name, attr, params, typ, cases };
 
 // Toplevel let binding
 Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: LowerIdent><params: OptTelescope> ":" <typ: Exp> "{" <body: Exp> "}" <r: @R> =>
   Let { span: span(l,r), doc, name, attr, params, typ, body };
-
-pub Match : (Vec<Case>, bool) = {
-    <cases: Comma<Case>> <omit_absurd: OmitAbsurd> => (cases, omit_absurd),
-}
 
 pub Case : Case = {
     <l: @L> <name: Ident> <params: OptTelescopeInst> <body: AbsurdOrBody> <r: @R> => Case { span: span(l, r), name, params, body },
@@ -258,8 +251,8 @@ Lam: Lam = <l: @L> "\\" <var: BindingSite> "." <body: Exp> <r: @R> =>
 DotCall: DotCall = <l: @L> <exp: Ops> "." <name: Ident> <args: OptArgs> <r: @R> =>
   DotCall { span: span(l, r), exp, name, args };
 
-LocalMatch: LocalMatch = <l: @L> <on_exp: Ops> "." "match" <name: Ident?> <motive: Motive?> "{" <body: Match> "}" <r: @R> =>
-  LocalMatch { span: span(l, r), name, on_exp, motive, cases: body.0, omit_absurd: body.1 };
+LocalMatch: LocalMatch = <l: @L> <on_exp: Ops> "." "match" <name: Ident?> <motive: Motive?> "{" <cases: Comma<Case>> "}" <r: @R> =>
+  LocalMatch { span: span(l, r), name, on_exp, motive, cases };
 
 CallWithArgs: Call = <l: @L> <name: Ident> <args: Args> <r: @R> =>
   Call { span: span(l, r), name, args };
@@ -267,8 +260,8 @@ CallWithArgs: Call = <l: @L> <name: Ident> <args: Args> <r: @R> =>
 CallWithoutArgs: Call = <l: @L> <name: Ident> <r: @R> =>
   Call { span: span(l, r), name, args: vec![] };
 
-LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <body: Match> "}" <r: @R> =>
-  LocalComatch { span: span(l, r), name, is_lambda_sugar: false, cases: body.0, omit_absurd: body.1 };
+LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <cases: Comma<Case>> "}" <r: @R> =>
+  LocalComatch { span: span(l, r), name, is_lambda_sugar: false, cases };
 
 TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>
   TypeUniv { span: span(l, r) };

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -39,8 +39,6 @@ pub enum Token {
     Comatch,
     #[token("absurd")]
     Absurd,
-    #[token("..absurd")]
-    DotsAbsurd,
     #[token("Type")]
     Type,
     #[token("implicit")]

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -115,7 +115,7 @@ impl Rename for Dtor {
 
 impl Rename for Def {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Def { span, doc, name, attr, params, self_param, ret_typ, cases, omit_absurd } = self;
+        let Def { span, doc, name, attr, params, self_param, ret_typ, cases } = self;
 
         let new_params = params.rename_in_ctx(ctx);
         ctx.bind_iter(new_params.params.clone().into_iter(), |new_ctx| {
@@ -133,7 +133,6 @@ impl Rename for Def {
                     self_param: new_self,
                     ret_typ: new_ret,
                     cases: new_cases,
-                    omit_absurd,
                 }
             })
         })
@@ -142,7 +141,7 @@ impl Rename for Def {
 
 impl Rename for Codef {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Codef { span, doc, name, attr, params, typ, cases, omit_absurd } = self;
+        let Codef { span, doc, name, attr, params, typ, cases } = self;
 
         let new_params = params.rename_in_ctx(ctx);
 
@@ -151,16 +150,7 @@ impl Rename for Codef {
 
             let new_cases = cases.rename_in_ctx(new_ctx);
 
-            Codef {
-                span,
-                doc,
-                name,
-                attr,
-                params: new_params,
-                typ: new_typ,
-                cases: new_cases,
-                omit_absurd,
-            }
+            Codef { span, doc, name, attr, params: new_params, typ: new_typ, cases: new_cases }
         })
     }
 }
@@ -311,14 +301,13 @@ impl Rename for Variable {
 
 impl Rename for LocalComatch {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
         LocalComatch {
             span,
             ctx: None,
             name,
             is_lambda_sugar,
             cases: cases.rename_in_ctx(ctx),
-            omit_absurd,
             inferred_type: None,
         }
     }
@@ -338,7 +327,7 @@ impl Rename for Hole {
 }
 impl Rename for LocalMatch {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let LocalMatch { span, name, on_exp, motive, ret_typ, cases, omit_absurd, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, ret_typ, cases, .. } = self;
         LocalMatch {
             span,
             ctx: None,
@@ -347,7 +336,6 @@ impl Rename for LocalMatch {
             motive: motive.rename_in_ctx(ctx),
             ret_typ: ret_typ.rename_in_ctx(ctx),
             cases: cases.rename_in_ctx(ctx),
-            omit_absurd,
             inferred_type: None,
         }
     }

--- a/lang/syntax/src/ast/decls.rs
+++ b/lang/syntax/src/ast/decls.rs
@@ -218,7 +218,6 @@ pub struct Def {
     pub self_param: SelfParam,
     pub ret_typ: Rc<Exp>,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
 }
 
 impl Def {
@@ -247,7 +246,6 @@ pub struct Codef {
     pub params: Telescope,
     pub typ: TypCtor,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
 }
 
 impl Codef {

--- a/lang/syntax/src/ast/exp.rs
+++ b/lang/syntax/src/ast/exp.rs
@@ -641,7 +641,6 @@ pub struct LocalMatch {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub ret_typ: Option<Rc<Exp>>,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub inferred_type: Option<TypCtor>,
 }
@@ -660,7 +659,7 @@ impl From<LocalMatch> for Exp {
 
 impl Shift for LocalMatch {
     fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
-        let LocalMatch { span, name, on_exp, motive, cases, omit_absurd, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, cases, .. } = self;
         LocalMatch {
             span: *span,
             ctx: None,
@@ -669,7 +668,6 @@ impl Shift for LocalMatch {
             motive: motive.shift_in_range(range.clone(), by),
             ret_typ: None,
             cases: cases.shift_in_range(range, by),
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
     }
@@ -691,7 +689,7 @@ impl HasTypeInfo for LocalMatch {
 impl Substitutable for LocalMatch {
     type Result = LocalMatch;
     fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
-        let LocalMatch { span, name, on_exp, motive, ret_typ, cases, omit_absurd, .. } = self;
+        let LocalMatch { span, name, on_exp, motive, ret_typ, cases, .. } = self;
         LocalMatch {
             span: *span,
             ctx: None,
@@ -700,7 +698,6 @@ impl Substitutable for LocalMatch {
             motive: motive.subst(ctx, by),
             ret_typ: ret_typ.subst(ctx, by),
             cases: cases.iter().map(|case| case.subst(ctx, by)).collect(),
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
     }
@@ -720,7 +717,6 @@ pub struct LocalComatch {
     pub name: Label,
     pub is_lambda_sugar: bool,
     pub cases: Vec<Case>,
-    pub omit_absurd: bool,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub inferred_type: Option<TypCtor>,
 }
@@ -739,14 +735,13 @@ impl From<LocalComatch> for Exp {
 
 impl Shift for LocalComatch {
     fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
-        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
         LocalComatch {
             span: *span,
             ctx: None,
             name: name.clone(),
             is_lambda_sugar: *is_lambda_sugar,
             cases: cases.shift_in_range(range, by),
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
     }
@@ -769,14 +764,13 @@ impl Substitutable for LocalComatch {
     type Result = LocalComatch;
 
     fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
-        let LocalComatch { span, name, is_lambda_sugar, cases, omit_absurd, .. } = self;
+        let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
         LocalComatch {
             span: *span,
             ctx: None,
             name: name.clone(),
             is_lambda_sugar: *is_lambda_sugar,
             cases: cases.iter().map(|case| case.subst(ctx, by)).collect(),
-            omit_absurd: *omit_absurd,
             inferred_type: None,
         }
     }

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -237,15 +237,11 @@ impl XData {
         let defs = dtors
             .values()
             .map(|dtor| {
-                let mut omit_absurd = false;
                 let cases = ctors
                     .values()
                     .flat_map(|ctor| {
                         let key = Key { dtor: dtor.name.clone(), ctor: ctor.name.clone() };
                         let body = exprs.get(&key).cloned();
-                        if body.is_none() {
-                            omit_absurd = true;
-                        }
                         body.map(|body| ast::Case {
                             span: None,
                             name: ctor.name.clone(),
@@ -264,7 +260,6 @@ impl XData {
                     self_param: dtor.self_param.clone(),
                     ret_typ: dtor.ret_typ.clone(),
                     cases,
-                    omit_absurd,
                 }
             })
             .collect();
@@ -289,7 +284,6 @@ impl XData {
         let codefs = ctors
             .values()
             .map(|ctor| {
-                let mut omit_absurd = false;
                 let cases = dtors
                     .values()
                     .flat_map(|dtor| {
@@ -304,9 +298,6 @@ impl XData {
                                 })
                             })
                         });
-                        if body.is_none() {
-                            omit_absurd = true;
-                        }
                         body.map(|body| ast::Case {
                             span: None,
                             name: dtor.name.clone(),
@@ -324,7 +315,6 @@ impl XData {
                     params: ctor.params.clone(),
                     typ: ctor.typ.clone(),
                     cases,
-                    omit_absurd,
                 }
             })
             .collect();

--- a/test/suites/success/011.pol
+++ b/test/suites/success/011.pol
@@ -9,5 +9,7 @@ data Foo(b: Bool) {
 
 def Foo(True).foo: Bool {
     Foo1 => True,
-    ..absurd
+    Foo2 absurd,
+    Foo3 absurd,
+    Foo4 absurd,
 }

--- a/test/suites/success/012.pol
+++ b/test/suites/success/012.pol
@@ -9,5 +9,7 @@ codata Foo(b: Bool) {
 
 codef MyFoo: Foo(True) {
     foo1 => True,
-    ..absurd
+    foo2 absurd,
+    foo3 absurd,
+    foo4 absurd
 }


### PR DESCRIPTION
This allows to simplify the implementation of the elaborator for matches and comatches. I have also factored the exhaustiveness checking into separate functions.