### PR TITLE
Refactor local match inference

### DIFF
--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -162,7 +162,7 @@ impl<'a> WithExpectedType<'a> {
                 // this case is really absurd. To do this, we verify that the unification
                 // actually fails.
                 None => {
-                    let case_out = params_inst.check_telescope(
+                    params_inst.check_telescope(
                         prg,
                         name,
                         ctx,
@@ -175,17 +175,19 @@ impl<'a> WithExpectedType<'a> {
                                 })
                                 .ok_no()?;
 
-                            Ok(Case {
+                            let case_out = Case {
                                 span: *span,
                                 name: name.clone(),
                                 params: args_out,
                                 body: None,
-                            })
+                            };
+
+                            cases_out.push(case_out);
+
+                            Ok(())
                         },
                         *span,
                     )?;
-
-                    cases_out.push(case_out);
                 }
                 Some(body) => {
                     // The programmer wrote a non-absurd case. We therefore have to check
@@ -283,7 +285,7 @@ impl<'a> WithExpectedType<'a> {
                     //
                     //
                     // Check the case given the equations
-                    let case_out = params_inst.check_telescope(
+                    params_inst.check_telescope(
                         prg,
                         name,
                         ctx,
@@ -310,17 +312,19 @@ impl<'a> WithExpectedType<'a> {
                                 })?
                             };
 
-                            Ok(Case {
+                            let case_out = Case {
                                 span: *span,
                                 name: name.clone(),
                                 params: args_out,
                                 body: body_out,
-                            })
+                            };
+
+                            cases_out.push(case_out);
+
+                            Ok(())
                         },
                         *span,
                     )?;
