### PR TITLE
Make tracing configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "clap",
  "elaborator",
  "env_logger",
+ "log",
  "lowering",
  "parser",
  "printer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "elaborator",
  "env_logger",
  "futures",
+ "log",
  "lsp-server",
  "miette",
  "printer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,6 @@ num-bigint = { version = "0.4" }
 # url (for file locations)
 url = { version = "2.5.0" }
 pretty = { version = "0.11", features = ["termcolor"] }
+# logging infrastructure
 log = "0.4.21"
+env_logger = "0.11.3"

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ From the root of this repository, run:
 pol run examples/example.pol
 ```
 
-Enable verbose tracing output:
-
-```sh
-RUST_LOG=trace pol run examples/example.pol
-```
-
 To pretty-print a file, run:
 
 ```sh
@@ -67,6 +61,21 @@ pol --help
 ```
 
 Please refer to the `README.md` files in the individual subprojects for further information.
+
+## Tracing Support
+
+The compiler uses the [log crate](https://crates.io/crates/log) to trace useful diagnostic information during its execution.
+The emitting of the logs is controlled via environment variables and the [env-logger crate](https://crates.io/crates/env_logger).
+The site for that crate contains a lot of information about all available options.
+The two flags `--trace` and `--debug` can also be used to configure the output.
+
+A simple invocation which writes trace information to the console is:
+
+```sh
+RUST_LOG=trace pol run examples/example.pol
+```
+
+The testsuite uses the same logging infrastructure as the main application, so any options used for the `pol` binary should also work for the `test-runner` binary.
 
 
 ## Licenses

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,7 @@ miette = { workspace = true, features = ["fancy"] }
 thiserror = { workspace = true }
 # Logging infrastructure
 env_logger = "0.11.3"
+log = { workspace = true }
 # lsp
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -22,7 +22,7 @@ termsize = "0.1"
 miette = { workspace = true, features = ["fancy"] }
 thiserror = { workspace = true }
 # Logging infrastructure
-env_logger = "0.11.3"
+env_logger = { workspace = true }
 log = { workspace = true }
 # lsp
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -10,8 +10,22 @@ mod texify;
 mod xfunc;
 
 pub fn exec() -> miette::Result<()> {
-    use Command::*;
     let cli = Cli::parse();
+    // Initialize the logger based on the flags
+    let mut builder = env_logger::Builder::from_default_env();
+    builder.format_timestamp(None).format_level(false).format_target(false);
+
+    if cli.trace {
+        builder.filter_level(log::LevelFilter::Trace);
+    } else if cli.debug {
+        builder.filter_level(log::LevelFilter::Debug);
+    } else {
+        builder.filter_level(log::LevelFilter::Info);
+    }
+
+    builder.init();
+
+    use Command::*;
     match cli.command {
         Run(args) => run::exec(args),
         Check(args) => check::exec(args),
@@ -26,6 +40,12 @@ pub fn exec() -> miette::Result<()> {
 #[derive(Parser)]
 #[clap(version, author, about, long_about = None)]
 struct Cli {
+    /// Enable trace logging
+    #[clap(long)]
+    trace: bool,
+    /// Enable debug logging
+    #[clap(long)]
+    debug: bool,
     #[clap(subcommand)]
     command: Command,
 }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5,7 +5,6 @@ mod result;
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() -> miette::Result<()> {
-    env_logger::builder().format_timestamp(None).format_level(false).format_target(false).init();
     miette::set_panic_hook();
     cli::exec()
 }

--- a/test/test-runner/Cargo.toml
+++ b/test/test-runner/Cargo.toml
@@ -11,9 +11,10 @@ clap = { version = "4", features = ["derive"] }
 # full text search engine
 tantivy = "0.18"
 # url (for file locations)
-url = "2.5.0"
+url = { workspace = true }
 # Logging infrastructure
-env_logger = "0.11.3"
+env_logger = { workspace = true }
+log = { workspace = true }
 # config
 serde = "1"
 serde_derive = "1"

--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -16,11 +16,31 @@ pub struct Args {
     filter: Option<String>,
     #[clap(long, num_args = 0)]
     update_expected: bool,
+    /// Enable trace logging
+    #[clap(long)]
+    trace: bool,
+    /// Enable debug logging
+    #[clap(long)]
+    debug: bool,
 }
 
 fn main() {
-    env_logger::builder().format_timestamp(None).format_level(false).format_target(false).init();
     let args = Args::parse();
+
+    // Initialize the logger based on the flags
+    let mut builder = env_logger::Builder::from_default_env();
+    builder.format_timestamp(None).format_level(false).format_target(false);
+
+    if args.trace {
+        builder.filter_level(log::LevelFilter::Trace);
+    } else if args.debug {
+        builder.filter_level(log::LevelFilter::Debug);
+    } else {
+        builder.filter_level(log::LevelFilter::Info);
+    }
+
+    builder.init();
+
     let runner = runner::Runner::load(crate::TEST_SUITES_PATH, crate::EXAMPLES_PATH);
     let mut res = runner.run(&args);
     if args.update_expected {


### PR DESCRIPTION
Builds upon your commit and adds the same functionality to the test-runner. Also some minor cleanup w.r.t. dependencies and the README.