### PR TITLE
Adjust stringlit lexer

### DIFF
--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -154,7 +154,7 @@ pub struct UseDecl {
 impl Print for UseDecl {
     fn print<'a>(&'a self, _cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let UseDecl { path, .. } = self;
-        alloc.text(USE).append(alloc.space()).append(path)
+        alloc.text(USE).append(alloc.space()).append(alloc.text(path).double_quotes())
     }
 }
 

--- a/lang/elaborator/src/lib.rs
+++ b/lang/elaborator/src/lib.rs
@@ -2,3 +2,5 @@ pub mod normalizer;
 pub mod result;
 pub mod typechecker;
 pub mod unifier;
+
+pub use typechecker::lookup_table::LookupTable;

--- a/lang/elaborator/src/result.rs
+++ b/lang/elaborator/src/result.rs
@@ -15,7 +15,7 @@ fn separated<I: IntoIterator<Item = String>>(s: &str, iter: I) -> String {
     vec.join(s)
 }
 
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Diagnostic, Debug, Clone)]
 pub enum TypeError {
     #[error("Wrong number of arguments to {name} provided: got {actual}, expected {expected}")]
     #[diagnostic(code("T-001"))]

--- a/lang/elaborator/src/typechecker/lookup_table.rs
+++ b/lang/elaborator/src/typechecker/lookup_table.rs
@@ -2,7 +2,7 @@ use ast::*;
 
 use super::TypeError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct LookupTable {
     // Calls
     //
@@ -84,18 +84,18 @@ impl LookupTable {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LetMeta {
     pub params: Telescope,
     pub typ: Box<Exp>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TyCtorMeta {
     pub params: Box<Telescope>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CodefMeta {
     pub params: Telescope,
     pub typ: TypCtor,
@@ -113,7 +113,7 @@ pub struct CtorMeta {
     pub typ: TypCtor,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DefMeta {
     pub params: Telescope,
     pub self_param: SelfParam,
@@ -138,14 +138,7 @@ pub struct DtorMeta {
 }
 
 pub fn build_lookup_table(module: &Module) -> LookupTable {
-    let mut lookup_table = LookupTable {
-        map_let: HashMap::default(),
-        map_tyctor: HashMap::default(),
-        map_codef: HashMap::default(),
-        map_ctor: HashMap::default(),
-        map_def: HashMap::default(),
-        map_dtor: HashMap::default(),
-    };
+    let mut lookup_table = LookupTable::default();
 
     let Module { decls, .. } = module;
 

--- a/lang/lowering/src/lookup_table.rs
+++ b/lang/lowering/src/lookup_table.rs
@@ -9,7 +9,7 @@ use parser::cst::*;
 
 use crate::LoweringError;
 
-#[derive(Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LookupTable {
     map: HashMap<Ident, DeclMeta>,
 }

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::lookup_table::DeclKind;
 
-#[derive(Error, Diagnostic, Debug)]
+#[derive(Error, Diagnostic, Debug, Clone)]
 pub enum LoweringError {
     #[error("Undefined identifier {}", name.id)]
     #[diagnostic(code("L-001"))]

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -101,7 +101,12 @@ pub enum Token {
     NumLit(BigUint),
     /// The regexp is from `https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5`
     /// We do not allow multi line strings.
-    #[regex(r###""([^"\\]|\\.)*""###, |lex| lex.slice().to_string())]
+    #[regex(r###""([^"\\]|\\.)*""###, |lex| {
+      let slice = lex.slice();
+      // Remove the surrounding quotation marks
+      let inner = &slice[1..slice.len()-1];
+      inner.to_string()
+    })]
     StringLit(String),
 
     // DocComments
@@ -147,20 +152,20 @@ mod lexer_tests {
     fn string_lit_simple() {
         let str = r###""hi""###;
         let mut lexer = Lexer::new(str);
-        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit(str.to_string()))
+        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit("hi".to_string()))
     }
 
     #[test]
     fn string_lit_newline() {
         let str = r###""h\ni""###;
         let mut lexer = Lexer::new(str);
-        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit(str.to_string()))
+        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit("h\\ni".to_string()))
     }
 
     #[test]
     fn string_lit_escaped_quote() {
         let str = r###""h\"i""###;
         let mut lexer = Lexer::new(str);
-        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit(str.to_string()))
+        assert_eq!(lexer.next().unwrap().unwrap().1, Token::StringLit("h\\\"i".to_string()))
     }
 }


### PR DESCRIPTION
Adjusts the string literals lexer to not store the quotation marks, and add some instances of Clone and Debug to types.