### PR TITLE
Parse and prettyprint use declarations

### DIFF
--- a/examples/imports.pol
+++ b/examples/imports.pol
@@ -1,0 +1,3 @@
+use "Data/Bool.pol"
+use "Data/Unit.pol"
+use "Data/Nat.pol"

--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -136,14 +136,30 @@ impl MetaVarState {
         }
     }
 }
+
+/// A use declaration
+///
+/// ```text
+/// use "Data/Bool.pol"
+/// ```
+#[derive(Debug, Clone)]
+pub struct UseDecl {
+    pub span: Span,
+    pub path: String,
+}
+
 /// A module containing declarations
 ///
 /// There is a 1-1 correspondence between modules and files in our system.
 #[derive(Debug, Clone)]
 pub struct Module {
+    /// The location of the module on disk
     pub uri: Url,
-    /// List of declarations in the module
+    /// List of module imports at the top of a module.
+    pub use_decls: Vec<UseDecl>,
+    /// Declarations contained in the module other than imports.
     pub decls: Vec<Decl>,
+    /// Metavariables that were generated for this module during lowering.
     pub meta_vars: HashMap<MetaVar, MetaVarState>,
 }
 

--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -14,7 +14,9 @@ use printer::tokens::DOT;
 use printer::tokens::HASH;
 use printer::tokens::IMPLICIT;
 use printer::tokens::LET;
+use printer::tokens::USE;
 use printer::util::BracesExt;
+use printer::util::IsNilExt;
 use printer::Alloc;
 use printer::Builder;
 use printer::Print;
@@ -148,6 +150,13 @@ pub struct UseDecl {
     pub path: String,
 }
 
+impl Print for UseDecl {
+    fn print<'a>(&'a self, _cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
+        let UseDecl { path, .. } = self;
+        alloc.text(USE).append(alloc.space()).append(path)
+    }
+}
+
 /// A module containing declarations
 ///
 /// There is a 1-1 correspondence between modules and files in our system.
@@ -275,16 +284,40 @@ impl Module {
 
 impl Print for Module {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let Module { decls, .. } = self;
+        let Module { use_decls, decls, .. } = self;
 
+        // UseDecls
+        //
+        //
+
+        let use_decls =
+            alloc.intersperse(use_decls.iter().map(|decl| decl.print(cfg, alloc)), alloc.line());
+
+        // Decls
+        //
+        //
+
+        // We usually separate declarations with an empty line, except when the `omit_decl_sep` option is set.
+        // This is useful for typesetting examples in papers which have to make economic use of vertical space.
         let sep = if cfg.omit_decl_sep { alloc.line() } else { alloc.line().append(alloc.line()) };
-        alloc.intersperse(
-            decls
-                .iter()
-                .filter(|decl| decl.attributes().is_visible())
-                .map(|decl| decl.print(cfg, alloc)),
-            sep,
-        )
+
+        let decls = decls
+            .iter()
+            .filter(|decl| decl.attributes().is_visible())
+            .map(|decl| decl.print(cfg, alloc));
+
+        // UseDecls + Decls
+        //
+        //
+
+        if use_decls.is_nil() {
+            alloc.intersperse(decls, sep)
+        } else {
+            use_decls
+                .append(alloc.line())
+                .append(alloc.line())
+                .append(alloc.intersperse(decls, sep))
+        }
     }
 }
 

--- a/lang/elaborator/src/typechecker/decls/mod.rs
+++ b/lang/elaborator/src/typechecker/decls/mod.rs
@@ -17,7 +17,12 @@ pub fn check(prg: Rc<Module>) -> Result<Module, TypeError> {
     let decls =
         prg.decls.iter().map(|decl| decl.check_wf(&mut ctx)).collect::<Result<_, TypeError>>()?;
 
-    Ok(Module { uri: prg.uri.clone(), decls, meta_vars: ctx.meta_vars.clone() })
+    Ok(Module {
+        uri: prg.uri.clone(),
+        use_decls: prg.use_decls.clone(),
+        decls,
+        meta_vars: ctx.meta_vars.clone(),
+    })
 }
 
 pub trait CheckToplevel: Sized {

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -72,11 +72,16 @@ impl Lift for Module {
     type Target = Module;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let Module { uri, decls, meta_vars } = self;
+        let Module { uri, use_decls, decls, meta_vars } = self;
 
         let decls = decls.iter().map(|decl| decl.lift(ctx)).collect();
 
-        Module { uri: uri.clone(), decls, meta_vars: meta_vars.clone() }
+        Module {
+            uri: uri.clone(),
+            use_decls: use_decls.clone(),
+            decls,
+            meta_vars: meta_vars.clone(),
+        }
     }
 }
 

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -3,7 +3,7 @@ mod lookup_table;
 mod lower;
 mod result;
 
