### PR TITLE
Fix parser ambiguities

### DIFF
--- a/examples/ChurchEncoding.pol
+++ b/examples/ChurchEncoding.pol
@@ -4,6 +4,6 @@ codata Fun(A B: Type) {
 
 codata Nat { .iter(A: Type, z: A, s: Fun(A, A)): A }
 
-codef S(p: Nat): Nat { iter(A, z, s) => s.ap(A, A, p.iter(A, z, s)) }
+codef S(p: Nat): Nat { .iter(A, z, s) => s.ap(A, A, p.iter(A, z, s)) }
 
-codef Z: Nat { iter(A, z, s) => z }
+codef Z: Nat { .iter(A, z, s) => z }

--- a/examples/ChurchEncoding.pol
+++ b/examples/ChurchEncoding.pol
@@ -2,7 +2,7 @@ codata Fun(A B: Type) {
   Fun(A,B).ap(A B: Type, x: A) : B
 }
 
-codata Nat { iter(A: Type, z: A, s: Fun(A, A)): A }
+codata Nat { .iter(A: Type, z: A, s: Fun(A, A)): A }
 
 codef S(p: Nat): Nat { iter(A, z, s) => s.ap(A, A, p.iter(A, z, s)) }
 

--- a/examples/ExpressionsCaseStudy.pol
+++ b/examples/ExpressionsCaseStudy.pol
@@ -18,21 +18,21 @@ codata Step(e1 e2: Tm) {
 }
 
 codef StIteT(e1 e2: Tm): Step(TmIte(TmTrue, e1, e2), e1) {
-    d_step3(e3) absurd,
-    d_step1(e3) absurd,
-    d_step5(e3, e4, e5, e5, ty, t1, t2, t3) => t2
+    .d_step3(e3) absurd,
+    .d_step1(e3) absurd,
+    .d_step5(e3, e4, e5, e5, ty, t1, t2, t3) => t2
 }
 
 codef StIteF(e1 e2: Tm): Step(TmIte(TmFalse, e1, e2), e2) {
-    d_step3(e3) absurd,
-    d_step1(e3) absurd,
-    d_step5(e3, e4, e5, e5, ty, t1, t2, t3) => t3
+    .d_step3(e3) absurd,
+    .d_step1(e3) absurd,
+    .d_step5(e3, e4, e5, e5, ty, t1, t2, t3) => t3
 }
 
 codef StIte(e1 e2 e3 e4: Tm, s: Step(e1,e2)) : Step(TmIte(e1,e3,e4),TmIte(e2,e3,e4)) {
-  d_step1(e5) absurd,
-  d_step3(e5) absurd,
-  d_step5(e1', e2', e3', e5', ty, t1, t2, t3) => TIte(e2, e3, e4, ty, t1.pres(e1, TyBool).preservationStep(e1,e2,TyBool, s), t2, t3)
+  .d_step1(e5) absurd,
+  .d_step3(e5) absurd,
+  .d_step5(e1', e2', e3', e5', ty, t1, t2, t3) => TIte(e2, e3, e4, ty, t1.pres(e1, TyBool).preservationStep(e1,e2,TyBool, s), t2, t3)
 }
 
 -- | The typing relation.
@@ -51,10 +51,10 @@ codata Preservation(e: Tm, ty: Ty) {
 }
 
 def Typing(e, ty).pres(e: Tm, ty: Ty): Preservation(e, ty) {
-    TTrue => comatch PreservationTrue { preservationStep(e1, e2, ty0, s) => s.d_step1(e2) },
-    TFalse => comatch PreservationFalse { preservationStep(e1, e2, ty0, s) => s.d_step3(e2) },
+    TTrue => comatch PreservationTrue { .preservationStep(e1, e2, ty0, s) => s.d_step1(e2) },
+    TFalse => comatch PreservationFalse { .preservationStep(e1, e2, ty0, s) => s.d_step3(e2) },
     TIte(e1, e2, e3, ty0, t1, t2, t3) =>
         comatch PreservationIte {
-            preservationStep(e4, e5, ty1, s) => s.d_step5(e1, e2, e3, e5, ty, t1, t2, t3)
+            .preservationStep(e4, e5, ty1, s) => s.d_step5(e1, e2, e3, e5, ty, t1, t2, t3)
         }
 }

--- a/examples/FuStumpEncoding.pol
+++ b/examples/FuStumpEncoding.pol
@@ -3,7 +3,7 @@ codata Fun(A B: Type) {
 }
 
 codef StepFun(P: Nat -> Type): Fun(Nat, Type) {
-    ap(_,_,x) => P.ap(Nat, Type, x) -> P.ap(Nat, Type, S(x))
+    .ap(_,_,x) => P.ap(Nat, Type, x) -> P.ap(Nat, Type, S(x))
 }
 
 codata Π(A: Type, T: Fun(A, Type)) {
@@ -18,10 +18,10 @@ codata Nat {
 }
 
 codef Z: Nat {
-    ind(P, base, step) => base
+    .ind(P, base, step) => base
 }
 
 codef S(m: Nat): Nat {
-    ind(P, base, step) => step.dap(Nat, StepFun(P), m)
+    .ind(P, base, step) => step.dap(Nat, StepFun(P), m)
         .ap(P.ap(Nat, Type, m), P.ap(Nat, Type, S(m)), m.ind(P, base, step))
 }

--- a/examples/ParigotEncoding.pol
+++ b/examples/ParigotEncoding.pol
@@ -4,7 +4,7 @@ codata Fun(A B: Type) {
 
 codata Nat { .analyze(A: Type, z: A, s: Fun(Nat, Fun(A, A))): A }
 
-codef S(p: Nat): Nat { analyze(A, z, s) => s.ap(Nat, Fun(A, A), p).ap(A, A, p.analyze(A, z, s)) }
+codef S(p: Nat): Nat { .analyze(A, z, s) => s.ap(Nat, Fun(A, A), p).ap(A, A, p.analyze(A, z, s)) }
 
-codef Z: Nat { analyze(A, z, s) => z }
+codef Z: Nat { .analyze(A, z, s) => z }
 

--- a/examples/ParigotEncoding.pol
+++ b/examples/ParigotEncoding.pol
@@ -2,7 +2,7 @@ codata Fun(A B: Type) {
   Fun(A,B).ap(A B: Type, x: A) : B
 }
 
-codata Nat { analyze(A: Type, z: A, s: Fun(Nat, Fun(A, A))): A }
+codata Nat { .analyze(A: Type, z: A, s: Fun(Nat, Fun(A, A))): A }
 
 codef S(p: Nat): Nat { analyze(A, z, s) => s.ap(Nat, Fun(A, A), p).ap(A, A, p.analyze(A, z, s)) }
 

--- a/examples/ScottEncoding.pol
+++ b/examples/ScottEncoding.pol
@@ -4,6 +4,6 @@ codata Fun(A B: Type) {
 
 codata Nat { .case(A: Type, z: A, s: Fun(Nat, A)): A }
 
-codef S(p: Nat): Nat { case(A, z, s) => s.ap(Nat, A, p) }
+codef S(p: Nat): Nat { .case(A, z, s) => s.ap(Nat, A, p) }
 
-codef Z: Nat { case(A, z, s) => z }
+codef Z: Nat { .case(A, z, s) => z }

--- a/examples/ScottEncoding.pol
+++ b/examples/ScottEncoding.pol
@@ -2,7 +2,7 @@ codata Fun(A B: Type) {
   Fun(A,B).ap(A B: Type, x: A) : B
 }
 
-codata Nat { case(A: Type, z: A, s: Fun(Nat, A)): A }
+codata Nat { .case(A: Type, z: A, s: Fun(Nat, A)): A }
 
 codef S(p: Nat): Nat { case(A, z, s) => s.ap(Nat, A, p) }
 

--- a/examples/Webserver.pol
+++ b/examples/Webserver.pol
@@ -29,7 +29,7 @@ data Response {
 }
 
 codata User {
-    hasCredentials : Bool
+    .hasCredentials : Bool
 }
 
 codata State(loggedIn: Bool) {
@@ -43,7 +43,7 @@ codata State(loggedIn: Bool) {
 }
 
 codata Utils {
-    put_twice(n: Nat, route: Route, state: State(route.requiresLogin)): ×₋(State(route.requiresLogin), Response)
+    .put_twice(n: Nat, route: Route, state: State(route.requiresLogin)): ×₋(State(route.requiresLogin), Response)
 }
 
 codef MkUtils: Utils {
@@ -60,7 +60,7 @@ def Eq(t1, a, b).cong_pair(t1 t2: Type, a b: t1, c: t2): Eq(×₋(t1, t2), Pair(
 }
 
 codata Route {
-    requiresLogin: Bool,
+    .requiresLogin: Bool,
     (self: Route).get: State(self.requiresLogin) -> Response,
     (self: Route).post: State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),
     (self: Route).put(n : Nat): State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),

--- a/examples/Webserver.pol
+++ b/examples/Webserver.pol
@@ -19,8 +19,8 @@ codata ×₋(a b : Type) {
 }
 
 codef Pair(a b : Type, x : a, y : b) : ×₋(a,b) {
-    fst(a,b) => x,
-    snd(a,b) => y
+    .fst(a,b) => x,
+    .snd(a,b) => y
 }
 
 data Response {
@@ -47,7 +47,7 @@ codata Utils {
 }
 
 codef MkUtils: Utils {
-    put_twice(n, route, state) =>
+    .put_twice(n, route, state) =>
         route.put(n).ap(State(route.requiresLogin), ×₋(State(route.requiresLogin), Response), route.put(n).ap(State(route.requiresLogin), ×₋(State(route.requiresLogin), Response), state).fst(State(route.requiresLogin), Response))
 }
 
@@ -69,21 +69,21 @@ codata Route {
 }
 
 codef Index: Route {
-    requiresLogin => False,
-    post => \state. comatch { fst(a,b) => state, snd(a,b) => Forbidden },
-    get => \state. Return(state.counter(False)),
-    put(n) => \state. Pair(State(False), Response, state, Forbidden),
-    put_idempotent(n) => comatch {
-        dap(_, _, state) => Refl(×₋(State(False), Response), Pair(State(False), Response, state, Forbidden))
+    .requiresLogin => False,
+    .post => \state. comatch { .fst(a,b) => state, .snd(a,b) => Forbidden },
+    .get => \state. Return(state.counter(False)),
+    .put(n) => \state. Pair(State(False), Response, state, Forbidden),
+    .put_idempotent(n) => comatch {
+        .dap(_, _, state) => Refl(×₋(State(False), Response), Pair(State(False), Response, state, Forbidden))
     }
 }
 
 codef Admin: Route {
-    requiresLogin => True,
-    post => \state. comatch { fst(a,b) => state.increment, snd(a,b) => Return(state.increment.counter(True)) },
-    get => \state. Return(state.counter(True)),
-    put(n) => \state. Pair(State(True), Response, state.set(n), Return(n)),
-    put_idempotent(n) => comatch {
-        dap(_, _, state) => state.set_idempotent(True, n).cong_pair(State(True), Response, state.set(n), state.set(n).set(n), Return(n))
+    .requiresLogin => True,
+    .post => \state. comatch { .fst(a,b) => state.increment, .snd(a,b) => Return(state.increment.counter(True)) },
+    .get => \state. Return(state.counter(True)),
+    .put(n) => \state. Pair(State(True), Response, state.set(n), Return(n)),
+    .put_idempotent(n) => comatch {
+        .dap(_, _, state) => state.set_idempotent(True, n).cong_pair(State(True), Response, state.set(n), state.set(n).set(n), Return(n))
     }
 }

--- a/examples/buffer.pol
+++ b/examples/buffer.pol
@@ -30,12 +30,12 @@ codata Buffer(n: Nat) {
 }
 
 codef Empty: Buffer(Z) {
-    read(n) absurd,
+    .read(n) absurd,
 }
 
 codef FromVec(n: Nat, xs: Vec(n)): Buffer(n) {
-    read(n') => comatch {
-        proj1(_, _) => xs.head(n'),
-        proj2(_, _) => FromVec(n', xs.tail(n'))
+    .read(n') => comatch {
+        .proj1(_, _) => xs.head(n'),
+        .proj2(_, _) => FromVec(n', xs.tail(n'))
     }
 }

--- a/examples/classical_logic.pol
+++ b/examples/classical_logic.pol
@@ -25,11 +25,11 @@ def Top.contra(a: Type, prf: a, ref: Not(a)) : False {
 
 def Top.lem(a: Type): DN(Or(a, Not(a))) {
     Unit => comatch C1 {
-        given(_, k) =>
+        .given(_, k) =>
             Unit.contra(
                 Or(a, Not(a)),
                 Right(a, Not(a), comatch C2 {
-                    ret(_, x) =>
+                    .ret(_, x) =>
                         Unit.contra(
                             Or(a, Not(a)),
                             Left(a, Not(a), x),

--- a/examples/colist.pol
+++ b/examples/colist.pol
@@ -21,12 +21,12 @@ codata CoList(n: CoNat) {
 }
 
 codef CountUp(from: CoNat) : CoList(Omega) {
-    head(n, p) => from,
-    tail(n) => CountUp(S(from)),
+    .head(n, p) => from,
+    .tail(n) => CountUp(S(from)),
 }
 
 codef TakeN(n: CoNat, s: CoList(Omega)) : CoList(n) {
-    head(n', p) => s.head(Omega, OmegaNotZero),
-    tail(n') => TakeN(n.pred, s.tail(Omega)),
+    .head(n', p) => s.head(Omega, OmegaNotZero),
+    .tail(n') => TakeN(n.pred, s.tail(Omega)),
 }
 

--- a/examples/comatches.pol
+++ b/examples/comatches.pol
@@ -8,18 +8,18 @@ codata Pi(a: Type, p: a->Type) {
 
 data Top { Unit }
 
-codef IdType: Fun(Type, Type) { ap(_, _, a) => a->a }
+codef IdType: Fun(Type, Type) { .ap(_, _, a) => a->a }
 
 def Top.id: Pi(Type, IdType) {
-    Unit => (comatch { pi_elim(_, _, a) => comatch { ap(_, _, x) => x } }):Pi(Type, IdType)
+    Unit => (comatch { .pi_elim(_, _, a) => comatch { .ap(_, _, x) => x } }):Pi(Type, IdType)
 }
 
-def Top.const: Pi(Type, comatch { ap(_, _, a) => Pi(Type, comatch { ap(_, _, b) => a->b->a }) }) {
+def Top.const: Pi(Type, comatch { .ap(_, _, a) => Pi(Type, comatch { .ap(_, _, b) => a->b->a }) }) {
     Unit =>
         comatch {
-            pi_elim(_, _, a) =>
+            .pi_elim(_, _, a) =>
                 comatch {
-                    pi_elim(_, _, b) => comatch { ap(_, _, x) => comatch { ap(_, _, y) => x } }
+                    .pi_elim(_, _, b) => comatch { .ap(_, _, x) => comatch { .ap(_, _, y) => x } }
                 }
         }
 }

--- a/examples/covect.pol
+++ b/examples/covect.pol
@@ -14,13 +14,13 @@ codata Vec(n: Nat) {
 }
 
 codef Nil() : Vec(Z) {
-    append(n, m, ys) => ys,
-    tail(n) absurd
+    .append(n, m, ys) => ys,
+    .tail(n) absurd
 }
 
 codef Cons(n': Nat, x: Nat, xs: Vec(n')): Vec(S(n')) {
-    tail(n) => xs,
-    append(n, m, ys) => Cons(n'.add(m), x, xs.append(n', m, ys))
+    .tail(n) => xs,
+    .append(n, m, ys) => Cons(n'.add(m), x, xs.append(n', m, ys))
 }
 
 data Top { Unit }

--- a/examples/evalorder.pol
+++ b/examples/evalorder.pol
@@ -8,7 +8,7 @@ codata Fun(a b: Type) {
 }
 
 codef Ignore(y: Bool): Fun(Bool, Bool) {
-    ap(a, b, x) => x
+    .ap(a, b, x) => x
 }
 
 data Top { Unit }
@@ -25,6 +25,6 @@ def Top.after : Fun(Bool, Bool) {
     Unit =>
         -- let y = Unit.diverge in
         comatch Ignore2 {
-            ap(a, b, x) => x
+            .ap(a, b, x) => x
         }
 }

--- a/examples/example.pol
+++ b/examples/example.pol
@@ -14,11 +14,11 @@ data Vec(n: Nat) {
 }
 
 codata Stream {
-    head : Nat,
-    tail : Stream
+    .head : Nat,
+    .tail : Stream
 }
 
 codata NatToNat {
-    ap(x: Nat) : Nat
+    .ap(x: Nat) : Nat
 }
 

--- a/examples/functor.pol
+++ b/examples/functor.pol
@@ -7,11 +7,11 @@ data Eq (a: Type, x: a, y: a) {
 }
 
 codef Id(a: Type) : Fun(a, a) {
-    ap(_, _, x) => x,
+    .ap(_, _, x) => x,
 }
 
 codef Compose(a: Type, b: Type, c: Type, f: Fun(a, b), g: Fun(b, c)) : Fun(a, c) {
-    ap(_, _, x) => g.ap(b, c, f.ap(a, b, x))
+    .ap(_, _, x) => g.ap(b, c, f.ap(a, b, x))
 }
 
 codata Functor(f: Fun(Type, Type)) {
@@ -25,7 +25,7 @@ data Box(a: Type) {
 }
 
 codef BoxFun: Fun(Type, Type) {
-    ap(_, _, a) => Box(a),
+    .ap(_, _, a) => Box(a),
 }
 
 def Box(a).map_box(a b: Type, g: Fun(a, b)): Box(b) {
@@ -33,11 +33,11 @@ def Box(a).map_box(a b: Type, g: Fun(a, b)): Box(b) {
 }
 
 codef BoxFunctor: Functor(BoxFun) {
-    map(_, a, b, g, x) => x.map_box(a, b, g),
-    law_id(_, a, x) => x.match as x => Eq(Box(a), x.map_box(a, a, Id(a)), x) {
+    .map(_, a, b, g, x) => x.map_box(a, b, g),
+    .law_id(_, a, x) => x.match as x => Eq(Box(a), x.map_box(a, a, Id(a)), x) {
         MkBox(_, x) => Refl(Box(a), MkBox(a, x))
     },
-    law_compose(_, a, b, c, g, h, x) => x.match as x => Eq(Box(c), x.map_box(a, c, Compose(a, b, c, g, h)), x.map_box(a, b, g).map_box(b, c, h)) {
+    .law_compose(_, a, b, c, g, h, x) => x.match as x => Eq(Box(c), x.map_box(a, c, Compose(a, b, c, g, h)), x.map_box(a, b, g).map_box(b, c, h)) {
         MkBox(_, x) => Refl(Box(c), MkBox(c, h.ap(b, c, g.ap(a, b, x))))
     },
 }

--- a/examples/local_matches.pol
+++ b/examples/local_matches.pol
@@ -25,6 +25,6 @@ def Top.top_is_zero(n: Nat): Bool {
 
 def Top.top_id(a: Type): Fun(a, a) {
     Unit => comatch Id {
-        ap(a, b, x) => x
+        .ap(a, b, x) => x
     }
 }

--- a/examples/neg_inverse.pol
+++ b/examples/neg_inverse.pol
@@ -9,13 +9,13 @@ codata Bool {
 }
 
 codef True: Bool {
-    neg_inverse => Refl(Bool, True),
-    and(other) => other,
-    not => False
+    .neg_inverse => Refl(Bool, True),
+    .and(other) => other,
+    .not => False
 }
 
 codef False: Bool {
-    neg_inverse => Refl(Bool, False),
-    and(other) => False,
-    not => True
+    .neg_inverse => Refl(Bool, False),
+    .and(other) => False,
+    .not => True
 }

--- a/examples/neg_inverse.pol
+++ b/examples/neg_inverse.pol
@@ -4,8 +4,8 @@ data Eq (a: Type, x y: a) {
 
 codata Bool {
     (x: Bool).neg_inverse: Eq(Bool, x, x.not.not),
-    and(other: Bool): Bool,
-    not: Bool
+    .and(other: Bool): Bool,
+    .not: Bool
 }
 
 codef True: Bool {

--- a/examples/setoid.pol
+++ b/examples/setoid.pol
@@ -3,7 +3,7 @@ codata Fun(a b: Type) {
 }
 
 codata Setoid {
-   type : Type,
+   .type : Type,
    (self: Setoid).equality : Fun(self.type, Fun(self.type, Type))
 }
 

--- a/examples/stlc.pol
+++ b/examples/stlc.pol
@@ -195,7 +195,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
             TApp(_, _, _, _, _, _, _) absurd,
             TVar(_, _, _, h_elem) =>
                 x.cmp_reflect(ctx1.len).match {
-                IsLT(_, _, h_eq_lt, h_lt) => h_eq_lt.transport(Cmp, LT, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsLT(_, _, h_eq_lt, h_lt) => h_eq_lt.transport(Cmp, LT, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     ctx2.weaken_append(ctx1, Var(x), t2)
                         .ap(
                             HasType(ctx1, Var(x), t2),
@@ -216,7 +216,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                             ),
                         )
                 ),
-                IsEQ(_, _, h_eq_eq, h_eq) => h_eq_eq.transport(Cmp, EQ, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsEQ(_, _, h_eq_eq, h_eq) => h_eq_eq.transport(Cmp, EQ, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     ctx1.append(ctx2).weaken_append(Nil, by_e, t2)
                         .ap(
                             HasType(Nil, by_e, t2),
@@ -225,16 +225,16 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                 Elem(ctx1.len, t2, ctx1.append(Cons(t1, ctx2))),
                                 Eq(Typ, t1, t2),
                                 h_eq.transport(
-                                    Nat, x, ctx1.len, comatch { ap(_, _, x) => Elem(x, t2, ctx1.append(Cons(t1, ctx2))) },
+                                    Nat, x, ctx1.len, comatch { .ap(_, _, x) => Elem(x, t2, ctx1.append(Cons(t1, ctx2))) },
                                     h_elem
                                 ),
                             ).transport(
-                                Typ, t1, t2, comatch { ap(_, _, t) => HasType(Nil, by_e, t) },
+                                Typ, t1, t2, comatch { .ap(_, _, t) => HasType(Nil, by_e, t) },
                                 h_by
                             )
                         )
                 ),
-                IsGT(_, _, h_eq_gt, h_gt) => h_eq_gt.transport(Cmp, GT, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsGT(_, _, h_eq_gt, h_gt) => h_eq_gt.transport(Cmp, GT, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     TVar(
                         ctx1.append(ctx2), x.pred, t2,
                         ctx1.elem_append_pred(ctx2, t2, t1, x)
@@ -305,7 +305,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) ->
     Nil => \h_e. ctx1.append_nil
         .transport(
             Ctx, ctx1, ctx1.append(Nil),
-            comatch { ap(_, _, ctx) => HasType(ctx, e, t) },
+            comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
             h_e
         ),
     Cons(t', ts) => \h_e.
@@ -314,7 +314,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) ->
                 Ctx,
                 ctx1.append(Cons(t', Nil)).append(ts),
                 ctx1.append(Cons(t', ts)),
-                comatch { ap(_, _, ctx) => HasType(ctx, e, t) },
+                comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
                 ts.weaken_append(ctx1.append(Cons(t', Nil)), e, t)
                     .ap(
                         HasType(ctx1.append(Cons(t', Nil)), e, t),
@@ -385,7 +385,7 @@ def (ctx1: Ctx).append_assoc(ctx2 ctx3: Ctx): Eq(Ctx, ctx1.append(ctx2).append(c
         .cong(Ctx, Ctx,
             xs.append(ctx2).append(ctx3),
             xs.append(ctx2.append(ctx3)),
-            comatch { ap(_, _, xs) => Cons(x, xs) }),
+            comatch { .ap(_, _, xs) => Cons(x, xs) }),
 }
 
 def (ctx: Ctx).append_nil: Eq(Ctx, ctx, ctx.append(Nil)) {
@@ -461,7 +461,7 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
             .le_unsucc(S(ts.len), x')
             .s_pred(ts.len, x')
             .transport(
-                Nat, S(x'.pred), x', comatch { ap(_, _, x) => Elem(x, t1, Cons(t, ts).append(ctx2)) },
+                Nat, S(x'.pred), x', comatch { .ap(_, _, x) => Elem(x, t1, Cons(t, ts).append(ctx2)) },
                 There(x'.pred, t1, t, ts.append(ctx2),
                     ts.elem_append_pred(ctx2, t1, t2, x')
                         .ap(

--- a/examples/stlc_bool.pol
+++ b/examples/stlc_bool.pol
@@ -278,7 +278,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
             TIf(_, _, _, _, _, _, _, _) absurd,
             TVar(_, _, _, h_elem) =>
                 x.cmp_reflect(ctx1.len).match {
-                IsLT(_, _, h_eq_lt, h_lt) => h_eq_lt.transport(Cmp, LT, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsLT(_, _, h_eq_lt, h_lt) => h_eq_lt.transport(Cmp, LT, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     ctx2.weaken_append(ctx1, Var(x), t2)
                         .ap(
                             HasType(ctx1, Var(x), t2),
@@ -299,7 +299,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                             ),
                         )
                 ),
-                IsEQ(_, _, h_eq_eq, h_eq) => h_eq_eq.transport(Cmp, EQ, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsEQ(_, _, h_eq_eq, h_eq) => h_eq_eq.transport(Cmp, EQ, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     ctx1.append(ctx2).weaken_append(Nil, by_e, t2)
                         .ap(
                             HasType(Nil, by_e, t2),
@@ -308,16 +308,16 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                 Elem(ctx1.len, t2, ctx1.append(Cons(t1, ctx2))),
                                 Eq(Typ, t1, t2),
                                 h_eq.transport(
-                                    Nat, x, ctx1.len, comatch { ap(_, _, x) => Elem(x, t2, ctx1.append(Cons(t1, ctx2))) },
+                                    Nat, x, ctx1.len, comatch { .ap(_, _, x) => Elem(x, t2, ctx1.append(Cons(t1, ctx2))) },
                                     h_elem
                                 ),
                             ).transport(
-                                Typ, t1, t2, comatch { ap(_, _, t) => HasType(Nil, by_e, t) },
+                                Typ, t1, t2, comatch { .ap(_, _, t) => HasType(Nil, by_e, t) },
                                 h_by
                             )
                         )
                 ),
-                IsGT(_, _, h_eq_gt, h_gt) => h_eq_gt.transport(Cmp, GT, x.cmp(ctx1.len), comatch { ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
+                IsGT(_, _, h_eq_gt, h_gt) => h_eq_gt.transport(Cmp, GT, x.cmp(ctx1.len), comatch { .ap(_, _, cmp) => HasType(ctx1.append(ctx2), cmp.subst_result(x, by_e), t2) },
                     TVar(
                         ctx1.append(ctx2), x.pred, t2,
                         ctx1.elem_append_pred(ctx2, t2, t1, x)
@@ -445,7 +445,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) ->
     Nil => \h_e. ctx1.append_nil
         .transport(
             Ctx, ctx1, ctx1.append(Nil),
-            comatch { ap(_, _, ctx) => HasType(ctx, e, t) },
+            comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
             h_e
         ),
     Cons(t', ts) => \h_e.
@@ -454,7 +454,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) ->
                 Ctx,
                 ctx1.append(Cons(t', Nil)).append(ts),
                 ctx1.append(Cons(t', ts)),
-                comatch { ap(_, _, ctx) => HasType(ctx, e, t) },
+                comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
                 ts.weaken_append(ctx1.append(Cons(t', Nil)), e, t)
                     .ap(
                         HasType(ctx1.append(Cons(t', Nil)), e, t),
@@ -563,7 +563,7 @@ def (ctx1: Ctx).append_assoc(ctx2 ctx3: Ctx): Eq(Ctx, ctx1.append(ctx2).append(c
         .cong(Ctx, Ctx,
             xs.append(ctx2).append(ctx3),
             xs.append(ctx2.append(ctx3)),
-            comatch { ap(_, _, xs) => Cons(x, xs) }),
+            comatch { .ap(_, _, xs) => Cons(x, xs) }),
 }
 
 def (ctx: Ctx).append_nil: Eq(Ctx, ctx, ctx.append(Nil)) {
@@ -639,7 +639,7 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
             .le_unsucc(S(ts.len), x')
             .s_pred(ts.len, x')
             .transport(
-                Nat, S(x'.pred), x', comatch { ap(_, _, x) => Elem(x, t1, Cons(t, ts).append(ctx2)) },
+                Nat, S(x'.pred), x', comatch { .ap(_, _, x) => Elem(x, t1, Cons(t, ts).append(ctx2)) },
                 There(x'.pred, t1, t, ts.append(ctx2),
                     ts.elem_append_pred(ctx2, t1, t2, x')
                         .ap(

--- a/examples/stream.pol
+++ b/examples/stream.pol
@@ -19,8 +19,8 @@ def Bool.if_then_else(a: Type, then: a, else: a) : a {
 }
 
 codata Stream {
-    head : Nat,
-    tail : Stream,
+    .head : Nat,
+    .tail : Stream,
 }
 
 codef Zeroes() : Stream {

--- a/examples/stream.pol
+++ b/examples/stream.pol
@@ -24,16 +24,16 @@ codata Stream {
 }
 
 codef Zeroes() : Stream {
-    head() => Z,
-    tail() => Zeroes()
+    .head() => Z,
+    .tail() => Zeroes()
 }
 
 codef Ones() : Stream {
-    head() => S(Z),
-    tail() => Ones()
+    .head() => S(Z),
+    .tail() => Ones()
 }
 
 codef Alternate(choose: Bool) : Stream {
-    head() => choose.if_then_else(Nat, S(Z), Z),
-    tail() => Alternate(choose.not())
+    .head() => choose.if_then_else(Nat, S(Z), Z),
+    .tail() => Alternate(choose.not())
 }

--- a/examples/strong_existentials.pol
+++ b/examples/strong_existentials.pol
@@ -95,6 +95,6 @@ codata Σ₋(A: Type, T: A -> Type) {
 }
 
 codef DefΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A, Type, x)): Σ₋(A,T) {
-  sπ₁(_,_) => x,
-  sπ₂(_,_) => w
+  .sπ₁(_,_) => x,
+  .sπ₂(_,_) => w
 }

--- a/examples/typedhole.pol
+++ b/examples/typedhole.pol
@@ -59,17 +59,17 @@ codata Stream {
 }
 
 codef Zeroes() : Stream {
-    sHead() => Z,
-    sTail() => Zeroes()
+    .sHead() => Z,
+    .sTail() => Zeroes()
 }
 
 codef Ones() : Stream {
-    sHead() => S(Z),
-    sTail() => ?
+    .sHead() => S(Z),
+    .sTail() => ?
 }
 
 codef Alternate(choose: Bool) : Stream {
-    sHead() => choose.if_then_else(Nat, S(?), Z),
-    sTail() => Alternate(choose.not())
+    .sHead() => choose.if_then_else(Nat, S(?), Z),
+    .sTail() => Alternate(choose.not())
 }
 

--- a/examples/typedhole.pol
+++ b/examples/typedhole.pol
@@ -54,8 +54,8 @@ def Bool.if_then_else(a: Type, then: a, else: a) : a {
 }
 
 codata Stream {
-    sHead : Nat,
-    sTail : Stream,
+    .sHead : Nat,
+    .sTail : Stream,
 }
 
 codef Zeroes() : Stream {

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -346,15 +346,21 @@ impl Eval for Case {
     type Val = val::Case;
 
     fn eval(&self, _prg: &Module, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let Case { span, name, params, body } = self;
+        let Case { span, pattern, body } = self;
 
         let body = body.as_ref().map(|body| Closure {
             body: body.clone(),
-            n_args: params.len(),
+            n_args: pattern.params.len(),
             env: env.clone(),
         });
 
-        Ok(val::Case { span: *span, name: name.clone(), params: params.clone(), body })
+        Ok(val::Case {
+            span: *span,
+            is_copattern: pattern.is_copattern,
+            name: pattern.name.clone(),
+            params: pattern.params.clone(),
+            body,
+        })
     }
 }
 

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -77,7 +77,7 @@ impl<'a> WithExpectedType<'a> {
         let mut dtors_actual = HashSet::default();
         let mut dtors_duplicate = HashSet::default();
 
-        for name in cases.iter().map(|case| &case.name) {
+        for name in cases.iter().map(|case| &case.pattern.name) {
             if dtors_actual.contains(name) {
                 dtors_duplicate.insert(name.clone());
             }
@@ -113,9 +113,10 @@ impl<'a> WithExpectedType<'a> {
         let mut cases_out = Vec::new();
 
         for case in cases.iter().cloned() {
-            let Dtor { self_param, ret_typ, params, .. } = prg.dtor(&case.name, case.span)?;
+            let Dtor { self_param, ret_typ, params, .. } =
+                prg.dtor(&case.pattern.name, case.span)?;
             let SelfParam { typ: TypCtor { args: def_args, .. }, .. } = self_param;
-            let Case { span, name, params: params_inst, body } = &case;
+            let Case { span, pattern: Pattern { name, params: params_inst, .. }, body } = &case;
             // We are in the following situation:
             //
             // codata T(...) {  (self : T(.....)).d(...) : t, ...}
@@ -176,8 +177,11 @@ impl<'a> WithExpectedType<'a> {
 
                             let case_out = Case {
                                 span: *span,
-                                name: name.clone(),
-                                params: args_out,
+                                pattern: Pattern {
+                                    is_copattern: true,
+                                    name: name.clone(),
+                                    params: args_out,
+                                },
                                 body: None,
                             };
 
@@ -301,8 +305,11 @@ impl<'a> WithExpectedType<'a> {
 
                             let case_out = Case {
                                 span: *span,
-                                name: name.clone(),
-                                params: args_out,
+                                pattern: Pattern {
+                                    is_copattern: true,
+                                    name: name.clone(),
+                                    params: args_out,
+                                },
                                 body: body_out,
                             };
 

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -119,7 +119,7 @@ impl<'a> WithScrutinee<'a> {
         let mut ctors_actual = HashSet::default();
         let mut ctors_duplicate = HashSet::default();
 
-        for name in cases.iter().map(|case| &case.name) {
+        for name in cases.iter().map(|case| &case.pattern.name) {
             if ctors_actual.contains(name) {
                 ctors_duplicate.insert(name.clone());
             }
@@ -154,7 +154,7 @@ impl<'a> WithScrutinee<'a> {
         let mut cases_out = Vec::new();
 
         for case in cases {
-            let Case { span, name, params: args, body } = case;
+            let Case { span, pattern: Pattern { name, params: args, .. }, body } = case;
             // Build equations for this case
             let Ctor { name, typ: TypCtor { args: def_args, .. }, params, .. } =
                 prg.ctor(&name, span)?;
@@ -241,8 +241,15 @@ impl<'a> WithScrutinee<'a> {
                             None
                         }
                     };
-                    let case_out =
-                        Case { span, name: name.clone(), params: args_out, body: body_out };
+                    let case_out = Case {
+                        span,
+                        pattern: Pattern {
+                            is_copattern: false,
+                            name: name.clone(),
+                            params: args_out,
+                        },
+                        body: body_out,
+                    };
                     cases_out.push(case_out);
                     Ok(())
                 },

--- a/lang/lifting/src/fv.rs
+++ b/lang/lifting/src/fv.rs
@@ -113,9 +113,9 @@ impl FV for Hole {
 
 impl FV for Case {
     fn visit_fv(&self, v: &mut USTVisitor) {
-        let Case { span: _, name: _, params, body } = self;
+        let Case { span: _, pattern, body } = self;
 
-        v.bind_iter(params.params.iter(), |v| {
+        v.bind_iter(pattern.params.params.iter(), |v| {
             body.visit_fv(v);
         })
     }

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -242,12 +242,15 @@ impl Lift for Case {
     type Target = Case;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Case { span, name, params, body } = self;
+        let Case { span, pattern, body } = self;
 
-        params.lift_telescope(ctx, |ctx, params| Case {
+        pattern.params.lift_telescope(ctx, |ctx, params| Case {
             span: *span,
-            name: name.clone(),
-            params,
+            pattern: Pattern {
+                is_copattern: pattern.is_copattern,
+                name: pattern.name.clone(),
+                params,
+            },
             body: body.lift(ctx),
         })
     }

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -66,8 +66,11 @@ impl Lower for cst::exp::Case<cst::exp::Pattern> {
         lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
             Ok(ast::Case {
                 span: Some(*span),
-                name: pattern.name.id.clone(),
-                params,
+                pattern: ast::Pattern {
+                    is_copattern: false,
+                    name: pattern.name.id.clone(),
+                    params,
+                },
                 body: body.lower(ctx)?,
             })
         })
@@ -83,8 +86,7 @@ impl Lower for cst::exp::Case<cst::exp::Copattern> {
         lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
             Ok(ast::Case {
                 span: Some(*span),
-                name: pattern.name.id.clone(),
-                params,
+                pattern: ast::Pattern { is_copattern: true, name: pattern.name.id.clone(), params },
                 body: body.lower(ctx)?,
             })
         })

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -3,7 +3,8 @@ use std::rc::Rc;
 use codespan::Span;
 use url::Url;
 
-use super::exp;
+use super::exp::Copattern;
+use super::exp::{self, Pattern};
 use super::ident::*;
 
 #[derive(Debug, Clone)]
@@ -144,7 +145,7 @@ pub struct Def {
     pub params: Telescope,
     pub scrutinee: Scrutinee,
     pub ret_typ: Rc<exp::Exp>,
-    pub cases: Vec<exp::Case>,
+    pub cases: Vec<exp::Case<Pattern>>,
 }
 
 /// Scrutinee within a toplevel definition
@@ -180,7 +181,7 @@ pub struct Codef {
     pub attr: Attributes,
     pub params: Telescope,
     pub typ: exp::Call,
-    pub cases: Vec<exp::Case>,
+    pub cases: Vec<exp::Case<Copattern>>,
 }
 
 /// Toplevel let-bound expression.

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -12,10 +12,21 @@ pub enum BindingSite {
 }
 
 #[derive(Debug, Clone)]
-pub struct Case {
-    pub span: Span,
+pub struct Pattern {
     pub name: Ident,
     pub params: Vec<BindingSite>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Copattern {
+    pub name: Ident,
+    pub params: Vec<BindingSite>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Case<P> {
+    pub span: Span,
+    pub pattern: P,
     /// Body being `None` represents an absurd pattern
     pub body: Option<Rc<Exp>>,
 }
@@ -67,7 +78,7 @@ pub struct LocalMatch {
     pub name: Option<Ident>,
     pub on_exp: Rc<Exp>,
     pub motive: Option<Motive>,
-    pub cases: Vec<Case>,
+    pub cases: Vec<Case<Pattern>>,
 }
 
 #[derive(Debug, Clone)]
@@ -75,7 +86,7 @@ pub struct LocalComatch {
     pub span: Span,
     pub name: Option<Ident>,
     pub is_lambda_sugar: bool,
-    pub cases: Vec<Case>,
+    pub cases: Vec<Case<Copattern>>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -144,11 +144,11 @@ pub Decl: Decl = {
 //
 
 Ctor: Ctor = {
-    <l: @L> <doc: DocComment?> <name: UpperIdent> <params: OptTelescope> <typ: (":" <TypApp>)?> <r: @R> => Ctor { span: span(l, r), doc, name, params, typ },
+    <l: @L> <doc: DocComment?> <name: Ident> <params: OptTelescope> <typ: (":" <TypApp>)?> <r: @R> => Ctor { span: span(l, r), doc, name, params, typ },
 }
 
 // Toplevel data type declaration
-Data: Data = <l: @L> <doc: DocComment?> <attr: OptAttributes> "data" <name: UpperIdent> <params: OptTelescope> "{" <ctors: Comma<Ctor>> "}" <r: @R> =>
+Data: Data = <l: @L> <doc: DocComment?> <attr: OptAttributes> "data" <name: Ident> <params: OptTelescope> "{" <ctors: Comma<Ctor>> "}" <r: @R> =>
   Data { span: span(l, r), doc, name, attr, params, ctors };
 
 Dtor: Dtor = {
@@ -156,19 +156,19 @@ Dtor: Dtor = {
 }
 
 // Toplevel codata type declaration
-Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name: UpperIdent> <params: OptTelescope> "{" <dtors: Comma<Dtor>> "}" <r: @R> =>
+Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name: Ident> <params: OptTelescope> "{" <dtors: Comma<Dtor>> "}" <r: @R> =>
   Codata { span: span(l, r), doc, name, attr, params, dtors };
 
 // Toplevel definition
-Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: Ident> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case>> "}" <r: @R> =>
   Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases };
 
 // Toplevel codefinition
-Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: UpperIdent> <params: OptTelescope> ":" <typ: TypApp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: Ident> <params: OptTelescope> ":" <typ: TypApp> "{" <cases: Comma<Case>> "}" <r: @R> =>
   Codef { span: span(l, r), doc, name, attr, params, typ, cases };
 
 // Toplevel let binding
-Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: LowerIdent><params: OptTelescope> ":" <typ: Exp> "{" <body: Exp> "}" <r: @R> =>
+Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: Ident><params: OptTelescope> ":" <typ: Exp> "{" <body: Exp> "}" <r: @R> =>
   Let { span: span(l,r), doc, name, attr, params, typ, body };
 
 pub Case : Case = {
@@ -291,5 +291,6 @@ Ident: Ident = {
     <s: LowerIdent> => s.to_owned(),
     <s: UpperIdent> => s.to_owned(),
 }
+
 LowerIdent: Ident = <s: "LowerCaseName" > => Ident { id: s.to_owned() };
 UpperIdent: Ident = <s: "UpperCaseName"> => Ident { id: s.to_owned() };

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -58,11 +58,10 @@ extern {
     "#" => Token::Hash,
     "_" => Token::Underscore,
 
-    // Names
+    // Identifiers
     //
     //
-    "UpperCaseName" => Token::UpperCaseName(<String>),
-    "LowerCaseName" => Token::LowerCaseName(<String>),
+    "Identifier" => Token::Ident(<String>),
 
     // Literals
     //
@@ -116,7 +115,7 @@ OptTelescopeInst: Vec<BindingSite> = <params: Parens<Comma<BindingSite>>?> => pa
 Args: Vec<Rc<Exp>> = ParenthesizedArgs<Exp>;
 OptArgs: Vec<Rc<Exp>> = OptParenthesizedArgs<Exp>;
 
-Attr: String = <s:"LowerCaseName"> => s.to_owned();
+Attr: String = <s:"Identifier"> => s.to_owned();
 Attributes: Attributes = "#" <attrs: BracketedArgs<Attr>> => Attributes { attrs };
 OptAttributes: Attributes = <attr: Attributes? > => attr.unwrap_or_default();
 
@@ -298,9 +297,5 @@ BindingSite: BindingSite = {
 }
 
 Ident: Ident = {
-    <s: LowerIdent> => s.to_owned(),
-    <s: UpperIdent> => s.to_owned(),
+    <i: "Identifier"> => Ident { id: i.to_owned() }
 }
-
-LowerIdent: Ident = <s: "LowerCaseName" > => Ident { id: s.to_owned() };
-UpperIdent: Ident = <s: "UpperCaseName"> => Ident { id: s.to_owned() };

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -139,7 +139,7 @@ pub Decl: Decl = {
     <d: Let> => Decl::Let(d),
 }
 
-// Toplevel declarations
+// Data Type Declarations
 //
 //
 
@@ -151,15 +151,31 @@ Ctor: Ctor = {
 Data: Data = <l: @L> <doc: DocComment?> <attr: OptAttributes> "data" <name: Ident> <params: OptTelescope> "{" <ctors: Comma<Ctor>> "}" <r: @R> =>
   Data { span: span(l, r), doc, name, attr, params, ctors };
 
+
+// Codata Type Declarations
+//
+//
+
+pub Destructee: Destructee = {
+    <l: @L> <scrutinee: (<Scrutinee>)?> <r: @R> => match scrutinee {
+        Some(Scrutinee { span, name, typ }) => Destructee { span, name, typ: Some(typ) },
+        None => Destructee { span: span(l, r), name: None, typ: None },
+    }
+}
+
 Dtor: Dtor = {
-    <l: @L> <doc: DocComment?> <destructee: Destructee> <name: LowerIdent> <params: OptTelescope> ":" <ret_typ: Exp> <r: @R> => Dtor { span: span(l, r), doc, name, params, destructee, ret_typ },
+    <l: @L> <doc: DocComment?> <destructee: Destructee> "." <name: Ident> <params: OptTelescope> ":" <ret_typ: Exp> <r: @R> =>
+      Dtor { span: span(l, r), doc, name, params, destructee, ret_typ },
 }
 
 // Toplevel codata type declaration
 Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name: Ident> <params: OptTelescope> "{" <dtors: Comma<Dtor>> "}" <r: @R> =>
   Codata { span: span(l, r), doc, name, attr, params, dtors };
 
+
 // Toplevel definition
+//
+//
 Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: Ident> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case>> "}" <r: @R> =>
   Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases };
 
@@ -180,12 +196,6 @@ pub AbsurdOrBody: Option<Rc<Exp>> = {
     "=>" <body: Exp> => Some(body),
 }
 
-pub Destructee: Destructee = {
-    <l: @L> <scrutinee: (<Scrutinee> ".")?> <r: @R> => match scrutinee {
-        Some(Scrutinee { span, name, typ }) => Destructee { span, name, typ: Some(typ) },
-        None => Destructee { span: span(l, r), name: None, typ: None },
-    }
-}
 
 pub Scrutinee: Scrutinee = {
     <l: @L> "(" <name: BindingSite> ":" <typ: TypApp> ")" <r: @R> => Scrutinee { span: span(l, r), name: match name { BindingSite::Wildcard{..} => None, BindingSite::Var { name,.. } => Some(name) }, typ },
@@ -193,7 +203,7 @@ pub Scrutinee: Scrutinee = {
 }
 
 pub TypApp: Call = {
-    <l: @L> <name: UpperIdent> <args: OptArgs> <r: @R> => Call { span: span(l, r), name, args },
+    <l: @L> <name: Ident> <args: OptArgs> <r: @R> => Call { span: span(l, r), name, args },
 }
 
 // Expressions

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -175,22 +175,31 @@ Codata: Codata = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codata" <name
 // Toplevel definition
 //
 //
-Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: Ident> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+Def: Def = <l: @L> <doc: DocComment?> <attr: OptAttributes> "def" <scrutinee: Scrutinee> "." <name: Ident> <params: OptTelescope> ":" <ret_typ: Exp> "{" <cases: Comma<Case<Pattern>>> "}" <r: @R> =>
   Def { span: span(l, r), doc, name, attr, params, scrutinee, ret_typ, cases };
 
 // Toplevel codefinition
-Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: Ident> <params: OptTelescope> ":" <typ: TypApp> "{" <cases: Comma<Case>> "}" <r: @R> =>
+Codef: Codef = <l: @L> <doc: DocComment?> <attr: OptAttributes> "codef" <name: Ident> <params: OptTelescope> ":" <typ: TypApp> "{" <cases: Comma<Case<Copattern>>> "}" <r: @R> =>
   Codef { span: span(l, r), doc, name, attr, params, typ, cases };
 
 // Toplevel let binding
 Let: Let = <l: @L> <doc: DocComment?> <attr: OptAttributes> "let" <name: Ident><params: OptTelescope> ":" <typ: Exp> "{" <body: Exp> "}" <r: @R> =>
   Let { span: span(l,r), doc, name, attr, params, typ, body };
 
-pub Case : Case = {
-    <l: @L> <name: Ident> <params: OptTelescopeInst> <body: AbsurdOrBody> <r: @R> => Case { span: span(l, r), name, params, body },
+
+Pattern: Pattern = {
+  <name: Ident><params: OptTelescopeInst> => Pattern { name, params },
 }
 
-pub AbsurdOrBody: Option<Rc<Exp>> = {
+Copattern: Copattern = {
+  <name: Ident><params: OptTelescopeInst> => Copattern { name, params },
+}
+
+Case<P> : Case<P> = {
+    <l: @L> <pattern: P> <body: AbsurdOrBody> <r: @R> => Case { span: span(l, r), pattern, body },
+}
+
+AbsurdOrBody: Option<Rc<Exp>> = {
     "absurd" => None,
     "=>" <body: Exp> => Some(body),
 }
@@ -260,7 +269,7 @@ Lam: Lam = <l: @L> "\\" <var: BindingSite> "." <body: Exp> <r: @R> =>
 DotCall: DotCall = <l: @L> <exp: Ops> "." <name: Ident> <args: OptArgs> <r: @R> =>
   DotCall { span: span(l, r), exp, name, args };
 
-LocalMatch: LocalMatch = <l: @L> <on_exp: Ops> "." "match" <name: Ident?> <motive: Motive?> "{" <cases: Comma<Case>> "}" <r: @R> =>
+LocalMatch: LocalMatch = <l: @L> <on_exp: Ops> "." "match" <name: Ident?> <motive: Motive?> "{" <cases: Comma<Case<Pattern>>> "}" <r: @R> =>
   LocalMatch { span: span(l, r), name, on_exp, motive, cases };
 
 CallWithArgs: Call = <l: @L> <name: Ident> <args: Args> <r: @R> =>
@@ -269,7 +278,7 @@ CallWithArgs: Call = <l: @L> <name: Ident> <args: Args> <r: @R> =>
 CallWithoutArgs: Call = <l: @L> <name: Ident> <r: @R> =>
   Call { span: span(l, r), name, args: vec![] };
 
-LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <cases: Comma<Case>> "}" <r: @R> =>
+LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <cases: Comma<Case<Copattern>>> "}" <r: @R> =>
   LocalComatch { span: span(l, r), name, is_lambda_sugar: false, cases };
 
 TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -192,7 +192,7 @@ Pattern: Pattern = {
 }
 
 Copattern: Copattern = {
-  <name: Ident><params: OptTelescopeInst> => Copattern { name, params },
+  "." <name: Ident><params: OptTelescopeInst> => Copattern { name, params },
 }
 
 Case<P> : Case<P> = {

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -86,13 +86,11 @@ pub enum Token {
     #[token("_")]
     Underscore,
 
-    // Names
+    // Identifiers
     //
     //
-    #[regex(r"[A-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*", |lex| lex.slice().to_string())]
-    UpperCaseName(String),
-    #[regex(r"[a-zα-ω][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*", |lex| lex.slice().to_string())]
-    LowerCaseName(String),
+    #[regex(r"[a-zα-ωA-ZΑ-Ω𝔹ℕ𝕍∃∀×][a-zα-ωA-ZΑ-Ω0-9_]*['⁺⁻₀₁₂₃₄₅₆₇₈₉₊₋]*", |lex| lex.slice().to_string())]
+    Ident(String),
 
     // Literals
     //

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -370,14 +370,18 @@ impl Rename for Args {
 
 impl Rename for Case {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Case { span, name, params, body } = self;
+        let Case { span, pattern, body } = self;
 
-        let new_params = params.rename_in_ctx(ctx);
+        let new_params = pattern.params.rename_in_ctx(ctx);
 
         ctx.bind_iter(new_params.params.clone().into_iter(), |new_ctx| {
             let new_body = body.rename_in_ctx(new_ctx);
-
-            Case { span, name, params: new_params, body: new_body }
+            let pattern = Pattern {
+                is_copattern: pattern.is_copattern,
+                name: pattern.name,
+                params: new_params,
+            };
+            Case { span, pattern, body: new_body }
         })
     }
 }

--- a/lang/syntax/src/ast/decls.rs
+++ b/lang/syntax/src/ast/decls.rs
@@ -429,7 +429,7 @@ impl Print for Dtor {
 
         let doc = doc.print(cfg, alloc);
         let head = if self_param.is_simple() {
-            alloc.nil()
+            alloc.text(DOT)
         } else {
             self_param.print(&PrintCfg { print_function_sugar: false, ..*cfg }, alloc).append(DOT)
         };

--- a/test/suites/fail-check/001.pol
+++ b/test/suites/fail-check/001.pol
@@ -3,5 +3,5 @@ codata Fun(a: Type, b: Type) {
 }
 
 codef ConvertAny(a: Type, b: Type): Fun(a, b) {
-    ap(a, b, x) => x
+    .ap(a, b, x) => x
 }

--- a/test/suites/fail-check/004.pol
+++ b/test/suites/fail-check/004.pol
@@ -4,8 +4,8 @@ data Eq (a: Type, x y: a) {
 
 codata Bool {
     (x: Bool).neg_inverse: Eq(Bool, x, x.not.not),
-    and(other: Bool): Bool,
-    not: Bool
+    .and(other: Bool): Bool,
+    .not: Bool
 }
 data Unit { Top }
 

--- a/test/suites/fail-check/004.pol
+++ b/test/suites/fail-check/004.pol
@@ -11,9 +11,9 @@ data Unit { Top }
 
 def Unit.example : Bool {
     Top => comatch {
-              neg_inverse => ?,
-              and(other) => ?,
-              not => ?
+              .neg_inverse => ?,
+              .and(other) => ?,
+              .not => ?
            }
 }
 

--- a/test/suites/fail-lower/L-002-05.pol
+++ b/test/suites/fail-lower/L-002-05.pol
@@ -1,6 +1,6 @@
 data Bool { True, False }
 
-codata T { f : Bool }
+codata T { .f : Bool }
 
 def Bool.f : Bool {
     True => ?,

--- a/test/suites/fail-lower/L-003.pol
+++ b/test/suites/fail-lower/L-003.pol
@@ -1,5 +1,5 @@
 data Bool { True, False }
-codata Foo { d : Bool }
+codata Foo { .d : Bool }
 
 data Unit { MkUnit }
 

--- a/test/suites/fail-parse/P-002.expected
+++ b/test/suites/fail-parse/P-002.expected
@@ -1,1 +1,1 @@
-Unexpected end of file. Expected "DocComment", "UpperCaseName", "}"
+Unexpected end of file. Expected "DocComment", "LowerCaseName", "UpperCaseName", "}"

--- a/test/suites/fail-parse/P-002.expected
+++ b/test/suites/fail-parse/P-002.expected
@@ -1,1 +1,1 @@
-Unexpected end of file. Expected "DocComment", "LowerCaseName", "UpperCaseName", "}"
+Unexpected end of file. Expected "DocComment", "Identifier", "}"

--- a/test/suites/fail-parse/P-003.expected
+++ b/test/suites/fail-parse/P-003.expected
@@ -1,1 +1,1 @@
-Unexpected end of file. Expected "(", ")", ",", "->", ".", ":", "=>", "LowerCaseName", "UpperCaseName", "_", "absurd", "as", "{", "}"
+Unexpected end of file. Expected "(", ")", ",", "->", ".", ":", "=>", "Identifier", "_", "absurd", "as", "{", "}"

--- a/test/suites/fail-parse/P-003.expected
+++ b/test/suites/fail-parse/P-003.expected
@@ -1,1 +1,1 @@
-Unexpected "LowerCaseName("foo")", expected "UpperCaseName"
+Unexpected end of file. Expected "(", ")", ",", "->", ".", ":", "=>", "LowerCaseName", "UpperCaseName", "_", "absurd", "as", "{", "}"

--- a/test/suites/success/001.pol
+++ b/test/suites/success/001.pol
@@ -3,5 +3,5 @@ codata Fun(a: Type, b: Type) {
 }
 
 codef Id(a: Type): Fun(a, a) {
-    ap(a, b, x) => x
+    .ap(a, b, x) => x
 }

--- a/test/suites/success/002.pol
+++ b/test/suites/success/002.pol
@@ -3,5 +3,5 @@ codata Fun(a: Type, b: Type) {
 }
 
 codef Compose(a: Type, b: Type, c: Type, f: Fun(a, b), g: Fun(b, c)) : Fun(a, c) {
-    ap(a', c', x) => g.ap(b, c, f.ap(a, b, x: a') : b) : c'
+    .ap(a', c', x) => g.ap(b, c, f.ap(a, b, x: a') : b) : c'
 }

--- a/test/suites/success/004.pol
+++ b/test/suites/success/004.pol
@@ -1,6 +1,6 @@
 data Bool { True, False }
 
 codata Stream {
-    head: Bool,
-    tail: Stream,
+    .head : Bool,
+    .tail : Stream,
 }

--- a/test/suites/success/012.pol
+++ b/test/suites/success/012.pol
@@ -8,8 +8,8 @@ codata Foo(b: Bool) {
 }
 
 codef MyFoo: Foo(True) {
-    foo1 => True,
-    foo2 absurd,
-    foo3 absurd,
-    foo4 absurd
+    .foo1 => True,
+    .foo2 absurd,
+    .foo3 absurd,
+    .foo4 absurd
 }

--- a/test/suites/success/Regression-137.pol
+++ b/test/suites/success/Regression-137.pol
@@ -9,7 +9,7 @@ codata Pi(T: Fun(Bool, Type)) {
 data Bool { True, False }
 
 def Bool.ind( P: Fun(Bool,Type)
-                , step: Pi(comatch { ap(_,_,x) => P.ap(Bool,Type,x) -> P.ap(Bool,Type,x) })
+                , step: Pi(comatch { .ap(_,_,x) => P.ap(Bool,Type,x) -> P.ap(Bool,Type,x) })
                 ) : Bool {
   True => ?,
   False => ?

--- a/test/suites/success/Regression-250.pol
+++ b/test/suites/success/Regression-250.pol
@@ -14,6 +14,6 @@ codata Product₋(arity: ℕ) {
 }
 
 codef Unit₋: Product₋(0) {
-    typeAt₋(_, _) absurd,
-    dataAt₋(_, _) absurd,
+    .typeAt₋(_, _) absurd,
+    .dataAt₋(_, _) absurd,
 }


### PR DESCRIPTION
Hey @timsueberkrueb,

I found a solution for our parser ambiguity problems in destructor declarations.
Due to those problems we couldn't make all identifiers be case insensitive. I found a solution that works, but it changes the surface syntax. If we require all destructor declarations to begin with a dot, then the ambiguity disappears:

```
codata foo { .d : Nat }
```

What do you think of this solution? Maybe we should then also require the destructors in cocases to begin with a dot, for the sake of consistency? I.e.:
```
cocase {
  .d => ...
}
```