### PR TITLE
Use generic ctx

### DIFF
--- a/lang/elaborator/src/normalizer/env.rs
+++ b/lang/elaborator/src/normalizer/env.rs
@@ -8,7 +8,7 @@ use syntax::ast::{Shift, ShiftRange};
 use crate::normalizer::val::*;
 use printer::tokens::COMMA;
 use printer::Print;
-use syntax::ast::{Idx, Lvl, Var};
+use syntax::ast::{Idx, Var};
 use syntax::ctx::values::TypeCtx;
 use syntax::ctx::{map_idx::*, GenericCtx};
 use syntax::ctx::{Context, ContextElem, LevelCtx};
@@ -29,7 +29,7 @@ impl Context for Env {
     type Elem = Rc<Val>;
 
     fn lookup<V: Into<Var>>(&self, idx: V) -> Self::Elem {
-        let lvl = self.var_to_lvl(idx.into());
+        let lvl = self.ctx.var_to_lvl(idx.into());
         self.ctx
             .bound
             .get(lvl.fst)
@@ -57,18 +57,6 @@ impl Context for Env {
     fn pop_binder(&mut self, _elem: Self::Elem) {
         let err = "Cannot pop from empty context";
         self.ctx.bound.last_mut().expect(err).pop().expect(err);
-    }
-
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.ctx.bound.len() - 1 - idx.fst;
-        let snd = self.ctx.bound[fst].len() - 1 - idx.snd;
-        Lvl { fst, snd }
-    }
-
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.ctx.bound.len() - 1 - lvl.fst;
-        let snd = self.ctx.bound[lvl.fst].len() - 1 - lvl.snd;
-        Idx { fst, snd }
     }
 }
 

--- a/lang/elaborator/src/normalizer/env.rs
+++ b/lang/elaborator/src/normalizer/env.rs
@@ -9,14 +9,20 @@ use crate::normalizer::val::*;
 use printer::tokens::COMMA;
 use printer::Print;
 use syntax::ast::{Idx, Lvl, Var};
-use syntax::ctx::map_idx::*;
 use syntax::ctx::values::TypeCtx;
+use syntax::ctx::{map_idx::*, GenericCtx};
 use syntax::ctx::{Context, ContextElem, LevelCtx};
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
 pub struct Env {
-    bound: Vec<Vec<Rc<Val>>>,
+    ctx: GenericCtx<Rc<Val>>,
+}
+
+impl From<GenericCtx<Rc<Val>>> for Env {
+    fn from(value: GenericCtx<Rc<Val>>) -> Self {
+        Env { ctx: value }
+    }
 }
 
 impl Context for Env {
@@ -24,7 +30,8 @@ impl Context for Env {
 
     fn lookup<V: Into<Var>>(&self, idx: V) -> Self::Elem {
         let lvl = self.var_to_lvl(idx.into());
-        self.bound
+        self.ctx
+            .bound
             .get(lvl.fst)
             .and_then(|ctx| ctx.get(lvl.snd))
             .unwrap_or_else(|| panic!("Unbound variable {lvl}"))
@@ -32,31 +39,35 @@ impl Context for Env {
     }
 
     fn push_telescope(&mut self) {
-        self.bound.push(vec![]);
+        self.ctx.bound.push(vec![]);
     }
 
     fn pop_telescope(&mut self) {
-        self.bound.pop().unwrap();
+        self.ctx.bound.pop().unwrap();
     }
 
     fn push_binder(&mut self, elem: Self::Elem) {
-        self.bound.last_mut().expect("Cannot push without calling level_inc_fst first").push(elem);
+        self.ctx
+            .bound
+            .last_mut()
+            .expect("Cannot push without calling level_inc_fst first")
+            .push(elem);
     }
 
     fn pop_binder(&mut self, _elem: Self::Elem) {
         let err = "Cannot pop from empty context";
-        self.bound.last_mut().expect(err).pop().expect(err);
+        self.ctx.bound.last_mut().expect(err).pop().expect(err);
     }
 
     fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.bound.len() - 1 - idx.fst;
-        let snd = self.bound[fst].len() - 1 - idx.snd;
+        let fst = self.ctx.bound.len() - 1 - idx.fst;
+        let snd = self.ctx.bound[fst].len() - 1 - idx.snd;
         Lvl { fst, snd }
     }
 
     fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.bound.len() - 1 - lvl.fst;
-        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
+        let fst = self.ctx.bound.len() - 1 - lvl.fst;
+        let snd = self.ctx.bound[lvl.fst].len() - 1 - lvl.snd;
         Idx { fst, snd }
     }
 }
