### PR TITLE
Make level context consistent with other contexts

### DIFF
--- a/lang/elaborator/src/normalizer/env.rs
+++ b/lang/elaborator/src/normalizer/env.rs
@@ -108,10 +108,10 @@ impl ToEnv for LevelCtx {
             .bound
             .iter()
             .enumerate()
-            .map(|(fst, len)| {
-                (0..*len)
+            .map(|(fst, v)| {
+                (0..v.len())
                     .map(|snd| {
-                        let idx = Idx { fst: self.bound.len() - 1 - fst, snd: len - 1 - snd };
+                        let idx = Idx { fst: self.bound.len() - 1 - fst, snd: v.len() - 1 - snd };
                         Rc::new(Val::Neu(Neu::Variable(Variable {
                             span: None,
                             name: String::new(),

--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -145,7 +145,7 @@ impl Ctx {
     /// also registered as unsolved.
     pub fn fresh_metavar(&mut self) -> MetaVar {
         let mv = MetaVar { id: self.next_meta_var };
-        let ctx = LevelCtx { bound: self.levels.clone() };
+        let ctx = LevelCtx::from(self.levels.clone());
         self.next_meta_var += 1;
         self.meta_vars.insert(mv, MetaVarState::Unsolved { ctx });
         mv


### PR DESCRIPTION
Turns the level context into a `Vec<Vec<()>>` instead of a `Vec<usize>`. This is necessary so that we can unify all existing contexts as `Vec<Vec<a>>`.