-use ast::{self, Decl};
+use ast::{self};
 use parser::cst;
 
 use crate::lookup_table::build_lookup_table;
@@ -13,12 +13,14 @@ pub use ctx::*;
 pub use result::*;
 
 pub fn lower_module(prg: &cst::decls::Module) -> Result<ast::Module, LoweringError> {
-    let cst::decls::Module { uri, decls, .. } = prg;
+    let cst::decls::Module { uri, use_decls, decls } = prg;
 
     let lookup_table = build_lookup_table(prg)?;
 
     let mut ctx = Ctx::empty(lookup_table);
-    let decls = decls.iter().map(|item| item.lower(&mut ctx)).collect::<Result<Vec<Decl>, _>>()?;
 
-    Ok(ast::Module { uri: uri.clone(), decls, meta_vars: ctx.meta_vars })
+    let use_decls = use_decls.lower(&mut ctx)?;
+    let decls = decls.lower(&mut ctx)?;
+
+    Ok(ast::Module { uri: uri.clone(), use_decls, decls, meta_vars: ctx.meta_vars })
 }

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -13,13 +13,12 @@ pub use ctx::*;
 pub use result::*;
 
 pub fn lower_module(prg: &cst::decls::Module) -> Result<ast::Module, LoweringError> {
-    let cst::decls::Module { uri, contents } = prg;
+    let cst::decls::Module { uri, decls, .. } = prg;
 
     let lookup_table = build_lookup_table(prg)?;
 
     let mut ctx = Ctx::empty(lookup_table);
-    let decls =
-        contents.decls.iter().map(|item| item.lower(&mut ctx)).collect::<Result<Vec<Decl>, _>>()?;
+    let decls = decls.iter().map(|item| item.lower(&mut ctx)).collect::<Result<Vec<Decl>, _>>()?;
 
     Ok(ast::Module { uri: uri.clone(), decls, meta_vars: ctx.meta_vars })
 }

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -13,12 +13,13 @@ pub use ctx::*;
 pub use result::*;
 
 pub fn lower_module(prg: &cst::decls::Module) -> Result<ast::Module, LoweringError> {
-    let cst::decls::Module { uri, items } = prg;
+    let cst::decls::Module { uri, contents } = prg;
 
     let lookup_table = build_lookup_table(prg)?;
 
     let mut ctx = Ctx::empty(lookup_table);
-    let decls = items.iter().map(|item| item.lower(&mut ctx)).collect::<Result<Vec<Decl>, _>>()?;
+    let decls =
+        contents.decls.iter().map(|item| item.lower(&mut ctx)).collect::<Result<Vec<Decl>, _>>()?;
 
     Ok(ast::Module { uri: uri.clone(), decls, meta_vars: ctx.meta_vars })
 }

