### PR TITLE
Refactor constraints

### DIFF
--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -161,7 +161,7 @@ impl<'a> WithExpectedType<'a> {
                         .iter()
                         .cloned()
                         .zip(on_args.args.iter().cloned())
-                        .map(|(lhs, rhs)| Constraint { lhs, rhs })
+                        .map(|(lhs, rhs)| Constraint::Equality { lhs, rhs })
                         .collect();
 
                     match body {

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use crate::normalizer::env::ToEnv;
 use crate::normalizer::normalize::Normalize;
 use crate::typechecker::exprs::CheckTelescope;
+use crate::unifier::constraints::Constraint;
 use crate::unifier::unify::*;
 use miette_util::ToMiette;
 use syntax::ast::*;
@@ -160,7 +161,7 @@ impl<'a> WithExpectedType<'a> {
                         .iter()
                         .cloned()
                         .zip(on_args.args.iter().cloned())
-                        .map(|(lhs, rhs)| Eqn { lhs, rhs })
+                        .map(|(lhs, rhs)| Constraint { lhs, rhs })
                         .collect();
 
                     match body {

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -210,7 +210,7 @@ impl<'a> WithScrutinee<'a> {
                         .iter()
                         .cloned()
                         .zip(on_args.args.iter().cloned())
-                        .map(|(lhs, rhs)| Constraint { lhs, rhs })
+                        .map(|(lhs, rhs)| Constraint::Equality { lhs, rhs })
                         .collect();
 
                     let body_out = match body {

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use crate::normalizer::env::ToEnv;
 use crate::normalizer::normalize::Normalize;
 use crate::typechecker::exprs::CheckTelescope;
+use crate::unifier::constraints::Constraint;
 use crate::unifier::unify::*;
 use miette_util::ToMiette;
 use syntax::ast::*;
@@ -209,7 +210,7 @@ impl<'a> WithScrutinee<'a> {
                         .iter()
                         .cloned()
                         .zip(on_args.args.iter().cloned())
-                        .map(|(lhs, rhs)| Eqn { lhs, rhs })
+                        .map(|(lhs, rhs)| Constraint { lhs, rhs })
                         .collect();
 
                     let body_out = match body {

--- a/lang/elaborator/src/typechecker/util.rs
+++ b/lang/elaborator/src/typechecker/util.rs
@@ -29,9 +29,8 @@ pub fn convert(
 ) -> Result<(), TypeError> {
     trace!("{} =? {}", this.print_to_colored_string(None), other.print_to_colored_string(None));
     // Convertibility is checked using the unification algorithm.
-    let eqn: Constraint = Constraint::Equality { lhs: this.clone(), rhs: other.clone() };
-    let eqns: Vec<Constraint> = vec![eqn];
-    let res = unify(ctx, meta_vars, eqns, true)?;
+    let constraint: Constraint = Constraint::Equality { lhs: this.clone(), rhs: other.clone() };
+    let res = unify(ctx, meta_vars, constraint, true)?;
     match res {
         crate::unifier::dec::Dec::Yes(_) => Ok(()),
         crate::unifier::dec::Dec::No(_) => Err(TypeError::not_eq(this.clone(), other.clone())),

--- a/lang/elaborator/src/typechecker/util.rs
+++ b/lang/elaborator/src/typechecker/util.rs
@@ -29,7 +29,7 @@ pub fn convert(
 ) -> Result<(), TypeError> {
     trace!("{} =? {}", this.print_to_colored_string(None), other.print_to_colored_string(None));
     // Convertibility is checked using the unification algorithm.
-    let eqn: Constraint = Constraint { lhs: this.clone(), rhs: other.clone() };
+    let eqn: Constraint = Constraint::Equality { lhs: this.clone(), rhs: other.clone() };
     let eqns: Vec<Constraint> = vec![eqn];
     let res = unify(ctx, meta_vars, eqns, true)?;
     match res {

--- a/lang/elaborator/src/typechecker/util.rs
+++ b/lang/elaborator/src/typechecker/util.rs
@@ -5,7 +5,7 @@ use log::trace;
 use printer::types::Print;
 use syntax::{ast::*, ctx::LevelCtx};
 
-use crate::unifier::unify::{unify, Eqn};
+use crate::unifier::{constraints::Constraint, unify::unify};
 
 use super::TypeError;
 
@@ -29,8 +29,8 @@ pub fn convert(
 ) -> Result<(), TypeError> {
     trace!("{} =? {}", this.print_to_colored_string(None), other.print_to_colored_string(None));
     // Convertibility is checked using the unification algorithm.
-    let eqn: Eqn = Eqn { lhs: this.clone(), rhs: other.clone() };
-    let eqns: Vec<Eqn> = vec![eqn];
+    let eqn: Constraint = Constraint { lhs: this.clone(), rhs: other.clone() };
+    let eqns: Vec<Constraint> = vec![eqn];
     let res = unify(ctx, meta_vars, eqns, true)?;
     match res {
         crate::unifier::dec::Dec::Yes(_) => Ok(()),

--- a/lang/elaborator/src/unifier/constraints.rs
+++ b/lang/elaborator/src/unifier/constraints.rs
@@ -1,12 +1,16 @@
-//! This module defines the language of constraints that can be solve by the constraint solver.
+//! This module defines the language of constraints that can be solved by the constraint solver.
 use std::rc::Rc;
 
 use printer::Print;
-use syntax::ast::Exp;
+use syntax::ast::{Args, Exp};
 
+/// A constraint that can be solved by the constraint solver.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Constraint {
+    /// An equality constraint between two expressions.
     Equality { lhs: Rc<Exp>, rhs: Rc<Exp> },
+    /// An equality constraint between two argument lists.
+    EqualityArgs { lhs: Args, rhs: Args },
 }
 
 impl Print for Constraint {
@@ -17,6 +21,9 @@ impl Print for Constraint {
     ) -> printer::Builder<'a> {
         match self {
             Constraint::Equality { lhs, rhs } => {
+                lhs.print(cfg, alloc).append(" = ").append(rhs.print(cfg, alloc))
+            }
+            Constraint::EqualityArgs { lhs, rhs } => {
                 lhs.print(cfg, alloc).append(" = ").append(rhs.print(cfg, alloc))
             }
         }

--- a/lang/elaborator/src/unifier/constraints.rs
+++ b/lang/elaborator/src/unifier/constraints.rs
@@ -1,12 +1,12 @@
+//! This module defines the language of constraints that can be solve by the constraint solver.
 use std::rc::Rc;
 
 use printer::Print;
 use syntax::ast::Exp;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Constraint {
-    pub lhs: Rc<Exp>,
-    pub rhs: Rc<Exp>,
+pub enum Constraint {
+    Equality { lhs: Rc<Exp>, rhs: Rc<Exp> },
 }
 
 impl Print for Constraint {
@@ -15,7 +15,10 @@ impl Print for Constraint {
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
-        self.lhs.print(cfg, alloc).append(" = ").append(self.rhs.print(cfg, alloc))
+        match self {
+            Constraint::Equality { lhs, rhs } => {
+                lhs.print(cfg, alloc).append(" = ").append(rhs.print(cfg, alloc))
+            }
+        }
     }
 }
-

--- a/lang/elaborator/src/unifier/constraints.rs
+++ b/lang/elaborator/src/unifier/constraints.rs
@@ -1,0 +1,21 @@
+use std::rc::Rc;
+
+use printer::Print;
+use syntax::ast::Exp;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Constraint {
+    pub lhs: Rc<Exp>,
+    pub rhs: Rc<Exp>,
+}
+
+impl Print for Constraint {
+    fn print<'a>(
+        &'a self,
+        cfg: &printer::PrintCfg,
+        alloc: &'a printer::Alloc<'a>,
+    ) -> printer::Builder<'a> {
+        self.lhs.print(cfg, alloc).append(" = ").append(self.rhs.print(cfg, alloc))
+    }
+}
+

--- a/lang/elaborator/src/unifier/mod.rs
+++ b/lang/elaborator/src/unifier/mod.rs
@@ -1,3 +1,3 @@
+pub mod constraints;
 pub mod dec;
 pub mod unify;
-pub mod constraints;

--- a/lang/elaborator/src/unifier/mod.rs
+++ b/lang/elaborator/src/unifier/mod.rs
@@ -1,2 +1,3 @@
 pub mod dec;
 pub mod unify;
+pub mod constraints;

--- a/lang/elaborator/src/unifier/unify.rs
+++ b/lang/elaborator/src/unifier/unify.rs
@@ -55,10 +55,10 @@ impl Unificator {
 pub fn unify(
     ctx: LevelCtx,
     meta_vars: &mut HashMap<MetaVar, MetaVarState>,
-    eqns: Vec<Constraint>,
+    constraint: Constraint,
     vars_are_rigid: bool,
 ) -> Result<Dec<Unificator>, TypeError> {
-    let mut ctx = Ctx::new(eqns.clone(), ctx.clone(), vars_are_rigid);
+    let mut ctx = Ctx::new(vec![constraint], ctx.clone(), vars_are_rigid);
     let res = match ctx.unify(meta_vars)? {
         Yes(_) => Yes(ctx.unif),
         No(()) => No(()),
@@ -68,7 +68,7 @@ pub fn unify(
 
 struct Ctx {
     /// Constraints that have not yet been solved
-    eqns: Vec<Constraint>,
+    constraints: Vec<Constraint>,
     /// A cache of solved constraints. We can skip solving a constraint
     /// if we have seen it before
     done: HashSet<Constraint>,
@@ -103,15 +103,21 @@ fn is_solvable(h: &Hole) -> bool {
 }
 
 impl Ctx {
-    fn new(eqns: Vec<Constraint>, ctx: LevelCtx, vars_are_rigid: bool) -> Self {
-        Self { eqns, done: HashSet::default(), ctx, unif: Unificator::empty(), vars_are_rigid }
+    fn new(constraints: Vec<Constraint>, ctx: LevelCtx, vars_are_rigid: bool) -> Self {
+        Self {
+            constraints,
+            done: HashSet::default(),
+            ctx,
+            unif: Unificator::empty(),
+            vars_are_rigid,
+        }
     }
 
     fn unify(&mut self, meta_vars: &mut HashMap<MetaVar, MetaVarState>) -> Result<Dec, TypeError> {
-        while let Some(eqn) = self.eqns.pop() {
-            match self.unify_eqn(&eqn, meta_vars)? {
+        while let Some(constraint) = self.constraints.pop() {
+            match self.unify_eqn(&constraint, meta_vars)? {
                 Yes(_) => {
-                    self.done.insert(eqn);
+                    self.done.insert(constraint);
                 }
                 No(_) => return Ok(No(())),
             }
@@ -125,103 +131,118 @@ impl Ctx {
         eqn: &Constraint,
         meta_vars: &mut HashMap<MetaVar, MetaVarState>,
     ) -> Result<Dec, TypeError> {
-        let Constraint::Equality { lhs, rhs, .. } = eqn;
-
-        match (&**lhs, &**rhs) {
-            (Exp::Hole(h), e) | (e, Exp::Hole(h)) if self.vars_are_rigid => {
-                let metavar_state = meta_vars.get(&h.metavar).unwrap();
-                match metavar_state {
-                    MetaVarState::Solved { ctx, solution } => {
-                        let lhs = solution.clone().subst(&mut ctx.clone(), &h.args);
-                        self.add_equation(Constraint::Equality { lhs, rhs: Rc::new(e.clone()) })?;
-                    }
-                    MetaVarState::Unsolved { ctx } => {
-                        if is_solvable(h) {
-                            meta_vars.insert(
-                                h.metavar,
-                                MetaVarState::Solved {
-                                    ctx: ctx.clone(),
-                                    solution: Rc::new(e.clone()),
-                                },
-                            );
-                        } else {
-                            return Err(TypeError::cannot_decide(
-                                Rc::new(Exp::Hole(h.clone())),
-                                Rc::new(e.clone()),
-                            ));
+        match eqn {
+            Constraint::Equality { lhs, rhs, .. } => match (&**lhs, &**rhs) {
+                (Exp::Hole(h), e) | (e, Exp::Hole(h)) if self.vars_are_rigid => {
+                    let metavar_state = meta_vars.get(&h.metavar).unwrap();
+                    match metavar_state {
+                        MetaVarState::Solved { ctx, solution } => {
+                            let lhs = solution.clone().subst(&mut ctx.clone(), &h.args);
+                            self.add_constraint(Constraint::Equality {
+                                lhs,
+                                rhs: Rc::new(e.clone()),
+                            })?;
+                        }
+                        MetaVarState::Unsolved { ctx } => {
+                            if is_solvable(h) {
+                                meta_vars.insert(
+                                    h.metavar,
+                                    MetaVarState::Solved {
+                                        ctx: ctx.clone(),
+                                        solution: Rc::new(e.clone()),
+                                    },
+                                );
+                            } else {
+                                return Err(TypeError::cannot_decide(
+                                    Rc::new(Exp::Hole(h.clone())),
+                                    Rc::new(e.clone()),
+                                ));
+                            }
                         }
                     }
-                }
 
+                    Ok(Yes(()))
+                }
+                (
+                    Exp::Variable(Variable { idx: idx_1, .. }),
+                    Exp::Variable(Variable { idx: idx_2, .. }),
+                ) => {
+                    if idx_1 == idx_2 {
+                        Ok(Yes(()))
+                    } else if self.vars_are_rigid {
+                        Ok(No(()))
+                    } else {
+                        self.add_assignment(*idx_1, rhs.clone())
+                    }
+                }
+                (Exp::Variable(Variable { idx, .. }), _) => {
+                    if self.vars_are_rigid {
+                        Ok(No(()))
+                    } else {
+                        self.add_assignment(*idx, rhs.clone())
+                    }
+                }
+                (_, Exp::Variable(Variable { idx, .. })) => {
+                    if self.vars_are_rigid {
+                        Ok(No(()))
+                    } else {
+                        self.add_assignment(*idx, lhs.clone())
+                    }
+                }
+                (
+                    Exp::TypCtor(TypCtor { name, args, .. }),
+                    Exp::TypCtor(TypCtor { name: name2, args: args2, .. }),
+                ) if name == name2 => {
+                    let constraint =
+                        Constraint::EqualityArgs { lhs: args.clone(), rhs: args2.clone() };
+                    self.add_constraint(constraint)
+                }
+                (Exp::TypCtor(TypCtor { name, .. }), Exp::TypCtor(TypCtor { name: name2, .. }))
+                    if name != name2 =>
+                {
+                    Ok(No(()))
+                }
+                (
+                    Exp::Call(Call { name, args, .. }),
+                    Exp::Call(Call { name: name2, args: args2, .. }),
+                ) if name == name2 => {
+                    let constraint =
+                        Constraint::EqualityArgs { lhs: args.clone(), rhs: args2.clone() };
+                    self.add_constraint(constraint)
+                }
+                (Exp::Call(Call { name, .. }), Exp::Call(Call { name: name2, .. }))
+                    if name != name2 =>
+                {
+                    Ok(No(()))
+                }
+                (
+                    Exp::DotCall(DotCall { exp, name, args, .. }),
+                    Exp::DotCall(DotCall { exp: exp2, name: name2, args: args2, .. }),
+                ) if name == name2 => {
+                    self.add_constraint(Constraint::Equality {
+                        lhs: exp.clone(),
+                        rhs: exp2.clone(),
+                    })?;
+                    let constraint =
+                        Constraint::EqualityArgs { lhs: args.clone(), rhs: args2.clone() };
+                    self.add_constraint(constraint)
+                }
+                (Exp::TypeUniv(_), Exp::TypeUniv(_)) => Ok(Yes(())),
+                (Exp::Anno(_), _) => Err(TypeError::unsupported_annotation(lhs.clone())),
+                (_, Exp::Anno(_)) => Err(TypeError::unsupported_annotation(rhs.clone())),
+                (_, _) => Err(TypeError::cannot_decide(lhs.clone(), rhs.clone())),
+            },
+            Constraint::EqualityArgs { lhs, rhs } => {
+                let new_eqns = lhs
+                    .args
+                    .iter()
+                    .cloned()
+                    .zip(rhs.args.iter().cloned())
+                    .map(|(lhs, rhs)| Constraint::Equality { lhs, rhs });
+                self.add_constraints(new_eqns)?;
                 Ok(Yes(()))
             }
-            (
-                Exp::Variable(Variable { idx: idx_1, .. }),
-                Exp::Variable(Variable { idx: idx_2, .. }),
-            ) => {
-                if idx_1 == idx_2 {
-                    Ok(Yes(()))
-                } else if self.vars_are_rigid {
-                    Ok(No(()))
-                } else {
-                    self.add_assignment(*idx_1, rhs.clone())
-                }
-            }
-            (Exp::Variable(Variable { idx, .. }), _) => {
-                if self.vars_are_rigid {
-                    Ok(No(()))
-                } else {
-                    self.add_assignment(*idx, rhs.clone())
-                }
-            }
-            (_, Exp::Variable(Variable { idx, .. })) => {
-                if self.vars_are_rigid {
-                    Ok(No(()))
-                } else {
-                    self.add_assignment(*idx, lhs.clone())
-                }
-            }
-            (
-                Exp::TypCtor(TypCtor { name, args, .. }),
-                Exp::TypCtor(TypCtor { name: name2, args: args2, .. }),
-            ) if name == name2 => self.unify_args(args, args2),
-            (Exp::TypCtor(TypCtor { name, .. }), Exp::TypCtor(TypCtor { name: name2, .. }))
-                if name != name2 =>
-            {
-                Ok(No(()))
-            }
-            (
-                Exp::Call(Call { name, args, .. }),
-                Exp::Call(Call { name: name2, args: args2, .. }),
-            ) if name == name2 => self.unify_args(args, args2),
-            (Exp::Call(Call { name, .. }), Exp::Call(Call { name: name2, .. }))
-                if name != name2 =>
-            {
-                Ok(No(()))
-            }
-            (
-                Exp::DotCall(DotCall { exp, name, args, .. }),
-                Exp::DotCall(DotCall { exp: exp2, name: name2, args: args2, .. }),
-            ) if name == name2 => {
-                self.add_equation(Constraint::Equality { lhs: exp.clone(), rhs: exp2.clone() })?;
-                self.unify_args(args, args2)
-            }
-            (Exp::TypeUniv(_), Exp::TypeUniv(_)) => Ok(Yes(())),
-            (Exp::Anno(_), _) => Err(TypeError::unsupported_annotation(lhs.clone())),
-            (_, Exp::Anno(_)) => Err(TypeError::unsupported_annotation(rhs.clone())),
-            (_, _) => Err(TypeError::cannot_decide(lhs.clone(), rhs.clone())),
         }
-    }
-
-    fn unify_args(&mut self, lhs: &Args, rhs: &Args) -> Result<Dec, TypeError> {
-        let new_eqns = lhs
-            .args
-            .iter()
-            .cloned()
-            .zip(rhs.args.iter().cloned())
-            .map(|(lhs, rhs)| Constraint::Equality { lhs, rhs });
-        self.add_equations(new_eqns)?;
-        Ok(Yes(()))
     }
 
     fn add_assignment(&mut self, idx: Idx, exp: Rc<Exp>) -> Result<Dec, TypeError> {
@@ -234,7 +255,7 @@ impl Ctx {
         match self.unif.map.get(&insert_lvl) {
             Some(other_exp) => {
                 let eqn = Constraint::Equality { lhs: exp, rhs: other_exp.clone() };
-                self.add_equation(eqn)
+                self.add_constraint(eqn)
             }
             None => {
                 self.unif.map.insert(insert_lvl, exp);
@@ -243,15 +264,15 @@ impl Ctx {
         }
     }
 
-    fn add_equation(&mut self, eqn: Constraint) -> Result<Dec, TypeError> {
-        self.add_equations([eqn])
+    fn add_constraint(&mut self, eqn: Constraint) -> Result<Dec, TypeError> {
+        self.add_constraints([eqn])
     }
 
-    fn add_equations<I: IntoIterator<Item = Constraint>>(
+    fn add_constraints<I: IntoIterator<Item = Constraint>>(
         &mut self,
         iter: I,
     ) -> Result<Dec, TypeError> {
-        self.eqns.extend(iter.into_iter().filter(|eqn| !self.done.contains(eqn)));
+        self.constraints.extend(iter.into_iter().filter(|eqn| !self.done.contains(eqn)));
         Ok(Yes(()))
     }
 }


### PR DESCRIPTION
The main difference is that we go from:

```rust
pub struct Eqn {
    pub lhs: Rc<Exp>,
    pub rhs: Rc<Exp>,
}
```
to
```rust

/// A constraint that can be solved by the constraint solver.
#[derive(Debug, Clone, Eq, PartialEq, Hash)]
pub enum Constraint {
    /// An equality constraint between two expressions.
    Equality { lhs: Rc<Exp>, rhs: Rc<Exp> },
    /// An equality constraint between two argument lists.
    EqualityArgs { lhs: Args, rhs: Args },
}
```

The motivation is that once we have made the `LevelCtx` a part of `Constraint`, we will have the following function invariant:

- If `unify(constraint) = Some(substitution)`, then the domain of the substitution is a subset of the LevelCtx of the constraint.

In order to express this invariant we are only allowed to pass exactly one constraint to `unify`, and we therefore need to have this `EqualityArgs` constraint which stands for a set of constraints.