### PR TITLE
Fix prettyprinting of keywords in browser

### DIFF
--- a/web/packages/app/src/tutorial/highlight.ts
+++ b/web/packages/app/src/tutorial/highlight.ts
@@ -15,7 +15,7 @@ const UPPER_IDENT = {
 const pol: Language = {
   case_insensitive: false,
   keywords: {
-    keyword: ["data", "codata", "impl", "def", "codef", "match", "comatch", "absurd"],
+    keyword: ["data", "codata", "def", "codef", "let", "match", "comatch", "implicit", "use"],
     built_in: ["Type"],
   },
   contains: [COMMENT, PUNCTUATION, UPPER_IDENT],


### PR DESCRIPTION
The demo on the website does not highlight the correct keywords. This will be a hotfix for that issue.