--- a/lang/lowering/src/lookup_table.rs
+++ b/lang/lowering/src/lookup_table.rs
@@ -84,7 +84,7 @@ impl fmt::Display for DeclKind {
 pub fn build_lookup_table(module: &Module) -> Result<LookupTable, LoweringError> {
     let mut lookup_table = LookupTable { map: HashMap::default() };
 
-    let Module { contents: ModuleContents { decls, .. }, .. } = module;
+    let Module { decls, .. } = module;
 
     for decl in decls {
         match decl {

--- a/lang/lowering/src/lookup_table.rs
+++ b/lang/lowering/src/lookup_table.rs
@@ -84,10 +84,10 @@ impl fmt::Display for DeclKind {
 pub fn build_lookup_table(module: &Module) -> Result<LookupTable, LoweringError> {
     let mut lookup_table = LookupTable { map: HashMap::default() };
 
-    let Module { items, .. } = module;
+    let Module { contents: ModuleContents { decls, .. }, .. } = module;
 
-    for item in items {
-        match item {
+    for decl in decls {
+        match decl {
             Decl::Data(data) => build_data(&mut lookup_table, data)?,
             Decl::Codata(codata) => build_codata(&mut lookup_table, codata)?,
             Decl::Def(def) => build_def(&mut lookup_table, def)?,

--- a/lang/lowering/src/lower/decls.rs
+++ b/lang/lowering/src/lower/decls.rs
@@ -28,6 +28,15 @@ impl Lower for cst::decls::Attributes {
     }
 }
 
+impl Lower for cst::decls::UseDecl {
+    type Target = ast::UseDecl;
+
+    fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+        let cst::decls::UseDecl { span, path } = self;
+        Ok(ast::UseDecl { span: span.clone(), path: path.clone() })
+    }
+}
+
 impl Lower for cst::decls::Decl {
     type Target = ast::Decl;
 

--- a/lang/lowering/src/lower/decls.rs
+++ b/lang/lowering/src/lower/decls.rs
@@ -33,7 +33,7 @@ impl Lower for cst::decls::UseDecl {
 
     fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
         let cst::decls::UseDecl { span, path } = self;
-        Ok(ast::UseDecl { span: span.clone(), path: path.clone() })
+        Ok(ast::UseDecl { span: *span, path: path.clone() })
     }
 }
 

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -21,7 +21,18 @@ pub struct Attributes {
 pub struct Module {
     /// The location of the module on disk
     pub uri: Url,
-    pub items: Vec<Decl>,
+    pub contents: ModuleContents,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModuleContents {
+    pub use_decls: Vec<UseDecl>,
+    pub decls: Vec<Decl>,
+}
+
+#[derive(Debug, Clone)]
+pub enum UseDecl {
+    String(String),
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/cst/decls.rs
+++ b/lang/parser/src/cst/decls.rs
@@ -21,18 +21,21 @@ pub struct Attributes {
 pub struct Module {
     /// The location of the module on disk
     pub uri: Url,
-    pub contents: ModuleContents,
-}
-
-#[derive(Debug, Clone)]
-pub struct ModuleContents {
+    /// List of module imports at the top of a module.
     pub use_decls: Vec<UseDecl>,
+    /// Declarations contained in the module other than imports.
     pub decls: Vec<Decl>,
 }
 
+/// A use declaration
+///
+/// ```text
+/// use "Data/Bool.pol"
+/// ```
 #[derive(Debug, Clone)]
-pub enum UseDecl {
-    String(String),
+pub struct UseDecl {
+    pub span: Span,
+    pub path: String,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -131,19 +131,19 @@ Arg: Arg = {
 //
 //
 
-pub ModuleContents: ModuleContents = {
-    <use_decls: UseDecl*> <decls: Decls> => ModuleContents { use_decls, decls }
+pub ModuleContents: (Vec<UseDecl>, Vec<Decl>) = {
+    <use_decls: UseDecl*> <decls: Decls> => (use_decls, decls)
 }
 
-pub UseDecl: UseDecl = {
-  "use" <lit: "StringLit"> => UseDecl::String(lit),
+UseDecl: UseDecl = {
+  <l: @L> "use" <path: "StringLit"> <r: @R> => UseDecl { span: span(l,r), path },
 }
 
-pub Decls: Vec<Decl> = {
+Decls: Vec<Decl> = {
     <items: Decl*> => items,
 }
 
-pub Decl: Decl = {
+Decl: Decl = {
     <d: Data> => Decl::Data(d),
     <d: Codata> => Decl::Codata(d),
     <d: Def> => Decl::Def(d),

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -30,6 +30,7 @@ extern {
     "absurd" => Token::Absurd,
     "Type" => Token::Type,
     "implicit" => Token::Implicit,
+    "use" => Token::Use,
 
     // Parens, Braces and Brackets
     //
@@ -129,6 +130,14 @@ Arg: Arg = {
 // Modules
 //
 //
+
+pub ModuleContents: ModuleContents = {
+    <use_decls: UseDecl*> <decls: Decls> => ModuleContents { use_decls, decls }
+}
+
+pub UseDecl: UseDecl = {
+  "use" <lit: "StringLit"> => UseDecl::String(lit),
+}
 
 pub Decls: Vec<Decl> = {
     <items: Decl*> => items,

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -43,6 +43,8 @@ pub enum Token {
     Type,
     #[token("implicit")]
     Implicit,
+    #[token("use")]
+    Use,
 
     // Parens, Braces and Brackets
     //

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -18,6 +18,6 @@ pub fn parse_exp(s: &str) -> Result<Box<cst::exp::Exp>, ParseError> {
 pub fn parse_module(uri: Url, s: &str) -> Result<cst::decls::Module, ParseError> {
     let lexer = Lexer::new(s);
     let parser = ModuleContentsParser::new();
-    let contents = parser.parse(lexer)?;
-    Ok(cst::decls::Module { uri, contents })
+    let (use_decls, decls) = parser.parse(lexer)?;
+    Ok(cst::decls::Module { uri, use_decls, decls })
 }

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -6,7 +6,7 @@ mod result;
 use lexer::Lexer;
 use url::Url;
 
-use grammar::cst::{DeclsParser, ExpParser};
+use grammar::cst::{ExpParser, ModuleContentsParser};
 pub use result::*;
 
 pub fn parse_exp(s: &str) -> Result<Box<cst::exp::Exp>, ParseError> {
@@ -17,7 +17,7 @@ pub fn parse_exp(s: &str) -> Result<Box<cst::exp::Exp>, ParseError> {
 
 pub fn parse_module(uri: Url, s: &str) -> Result<cst::decls::Module, ParseError> {
     let lexer = Lexer::new(s);
-    let parser = DeclsParser::new();
-    let items = parser.parse(lexer)?;
-    Ok(cst::decls::Module { uri, items })
+    let parser = ModuleContentsParser::new();
+    let contents = parser.parse(lexer)?;
+    Ok(cst::decls::Module { uri, contents })
 }

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -28,6 +28,8 @@ pub const HOLE: &str = "?";
 
 /// The symbol `#`
 pub const HASH: &str = "#";
+
+/// The symbol `:=`
 pub const COLONEQ: &str = ":=";
 
 // Keywords
@@ -66,3 +68,6 @@ pub const TYPE: &str = "Type";
 
 /// The keyword `implicit`
 pub const IMPLICIT: &str = "implicit";
+
+/// The keyword `use`
+pub const USE: &str = "use";

--- a/lang/query/src/view/xfunc.rs
+++ b/lang/query/src/view/xfunc.rs
@@ -77,8 +77,12 @@ fn generate_edits(
 
     // Edits for the type that has been xfunctionalized
     // Here we rewrite the entire (co)data declaration and its associated (co)definitions
-    let new_items =
-        Module { uri: module.uri.clone(), decls: new_decls, meta_vars: module.meta_vars.clone() };
+    let new_items = Module {
+        uri: module.uri.clone(),
+        use_decls: module.use_decls.clone(),
+        decls: new_decls,
+        meta_vars: module.meta_vars.clone(),
+    };
     let type_text = new_items.print_to_string(None);
 
     let mut edits = vec![Edit { span: original.type_span, text: type_text }];

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -46,11 +46,11 @@ impl<R: Rename + Clone> Rename for Box<R> {
 
 impl Rename for Module {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Module { uri, decls, meta_vars } = self;
+        let Module { uri, use_decls, decls, meta_vars } = self;
 
         let decls = decls.rename_in_ctx(ctx);
 
-        Module { uri, decls, meta_vars }
+        Module { uri, use_decls, decls, meta_vars }
     }
 }
 


### PR DESCRIPTION
I slightly changed the `cst` representation that you chose, and made the `ast` definition of modules consistent with that.
It should not be too hard to rebase #283 on top of this PR.