-
-                    cases_out.push(case_out);
                 }
             };
         }

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -157,17 +157,17 @@ impl<'a> WithExpectedType<'a> {
                 .map(|(lhs, rhs)| Eqn { lhs, rhs })
                 .collect();
 
-            match body {
-                // The programmer wrote an absurd case. We therefore have to check whether
-                // this case is really absurd. To do this, we verify that the unification
-                // actually fails.
-                None => {
-                    params_inst.check_telescope(
-                        prg,
-                        name,
-                        ctx,
-                        params,
-                        |ctx, args_out| {
+            params_inst.check_telescope(
+                prg,
+                name,
+                ctx,
+                params,
+                |ctx, args_out| {
+                    match body {
+                        // The programmer wrote an absurd case. We therefore have to check whether
+                        // this case is really absurd. To do this, we verify that the unification
+                        // actually fails.
+                        None => {
                             unify(ctx.levels(), &mut ctx.meta_vars, eqns, false)?
                                 .map_yes(|_| TypeError::PatternIsNotAbsurd {
                                     name: name.clone(),
@@ -185,112 +185,99 @@ impl<'a> WithExpectedType<'a> {
                             cases_out.push(case_out);
 
                             Ok(())
-                        },
-                        *span,
-                    )?;
-                }
-                Some(body) => {
-                    // The programmer wrote a non-absurd case. We therefore have to check
-                    // that the unification succeeds.
+                        }
+                        Some(body) => {
+                            // The programmer wrote a non-absurd case. We therefore have to check
+                            // that the unification succeeds.
 
-                    // We compute the return type for that specific cocase.
-                    // E.g. for the following comatch:
-                    // ```text
-                    // codef Ones : Stream(Nat) {
-                    //    hd => 1
-                    //    tl => Ones
-                    // }
-                    // ```
-                    // we compute the types `Nat` resp, `Stream(Nat)` for the respective
-                    // cocases.
-                    let ret_typ_nf = match label {
-                        Some((label, n_label_args)) => {
-                            // We know that we are checking a *global* comatch which can use
-                            // the self parameter in its return type.
-                            // The term that we have to substitute for `self` is:
+                            // We compute the return type for that specific cocase.
+                            // E.g. for the following comatch:
                             // ```text
-                            // C(x, ... x_n)
-                            // ^          ^
-                            // |          \---- n_label_args
-                            // \--------------- label
-                            //
+                            // codef Ones : Stream(Nat) {
+                            //    hd => 1
+                            //    tl => Ones
+                            // }
                             // ```
-                            let args = (0..*n_label_args)
-                                .rev()
-                                .map(|snd| {
-                                    Exp::Variable(Variable {
+                            // we compute the types `Nat` resp, `Stream(Nat)` for the respective
+                            // cocases.
+                            let ret_typ_nf = match label {
+                                Some((label, n_label_args)) => {
+                                    // We know that we are checking a *global* comatch which can use
+                                    // the self parameter in its return type.
+                                    // The term that we have to substitute for `self` is:
+                                    // ```text
+                                    // C(x, ... x_n)
+                                    // ^          ^
+                                    // |          \---- n_label_args
+                                    // \--------------- label
+                                    //
+                                    // ```
+                                    let args = (0..*n_label_args)
+                                        .rev()
+                                        .map(|snd| {
+                                            Exp::Variable(Variable {
+                                                span: None,
+                                                // The field `fst` has to be `2` because we have two surrounding telescopes:
+                                                // - The arguments to the toplevel codefinition
+                                                // - The arguments bound by the destructor copattern.
+                                                idx: Idx { fst: 2, snd },
+                                                name: "".to_owned(),
+                                                inferred_type: None,
+                                            })
+                                        })
+                                        .map(Rc::new)
+                                        .collect();
+                                    let ctor = Rc::new(Exp::Call(Call {
                                         span: None,
-                                        // The field `fst` has to be `2` because we have two surrounding telescopes:
-                                        // - The arguments to the toplevel codefinition
-                                        // - The arguments bound by the destructor copattern.
-                                        idx: Idx { fst: 2, snd },
-                                        name: "".to_owned(),
+                                        kind: CallKind::Codefinition,
+                                        name: label.clone(),
+                                        args: Args { args },
                                         inferred_type: None,
-                                    })
-                                })
-                                .map(Rc::new)
-                                .collect();
-                            let ctor = Rc::new(Exp::Call(Call {
-                                span: None,
-                                kind: CallKind::Codefinition,
-                                name: label.clone(),
-                                args: Args { args },
-                                inferred_type: None,
-                            }));
+                                    }));
 
-                            // Recall that we are in the following situation:
-                            //
-                            // codata T(...) {  (self : T(  σ  )).d( Ξ ) : t, ...}
-                            //                            ^^^^^   ^ ^^^    ^
-                            //                              |     |  |     \------ ret_typ
-                            //                              |     |  \------------ params
-                            //                              |     \--------------- name
-                            //                              \--------------------- def_args
-                            //
-                            // codef C(Δ) { d( Ξ ) => e, ...}
-                            //              ^ ^^^     ^
-                            //              |  |      \------------------------------ body
-                            //              |  \------------------------------------- params_inst
-                            //              \---------------------------------------- name
-                            //
-                            // Note that t is tyed under the following context:
-                            // Ξ;self |- t : Type
-                            // We want to perform the following substitution:
-                            // Δ;Ξ |- [C id_Δ / self]t : Type
-                            // To represent id_Δ, we mentally extend the context by self as follows:
-                            // Δ;Ξ;self |- C id_Δ : Type
-                            // This is why id_Δ = [(2,n), (2, n-1), ..., (2, 0)]
-                            // Since t is defined under context Ξ;self, we
-                            // still substitute for level (1, 0) which corresponds to self under context Ξ;self.
-                            // The result is under context Δ;Ξ;self, which we shift by (-1, 0) to get rid of self
-                            // (which no longer occurs) in [C id_Δ / self]t.
-                            // So we finally have:
-                            // Δ;Ξ |- [C id_Δ / self]t : Type
-                            //
-                            let subst = Assign { lvl: Lvl { fst: 1, snd: 0 }, exp: ctor };
-                            let mut subst_ctx = LevelCtx::from(vec![params.len(), 1]);
-                            ret_typ.subst(&mut subst_ctx, &subst).shift((-1, 0)).normalize(
-                                prg,
-                                &mut LevelCtx::from(vec![*n_label_args, params.len()]).env(),
-                            )?
-                        }
+                                    // Recall that we are in the following situation:
+                                    //
+                                    // codata T(...) {  (self : T(  σ  )).d( Ξ ) : t, ...}
+                                    //                            ^^^^^   ^ ^^^    ^
+                                    //                              |     |  |     \------ ret_typ
+                                    //                              |     |  \------------ params
+                                    //                              |     \--------------- name
+                                    //                              \--------------------- def_args
+                                    //
+                                    // codef C(Δ) { d( Ξ ) => e, ...}
+                                    //              ^ ^^^     ^
+                                    //              |  |      \------------------------------ body
+                                    //              |  \------------------------------------- params_inst
+                                    //              \---------------------------------------- name
+                                    //
+                                    // Note that t is tyed under the following context:
+                                    // Ξ;self |- t : Type
+                                    // We want to perform the following substitution:
+                                    // Δ;Ξ |- [C id_Δ / self]t : Type
+                                    // To represent id_Δ, we mentally extend the context by self as follows:
+                                    // Δ;Ξ;self |- C id_Δ : Type
+                                    // This is why id_Δ = [(2,n), (2, n-1), ..., (2, 0)]
+                                    // Since t is defined under context Ξ;self, we
+                                    // still substitute for level (1, 0) which corresponds to self under context Ξ;self.
+                                    // The result is under context Δ;Ξ;self, which we shift by (-1, 0) to get rid of self
+                                    // (which no longer occurs) in [C id_Δ / self]t.
+                                    // So we finally have:
+                                    // Δ;Ξ |- [C id_Δ / self]t : Type
+                                    //
+                                    let subst = Assign { lvl: Lvl { fst: 1, snd: 0 }, exp: ctor };
+                                    let mut subst_ctx = LevelCtx::from(vec![params.len(), 1]);
+                                    ret_typ.subst(&mut subst_ctx, &subst).shift((-1, 0)).normalize(
+                                        prg,
+                                        &mut LevelCtx::from(vec![*n_label_args, params.len()])
+                                            .env(),
+                                    )?
+                                }
 
-                        None => {
-                            // TODO: Self parameter for local comatches
-                            ret_typ.shift((-1, 0))
-                        }
-                    };
-
-                    // TODO: Document what is happening here:
-                    //
-                    //
-                    // Check the case given the equations
-                    params_inst.check_telescope(
-                        prg,
-                        name,
-                        ctx,
-                        params,
-                        |ctx, args_out| {
+                                None => {
+                                    // TODO: Self parameter for local comatches
+                                    ret_typ.shift((-1, 0))
+                                }
+                            };
                             let body_out = {
                                 let unif = unify(ctx.levels(), &mut ctx.meta_vars, eqns, false)?
                                     .map_no(|()| TypeError::PatternIsAbsurd {
@@ -322,11 +309,11 @@ impl<'a> WithExpectedType<'a> {
                             cases_out.push(case_out);
 
                             Ok(())
-                        },
-                        *span,
-                    )?;
-                }
-            };
+                        }
+                    }
+                },
+                *span,
+            )?;
         }
 
         Ok(cases_out)

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -142,27 +142,27 @@ impl<'a> WithExpectedType<'a> {
             let ret_typ =
                 ret_typ.normalize(prg, &mut LevelCtx::from(vec![params.len(), 1]).env())?;
 
-            // We have to check whether we have an absurd case or an ordinary case.
-            // To do this we have solve the following unification problem:
-            //
-            //               T(...) =? T(...)
-            //                 ^^^       ^^^
-            //                  |         \----------------------- on_args
-            //                  \--------------------------------- def_args
-            //
-            let eqns: Vec<_> = def_args
-                .iter()
-                .cloned()
-                .zip(on_args.args.iter().cloned())
-                .map(|(lhs, rhs)| Eqn { lhs, rhs })
-                .collect();
-
             params_inst.check_telescope(
                 prg,
                 name,
                 ctx,
                 params,
                 |ctx, args_out| {
+                    // We have to check whether we have an absurd case or an ordinary case.
+                    // To do this we have solve the following unification problem:
+                    //
+                    //               T(...) =? T(...)
+                    //                 ^^^       ^^^
+                    //                  |         \----------------------- on_args
+                    //                  \--------------------------------- def_args
+                    //
+                    let eqns: Vec<_> = def_args
+                        .iter()
+                        .cloned()
+                        .zip(on_args.args.iter().cloned())
+                        .map(|(lhs, rhs)| Eqn { lhs, rhs })
+                        .collect();
+
                     match body {
                         // The programmer wrote an absurd case. We therefore have to check whether
                         // this case is really absurd. To do this, we verify that the unification

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -2,10 +2,6 @@
 
 use std::rc::Rc;
 
-use log::trace;
-
-use printer::types::Print;
-
 use crate::normalizer::env::ToEnv;
 use crate::normalizer::normalize::Normalize;
 use crate::typechecker::exprs::CheckTelescope;
@@ -157,9 +153,10 @@ impl<'a> WithScrutinee<'a> {
         let mut cases_out = Vec::new();
 
         for case in cases {
+            let Case { span, name, params: args, body } = case;
             // Build equations for this case
-            let Ctor { typ: TypCtor { args: def_args, .. }, params, .. } =
-                prg.ctor(&case.name, case.span)?;
+            let Ctor { name, typ: TypCtor { args: def_args, .. }, params, .. } =
+                prg.ctor(&name, span)?;
 
             let def_args_nf = LevelCtx::empty()
                 .bind_iter(params.params.iter(), |ctx| def_args.normalize(prg, &mut ctx.env()))?;
@@ -175,106 +172,89 @@ impl<'a> WithScrutinee<'a> {
                 .collect();
 
             // Check the case given the equations
-            let case_out = check_case(eqns, &case, prg, ctx, t.clone())?;
+            let case_out = {
+                // FIXME: Refactor this
+                let mut subst_ctx_1 = ctx.levels().append(&vec![1, params.len()].into());
+                let mut subst_ctx_2 = ctx.levels().append(&vec![params.len(), 1].into());
+                let curr_lvl = subst_ctx_2.len() - 1;
+
+                args.check_telescope(
+                    prg,
+                    name,
+                    ctx,
+                    params,
+                    |ctx, args_out| {
+                        // Substitute the constructor for the self parameter
+                        let args = (0..params.len())
+                            .rev()
+                            .map(|snd| {
+                                Exp::Variable(Variable {
+                                    span: None,
+                                    idx: Idx { fst: 1, snd },
+                                    name: "".to_owned(),
+                                    inferred_type: None,
+                                })
+                            })
+                            .map(Rc::new)
+                            .collect();
+                        let ctor = Rc::new(Exp::Call(Call {
+                            span: None,
+                            kind: CallKind::Constructor,
+                            name: name.clone(),
+                            args: Args { args },
+                            inferred_type: None,
+                        }));
+                        let subst = Assign { lvl: Lvl { fst: curr_lvl, snd: 0 }, exp: ctor };
+
+                        // FIXME: Refactor this
+                        let t = t
+                            .shift((1, 0))
+                            .swap_with_ctx(&mut subst_ctx_1, curr_lvl, curr_lvl - 1)
+                            .subst(&mut subst_ctx_2, &subst)
+                            .shift((-1, 0));
+
+                        let body_out = match body {
+                            Some(body) => {
+                                let unif =
+                                    unify(ctx.levels(), &mut ctx.meta_vars, eqns.clone(), false)?
+                                        .map_no(|()| TypeError::PatternIsAbsurd {
+                                            name: name.clone(),
+                                            span: span.to_miette(),
+                                        })
+                                        .ok_yes()?;
+
+                                ctx.fork::<Result<_, TypeError>, _>(|ctx| {
+                                    ctx.subst(prg, &unif)?;
+                                    let body = body.subst(&mut ctx.levels(), &unif);
+
+                                    let t_subst = t.subst(&mut ctx.levels(), &unif);
+                                    let t_nf = t_subst.normalize(prg, &mut ctx.env())?;
+
+                                    let body_out = body.check(prg, ctx, t_nf)?;
+
+                                    Ok(Some(body_out))
+                                })?
+                            }
+                            None => {
+                                unify(ctx.levels(), &mut ctx.meta_vars, eqns.clone(), false)?
+                                    .map_yes(|_| TypeError::PatternIsNotAbsurd {
+                                        name: name.clone(),
+                                        span: span.to_miette(),
+                                    })
+                                    .ok_no()?;
+
+                                None
+                            }
+                        };
+
+                        Ok(Case { span, name: name.clone(), params: args_out, body: body_out })
+                    },
+                    span,
+                )
+            }?;
             cases_out.push(case_out);
         }
 
         Ok(cases_out)
     }
-}
-
-/// Infer a case in a pattern match
-fn check_case(
-    eqns: Vec<Eqn>,
-    case: &Case,
-    prg: &Module,
-    ctx: &mut Ctx,
-    t: Rc<Exp>,
-) -> Result<Case, TypeError> {
-    trace!(
-        "{} |- {} <= {}",
-        ctx.print_to_colored_string(None),
-        case.print_to_colored_string(None),
-        t.print_to_colored_string(None)
-    );
-    let Case { span, name, params: args, body } = case;
-    let Ctor { name, params, .. } = prg.ctor(name, *span)?;
-
-    // FIXME: Refactor this
-    let mut subst_ctx_1 = ctx.levels().append(&vec![1, params.len()].into());
-    let mut subst_ctx_2 = ctx.levels().append(&vec![params.len(), 1].into());
-    let curr_lvl = subst_ctx_2.len() - 1;
-
-    args.check_telescope(
-        prg,
-        name,
-        ctx,
-        params,
-        |ctx, args_out| {
-            // Substitute the constructor for the self parameter
-            let args = (0..params.len())
-                .rev()
-                .map(|snd| {
-                    Exp::Variable(Variable {
-                        span: None,
-                        idx: Idx { fst: 1, snd },
-                        name: "".to_owned(),
-                        inferred_type: None,
-                    })
-                })
-                .map(Rc::new)
-                .collect();
-            let ctor = Rc::new(Exp::Call(Call {
-                span: None,
-                kind: CallKind::Constructor,
-                name: name.clone(),
-                args: Args { args },
-                inferred_type: None,
-            }));
-            let subst = Assign { lvl: Lvl { fst: curr_lvl, snd: 0 }, exp: ctor };
-
-            // FIXME: Refactor this
-            let t = t
-                .shift((1, 0))
-                .swap_with_ctx(&mut subst_ctx_1, curr_lvl, curr_lvl - 1)
-                .subst(&mut subst_ctx_2, &subst)
-                .shift((-1, 0));
-
-            let body_out = match body {
-                Some(body) => {
-                    let unif = unify(ctx.levels(), &mut ctx.meta_vars, eqns.clone(), false)?
-                        .map_no(|()| TypeError::PatternIsAbsurd {
-                            name: name.clone(),
-                            span: span.to_miette(),
-                        })
-                        .ok_yes()?;
-
-                    ctx.fork::<Result<_, TypeError>, _>(|ctx| {
-                        ctx.subst(prg, &unif)?;
-                        let body = body.subst(&mut ctx.levels(), &unif);
-
-                        let t_subst = t.subst(&mut ctx.levels(), &unif);
-                        let t_nf = t_subst.normalize(prg, &mut ctx.env())?;
-
-                        let body_out = body.check(prg, ctx, t_nf)?;
-
-                        Ok(Some(body_out))
-                    })?
-                }
-                None => {
-                    unify(ctx.levels(), &mut ctx.meta_vars, eqns.clone(), false)?
-                        .map_yes(|_| TypeError::PatternIsNotAbsurd {
-                            name: name.clone(),
-                            span: span.to_miette(),
-                        })
-                        .ok_no()?;
-
-                    None
-                }
-            };
-
-            Ok(Case { span: *span, name: name.clone(), params: args_out, body: body_out })
-        },
-        *span,
-    )
 }


### PR DESCRIPTION
Here is the background for this PR: Unification is currently implemented in a way that is subtly wrong, and that will definitely break in the future when we extend it. The problem is that the unification algorithm assumes that there is only one `LevelCtx` which is valid for all constraints. What we should do instead is to make the `LevelCtx` part of each individual constraint. In order to do this we have to move the generation of the constraints in the inference of the `local_match` and `local_comatch` functions syntactically close to the call of `unify(...)` , and essentially under the context extension `check_telescope`, so that we can correctly annotate the constraints with the correct context in the future.