### PR TITLE
Add Makefile target for computing code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,15 @@ lint:
 test:
 	@cargo test --all
 
+
 .PHONY: update-expected
 update-expected:
 	@cargo test -p test-runner -- --update-expected
+
+
+.PHONY: coverage
+coverage:
+	@echo "Make sure to install via cargo install cargo-llvm-cov first"
+	@cargo llvm-cov --workspace --html
+	@cargo llvm-cov --workspace --open
+


### PR DESCRIPTION
This works, but only takes into account the tests configured inside the workspace, and doesn't run the testrunner. I have to figure out how to include the coverage generated from running the testsuite as well.