@@ -68,26 +79,19 @@ impl ContextElem<Env> for &Rc<Val> {
 }
 
 impl Env {
-    pub fn empty() -> Self {
-        Self { bound: vec![] }
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &[Rc<Val>]> {
-        self.bound.iter().map(|inner| &inner[..])
-    }
-
     pub(super) fn map<F>(&self, f: F) -> Self
     where
         F: Fn(&Rc<Val>) -> Rc<Val>,
     {
-        let bound = self.bound.iter().map(|inner| inner.iter().map(&f).collect()).collect();
-        Self { bound }
+        let bound: Vec<Vec<Rc<Val>>> =
+            self.ctx.bound.iter().map(|inner| inner.iter().map(&f).collect()).collect();
+        Self { ctx: bound.into() }
     }
 }
 
 impl From<Vec<Vec<Rc<Val>>>> for Env {
     fn from(bound: Vec<Vec<Rc<Val>>>) -> Self {
-        Self { bound }
+        Self { ctx: bound.into() }
     }
 }
 
@@ -150,7 +154,7 @@ impl Print for Env {
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
-        let iter = self.iter().map(|ctx| {
+        let iter = self.ctx.iter().map(|ctx| {
             alloc
                 .intersperse(ctx.iter().map(|typ| typ.print(cfg, alloc)), alloc.text(COMMA))
                 .brackets()

--- a/lang/elaborator/src/normalizer/env.rs
+++ b/lang/elaborator/src/normalizer/env.rs
@@ -50,7 +50,7 @@ impl Context for Env {
         self.ctx
             .bound
             .last_mut()
-            .expect("Cannot push without calling level_inc_fst first")
+            .expect("Cannot push without calling push_telescope first")
             .push(elem);
     }
 

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -4,7 +4,7 @@ use log::trace;
 
 use printer::types::Print;
 use syntax::ast::*;
-use syntax::ctx::{BindContext, Context};
+use syntax::ctx::{BindContext, Context, GenericCtx};
 
 use crate::normalizer::env::*;
 use crate::normalizer::val::{self, Closure, Val};
@@ -144,8 +144,8 @@ impl Eval for DotCall {
 
                         // First, we have to find the corresponding case in the toplevel definition `d`.
                         let Def { cases, .. } = prg.def(name, None)?;
-                        let cases =
-                            Env::empty().bind_iter(args.iter(), |env| cases.eval(prg, env))?;
+                        let mut env: Env = GenericCtx::empty().into();
+                        let cases = env.bind_iter(args.iter(), |env| cases.eval(prg, env))?;
                         let val::Case { body, .. } =
                             cases.clone().into_iter().find(|case| case.name == call_name).unwrap();
 
@@ -170,8 +170,8 @@ impl Eval for DotCall {
                         // First, we have to find the corresponding cocase in the toplevel
                         // codefinition `C`.
                         let Codef { cases, .. } = prg.codef(&call_name, None)?;
-                        let cases =
-                            Env::empty().bind_iter(call_args.iter(), |env| cases.eval(prg, env))?;
+                        let mut env: Env = GenericCtx::empty().into();
+                        let cases = env.bind_iter(call_args.iter(), |env| cases.eval(prg, env))?;
                         let val::Case { body, .. } =
                             cases.clone().into_iter().find(|cocase| cocase.name == *name).unwrap();
 

--- a/lang/elaborator/src/normalizer/normalize.rs
+++ b/lang/elaborator/src/normalizer/normalize.rs
@@ -1,4 +1,5 @@
 use syntax::ast::*;
+use syntax::ctx::GenericCtx;
 
 use super::env::Env;
 use super::eval::*;
@@ -11,7 +12,7 @@ pub trait Normalize {
     fn normalize(&self, prg: &Module, env: &mut Env) -> Result<Self::Nf, TypeError>;
 
     fn normalize_in_empty_env(&self, prg: &Module) -> Result<Self::Nf, TypeError> {
-        self.normalize(prg, &mut Env::empty())
+        self.normalize(prg, &mut GenericCtx::empty().into())
     }
 }
 

--- a/lang/elaborator/src/unifier/unify.rs
+++ b/lang/elaborator/src/unifier/unify.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use syntax::ast::{occurs_in, Variable};
-use syntax::ctx::{Context, LevelCtx};
+use syntax::ctx::LevelCtx;
 
 use crate::result::TypeError;
 use crate::unifier::dec::{Dec, No, Yes};

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -31,7 +31,7 @@ pub trait Rename: Sized {
     /// Assigns consistent names to all binding and bound variable occurrences.
     /// Should only be called on closed expressions or declarations.
     fn rename(self) -> Self {
-        let mut ctx = Ctx::empty();
+        let mut ctx = GenericCtx::empty().into();
         self.rename_in_ctx(&mut ctx)
     }
     /// Assigns consistent names to all binding and bound variable occurrences.

--- a/lang/renaming/src/ctx.rs
+++ b/lang/renaming/src/ctx.rs
@@ -39,25 +39,13 @@ impl Context for Ctx {
     }
 
     fn lookup<V: Into<Var>>(&self, idx: V) -> Self::Elem {
-        let lvl = self.var_to_lvl(idx.into());
+        let lvl = self.ctx.var_to_lvl(idx.into());
         self.ctx
             .bound
             .get(lvl.fst)
             .and_then(|ctx| ctx.get(lvl.snd))
             .unwrap_or_else(|| panic!("Unbound variable {lvl}"))
             .clone()
-    }
-
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.ctx.bound.len() - 1 - idx.fst;
-        let snd = self.ctx.bound[fst].len() - 1 - idx.snd;
-        Lvl { fst, snd }
-    }
-
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.ctx.bound.len() - 1 - lvl.fst;
-        let snd = self.ctx.bound[lvl.fst].len() - 1 - lvl.snd;
-        Idx { fst, snd }
     }
 }
 

--- a/lang/renaming/src/ctx.rs
+++ b/lang/renaming/src/ctx.rs
@@ -29,7 +29,7 @@ impl Context for Ctx {
         self.ctx
             .bound
             .last_mut()
-            .expect("Cannot push without calling level_inc_fst first")
+            .expect("Cannot push without calling push_telescope first")
             .push(elem);
     }
 

--- a/lang/syntax/src/ast/exp.rs
+++ b/lang/syntax/src/ast/exp.rs
@@ -13,7 +13,7 @@ use printer::util::{BackslashExt, BracesExt, IsNilExt};
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg};
 
 use crate::ctx::values::TypeCtx;
-use crate::ctx::{BindContext, Context, LevelCtx};
+use crate::ctx::{BindContext, LevelCtx};
 
 use super::subst::{Substitutable, Substitution};
 use super::traits::HasSpan;

--- a/lang/syntax/src/ast/traits/occurs.rs
+++ b/lang/syntax/src/ast/traits/occurs.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::ast::exp::Exp;
 use crate::ast::{Idx, Lvl};
-use crate::ctx::{Context, LevelCtx};
+use crate::ctx::LevelCtx;
 
 pub trait Occurs {
     fn occurs(&self, ctx: &mut LevelCtx, lvl: Lvl) -> bool;

--- a/lang/syntax/src/ctx/def.rs
+++ b/lang/syntax/src/ctx/def.rs
@@ -1,6 +1,45 @@
 //! Generic definition of variable contexts
 
+use derivative::Derivative;
+
 use crate::ast::{Idx, Lvl, Var};
+
+use super::LevelCtx;
+
+#[derive(Debug, Clone, Default, Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+pub struct GenericCtx<T> {
+    pub bound: Vec<Vec<T>>,
+}
+
+impl<T> GenericCtx<T> {
+    pub fn len(&self) -> usize {
+        self.bound.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bound.is_empty()
+    }
+
+    pub fn empty() -> Self {
+        Self { bound: vec![] }
+    }
+
+    pub fn levels(&self) -> LevelCtx {
+        let bound: Vec<_> = self.bound.iter().map(|inner| inner.len()).collect();
+        LevelCtx::from(bound)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &[T]> {
+        self.bound.iter().map(|inner| &inner[..])
+    }
+}
+
+impl<T> From<Vec<Vec<T>>> for GenericCtx<T> {
+    fn from(value: Vec<Vec<T>>) -> Self {
+        GenericCtx { bound: value }
+    }
+}
 
 /// Defines the interface of a variable context
 pub trait Context: Sized {

--- a/lang/syntax/src/ctx/def.rs
+++ b/lang/syntax/src/ctx/def.rs
@@ -33,6 +33,31 @@ impl<T> GenericCtx<T> {
     pub fn iter(&self) -> impl Iterator<Item = &[T]> {
         self.bound.iter().map(|inner| &inner[..])
     }
+
+    pub fn idx_to_lvl(&self, idx: Idx) -> Lvl {
+        let fst = self.bound.len() - 1 - idx.fst;
+        let snd = self.bound[fst].len() - 1 - idx.snd;
+        Lvl { fst, snd }
+    }
+
+    pub fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
+        let fst = self.bound.len() - 1 - lvl.fst;
+        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
+        Idx { fst, snd }
+    }
+
+    pub fn var_to_lvl(&self, var: Var) -> Lvl {
+        match var {
+            Var::Lvl(lvl) => lvl,
+            Var::Idx(idx) => self.idx_to_lvl(idx),
+        }
+    }
+    pub fn var_to_idx(&self, var: Var) -> Idx {
+        match var {
+            Var::Lvl(lvl) => self.lvl_to_idx(lvl),
+            Var::Idx(idx) => idx,
+        }
+    }
 }
 
 impl<T> From<Vec<Vec<T>>> for GenericCtx<T> {
@@ -62,21 +87,6 @@ pub trait Context: Sized {
 
     /// Pop a binder from the most-recently pushed telescope
     fn pop_binder(&mut self, elem: Self::Elem);
-
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl;
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx;
-    fn var_to_lvl(&self, var: Var) -> Lvl {
-        match var {
-            Var::Lvl(lvl) => lvl,
-            Var::Idx(idx) => self.idx_to_lvl(idx),
-        }
-    }
-    fn var_to_idx(&self, var: Var) -> Idx {
-        match var {
-            Var::Lvl(lvl) => self.lvl_to_idx(lvl),
-            Var::Idx(idx) => idx,
-        }
-    }
 }
 
 /// Interface to bind variables to anything that has a `Context`

--- a/lang/syntax/src/ctx/levels.rs
+++ b/lang/syntax/src/ctx/levels.rs
@@ -55,18 +55,6 @@ impl Context for LevelCtx {
     }
 
     fn lookup<V: Into<Var>>(&self, _idx: V) -> Self::Elem {}
-
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.bound.len() - 1 - idx.fst;
-        let snd = self.bound[fst].len() - 1 - idx.snd;
-        Lvl { fst, snd }
-    }
-
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.bound.len() - 1 - lvl.fst;
-        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
-        Idx { fst, snd }
-    }
 }
 
 impl<T> ContextElem<LevelCtx> for T {

--- a/lang/syntax/src/ctx/levels.rs
+++ b/lang/syntax/src/ctx/levels.rs
@@ -13,25 +13,9 @@ use crate::ast::*;
 
 use super::def::*;
 
-#[derive(Clone, Debug, Default)]
-pub struct LevelCtx {
-    /// Number of binders in the second dimension for each first dimension
-    pub bound: Vec<Vec<()>>,
-}
+pub type LevelCtx = GenericCtx<()>;
 
 impl LevelCtx {
-    pub fn empty() -> Self {
-        Self { bound: vec![] }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.bound.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.bound.len()
-    }
-
     pub fn append(&self, other: &LevelCtx) -> Self {
         let mut bound = self.bound.clone();
         bound.extend(other.bound.iter().cloned());

--- a/lang/syntax/src/ctx/values.rs
+++ b/lang/syntax/src/ctx/values.rs
@@ -77,18 +77,6 @@ impl Context for TypeCtx {
         self.bound.last_mut().expect(err).pop().expect(err);
         self.shift_at_lvl(0..1, self.bound.len() - 1, (0, -1));
     }
-
-    fn idx_to_lvl(&self, idx: Idx) -> Lvl {
-        let fst = self.bound.len() - 1 - idx.fst;
-        let snd = self.bound[fst].len() - 1 - idx.snd;
-        Lvl { fst, snd }
-    }
-
-    fn lvl_to_idx(&self, lvl: Lvl) -> Idx {
-        let fst = self.bound.len() - 1 - lvl.fst;
-        let snd = self.bound[lvl.fst].len() - 1 - lvl.snd;
-        Idx { fst, snd }
-    }
 }
 
 impl ContextElem<TypeCtx> for &Binder {


### PR DESCRIPTION
Use a generic implementation `pub struct GenericCtx<T> { bounds: Vec<Vec<T>> }` for contexts. This allows to remove some duplication, e.g. the implementation of `idx_to_lvl` and `lvl_to_idx` was the same for all 4 contexts, but the code couldn't be shared before.