### PR TITLE
Implement different kinds of typed holes

### DIFF
--- a/lang/ast/src/exp.rs
+++ b/lang/ast/src/exp.rs
@@ -1043,25 +1043,11 @@ fn print_lambda_sugar<'a>(cases: &'a [Case], cfg: &PrintCfg, alloc: &'a Alloc<'a
 
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
-pub enum HoleKind {
-    /// A typed hole written `_` that must be solved during type inference.
-    /// If type inference doesn't find a unique solution, an error is thrown.
-    MustSolve,
-    /// A typed hole written `?` that stands for an incomplete program.
-    /// This hole can be solved during type checking, but we do not throw an error
-    /// if it isn't solved.
-    CanSolve,
-    /// Inserted during lowering for implicit argument.
-    Inserted,
-}
-
-#[derive(Debug, Clone, Derivative)]
-#[derivative(Eq, PartialEq, Hash)]
 pub struct Hole {
     /// Source code location
     pub span: Option<Span>,
     /// Whether the hole must be solved during typechecking or not.
-    pub kind: HoleKind,
+    pub kind: MetaVarKind,
     /// The metavariable that we want to solve for that hole
     pub metavar: MetaVar,
     /// The inferred type of the hole annotated during elaboration.
@@ -1102,7 +1088,7 @@ impl Shift for Hole {
         let new_args = args.shift_in_range(range, by);
         Hole {
             span: *span,
-            kind: kind.clone(),
+            kind: *kind,
             metavar: *metavar,
             inferred_type: None,
             inferred_ctx: None,
@@ -1130,7 +1116,7 @@ impl Substitutable for Hole {
         let Hole { span, kind, metavar, args, .. } = self;
         Hole {
             span: *span,
-            kind: kind.clone(),
+            kind: *kind,
             metavar: *metavar,
             inferred_type: None,
             inferred_ctx: None,
@@ -1147,21 +1133,21 @@ impl Print for Hole {
         _prec: Precedence,
     ) -> Builder<'a> {
         match self.kind {
-            HoleKind::MustSolve => {
+            MetaVarKind::MustSolve => {
                 if cfg.print_metavar_ids {
                     alloc.text(format!("_{}", self.metavar.id))
                 } else {
                     alloc.keyword(UNDERSCORE)
                 }
             }
-            HoleKind::CanSolve => {
+            MetaVarKind::CanSolve => {
                 if cfg.print_metavar_ids {
                     alloc.text(format!("?{}", self.metavar.id))
                 } else {
                     alloc.keyword(QUESTIONMARK)
                 }
             }
-            HoleKind::Inserted => alloc.text(format!("<Inserted>{}", self.metavar.id)),
+            MetaVarKind::Inserted => alloc.text(format!("<Inserted>{}", self.metavar.id)),
         }
     }
 }

--- a/lang/ast/src/exp.rs
+++ b/lang/ast/src/exp.rs
@@ -6,7 +6,7 @@ use derivative::Derivative;
 use pretty::DocAllocator;
 use printer::theme::ThemeExt;
 use printer::tokens::{
-    ABSURD, ARROW, AS, COLON, COMATCH, COMMA, DOT, FAT_ARROW, MATCH, QUESTIONMARK, TYPE,
+    ABSURD, ARROW, AS, COLON, COMATCH, COMMA, DOT, FAT_ARROW, MATCH, QUESTIONMARK, TYPE, UNDERSCORE,
 };
 use printer::util::{BackslashExt, BracesExt, IsNilExt};
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg};
@@ -1146,10 +1146,22 @@ impl Print for Hole {
         alloc: &'a Alloc<'a>,
         _prec: Precedence,
     ) -> Builder<'a> {
-        if cfg.print_metavar_ids {
-            alloc.text(format!("?{}", self.metavar.id))
-        } else {
-            alloc.keyword(QUESTIONMARK)
+        match self.kind {
+            HoleKind::MustSolve => {
+                if cfg.print_metavar_ids {
+                    alloc.text(format!("_{}", self.metavar.id))
+                } else {
+                    alloc.keyword(UNDERSCORE)
+                }
+            }
+            HoleKind::CanSolve => {
+                if cfg.print_metavar_ids {
+                    alloc.text(format!("?{}", self.metavar.id))
+                } else {
+                    alloc.keyword(QUESTIONMARK)
+                }
+            }
+            HoleKind::Inserted => alloc.text(format!("<Inserted>{}", self.metavar.id)),
         }
     }
 }

--- a/lang/ast/src/exp.rs
+++ b/lang/ast/src/exp.rs
@@ -6,7 +6,8 @@ use derivative::Derivative;
 use pretty::DocAllocator;
 use printer::theme::ThemeExt;
 use printer::tokens::{
-    ABSURD, ARROW, AS, COLON, COMATCH, COMMA, DOT, FAT_ARROW, MATCH, QUESTIONMARK, TYPE, UNDERSCORE,
+    ABSURD, ARROW, AS, COLON, COMATCH, COMMA, DOT, FAT_ARROW, MATCH, QUESTION_MARK, TYPE,
+    UNDERSCORE,
 };
 use printer::util::{BackslashExt, BracesExt, IsNilExt};
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg};
@@ -1144,7 +1145,7 @@ impl Print for Hole {
                 if cfg.print_metavar_ids {
                     alloc.text(format!("?{}", self.metavar.id))
                 } else {
-                    alloc.keyword(QUESTIONMARK)
+                    alloc.keyword(QUESTION_MARK)
                 }
             }
             MetaVarKind::Inserted => alloc.text(format!("<Inserted>{}", self.metavar.id)),

--- a/lang/ast/src/ident.rs
+++ b/lang/ast/src/ident.rs
@@ -46,6 +46,15 @@ impl MetaVar {
     pub fn is_user(&self) -> bool {
         self.kind == MetaVarKind::MustSolve || self.kind == MetaVarKind::CanSolve
     }
+
+    /// Metavariables which must be solved during type inference.
+    pub fn must_be_solved(&self) -> bool {
+        match self.kind {
+            MetaVarKind::MustSolve => true,
+            MetaVarKind::CanSolve => false,
+            MetaVarKind::Inserted => true,
+        }
+    }
 }
 
 // Difference between two-level deBruijn indizes and levels

--- a/lang/ast/src/ident.rs
+++ b/lang/ast/src/ident.rs
@@ -14,8 +14,13 @@ pub type Ident = String;
 #[derive(Debug, Clone, Copy, Derivative)]
 #[derivative(Eq, PartialEq, Hash)]
 pub enum MetaVarKind {
-    /// A metavariable which was generated for a typed hole written by the user.
-    User,
+    /// A typed hole written `_` that must be solved during type inference.
+    /// If type inference doesn't find a unique solution, an error is thrown.
+    MustSolve,
+    /// A typed hole written `?` that stands for an incomplete program.
+    /// This hole can be solved during type checking, but we do not throw an error
+    /// if it isn't solved.
+    CanSolve,
     /// A metavariable which was inserted during lowering for an implicit argument.
     Inserted,
 }
@@ -39,7 +44,7 @@ impl MetaVar {
     /// Check whether this metavariable corresponds to a typed hole written
     /// by the programmer.
     pub fn is_user(&self) -> bool {
-        self.kind == MetaVarKind::User
+        self.kind == MetaVarKind::MustSolve || self.kind == MetaVarKind::CanSolve
     }
 }
 

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -354,7 +354,7 @@ impl Eval for Hole {
         let Hole { span, kind, metavar, args, .. } = self;
         let args = args.eval(prg, env)?;
         Ok(Rc::new(Val::Neu(
-            val::Hole { span: *span, kind: kind.clone(), metavar: *metavar, args }.into(),
+            val::Hole { span: *span, kind: *kind, metavar: *metavar, args }.into(),
         )))
     }
 }

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -351,9 +351,11 @@ impl Eval for Hole {
     type Val = Rc<Val>;
 
     fn eval(&self, prg: &Module, env: &mut Env) -> Result<Self::Val, TypeError> {
-        let Hole { span, metavar, args, .. } = self;
+        let Hole { span, kind, metavar, args, .. } = self;
         let args = args.eval(prg, env)?;
-        Ok(Rc::new(Val::Neu(val::Hole { span: *span, metavar: *metavar, args }.into())))
+        Ok(Rc::new(Val::Neu(
+            val::Hole { span: *span, kind: kind.clone(), metavar: *metavar, args }.into(),
+        )))
     }
 }
 

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -555,7 +555,7 @@ impl ReadBack for LocalMatch {
 pub struct Hole {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub span: Option<Span>,
-    pub kind: ast::HoleKind,
+    pub kind: ast::MetaVarKind,
     pub metavar: MetaVar,
     /// Explicit substitution of the context, compare documentation of ast::Hole
     pub args: Vec<Vec<Rc<Val>>>,
@@ -564,12 +564,7 @@ pub struct Hole {
 impl Shift for Hole {
     fn shift_in_range<R: ShiftRange>(&self, range: R, by: (isize, isize)) -> Self {
         let Hole { span, kind, metavar, args } = self;
-        Hole {
-            span: *span,
-            kind: kind.clone(),
-            metavar: *metavar,
-            args: args.shift_in_range(range, by),
-        }
+        Hole { span: *span, kind: *kind, metavar: *metavar, args: args.shift_in_range(range, by) }
     }
 }
 
@@ -597,7 +592,7 @@ impl ReadBack for Hole {
         let args = args.read_back(prg)?;
         Ok(ast::Hole {
             span: *span,
-            kind: kind.clone(),
+            kind: *kind,
             metavar: *metavar,
             inferred_type: None,
             inferred_ctx: None,

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -573,7 +573,7 @@ impl Print for Hole {
         if cfg.print_metavar_ids {
             alloc.text(format!("?{}", self.metavar.id))
         } else {
-            alloc.keyword(QUESTIONMARK)
+            alloc.keyword(QUESTION_MARK)
         }
     }
 }

--- a/lang/elaborator/src/typechecker/ctx.rs
+++ b/lang/elaborator/src/typechecker/ctx.rs
@@ -40,10 +40,11 @@ impl Ctx {
     pub fn check_metavars_solved(&self) -> Result<(), TypeError> {
         let mut unsolved: HashSet<MetaVar> = HashSet::default();
         for (var, state) in self.meta_vars.iter() {
-            // We only have to throw an error for unsolved inserted metavars.
-            // Unsolved metavariables that correspond to typed holes do not lead
+            // We only have to throw an error for unsolved metavars which were either
+            // inserted or are holes `_` which must be solved
+            // Unsolved metavariables that correspond to typed holes `?` do not lead
             // to an error.
-            if !state.is_solved() && var.is_inserted() {
+            if !state.is_solved() && var.must_be_solved() {
                 unsolved.insert(*var);
             }
         }

--- a/lang/elaborator/src/typechecker/exprs/hole.rs
+++ b/lang/elaborator/src/typechecker/exprs/hole.rs
@@ -20,7 +20,7 @@ impl CheckInfer for Hole {
             .collect::<Result<_, _>>()?;
         Ok(Hole {
             span: *span,
-            kind: kind.clone(),
+            kind: *kind,
             metavar: *metavar,
             inferred_type: Some(Box::new(t.clone())),
             inferred_ctx: Some(ctx.vars.clone()),

--- a/lang/elaborator/src/typechecker/exprs/hole.rs
+++ b/lang/elaborator/src/typechecker/exprs/hole.rs
@@ -13,13 +13,14 @@ use crate::result::TypeError;
 
 impl CheckInfer for Hole {
     fn check(&self, ctx: &mut Ctx, t: &Exp) -> Result<Self, TypeError> {
-        let Hole { span, metavar, args, .. } = self;
+        let Hole { span, kind, metavar, args, .. } = self;
         let args: Vec<Vec<Box<Exp>>> = args
             .iter()
             .map(|subst| subst.iter().map(|exp| exp.infer(ctx)).collect::<Result<Vec<_>, _>>())
             .collect::<Result<_, _>>()?;
         Ok(Hole {
             span: *span,
+            kind: kind.clone(),
             metavar: *metavar,
             inferred_type: Some(Box::new(t.clone())),
             inferred_ctx: Some(ctx.vars.clone()),

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -362,7 +362,7 @@ impl Lift for Hole {
         let Hole { span, kind, metavar, args, .. } = self;
         Hole {
             span: *span,
-            kind: kind.clone(),
+            kind: *kind,
             metavar: *metavar,
             inferred_type: None,
             inferred_ctx: None,

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -359,9 +359,10 @@ impl Lift for Hole {
     type Target = Exp;
 
     fn lift(&self, _ctx: &mut Ctx) -> Self::Target {
-        let Hole { span, metavar, args, .. } = self;
+        let Hole { span, kind, metavar, args, .. } = self;
         Hole {
             span: *span,
+            kind: kind.clone(),
             metavar: *metavar,
             inferred_type: None,
             inferred_ctx: None,

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -416,7 +416,7 @@ impl Lower for cst::exp::Hole {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Hole { span } = self;
+        let cst::exp::Hole { span, .. } = self;
         let mv = ctx.fresh_metavar(MetaVarKind::User);
         let args = ctx.subst_from_ctx();
         Ok(Hole { span: Some(*span), metavar: mv, inferred_type: None, inferred_ctx: None, args }

--- a/lang/lowering/src/lower/exp.rs
+++ b/lang/lowering/src/lower/exp.rs
@@ -193,7 +193,7 @@ fn lower_args(
                 let args = ctx.subst_from_ctx();
                 let hole = Hole {
                     span: None,
-                    kind: ast::HoleKind::Inserted,
+                    kind: ast::MetaVarKind::Inserted,
                     metavar: mv,
                     inferred_type: None,
                     inferred_ctx: None,
@@ -419,12 +419,12 @@ impl Lower for cst::exp::LocalComatch {
 }
 
 impl Lower for cst::exp::HoleKind {
-    type Target = ast::HoleKind;
+    type Target = ast::MetaVarKind;
 
     fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
         match self {
-            cst::exp::HoleKind::MustSolve => Ok(ast::HoleKind::MustSolve),
-            cst::exp::HoleKind::CanSolve => Ok(ast::HoleKind::CanSolve),
+            cst::exp::HoleKind::MustSolve => Ok(ast::MetaVarKind::MustSolve),
+            cst::exp::HoleKind::CanSolve => Ok(ast::MetaVarKind::CanSolve),
         }
     }
 }
@@ -434,11 +434,12 @@ impl Lower for cst::exp::Hole {
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
         let cst::exp::Hole { span, kind, .. } = self;
-        let mv = ctx.fresh_metavar(MetaVarKind::User);
+        let kind = kind.lower(ctx)?;
+        let mv = ctx.fresh_metavar(kind);
         let args = ctx.subst_from_ctx();
         Ok(Hole {
             span: Some(*span),
-            kind: kind.lower(ctx)?,
+            kind,
             metavar: mv,
             inferred_type: None,
             inferred_ctx: None,

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -123,8 +123,15 @@ pub struct LocalComatch {
 }
 
 #[derive(Debug, Clone)]
+pub enum HoleKind {
+    MustSolve,
+    CanSolve,
+}
+
+#[derive(Debug, Clone)]
 pub struct Hole {
     pub span: Span,
+    pub kind: HoleKind,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -124,7 +124,9 @@ pub struct LocalComatch {
 
 #[derive(Debug, Clone)]
 pub enum HoleKind {
+    /// A hole `_` that must be solved by the constraint solver.
     MustSolve,
+    /// A hole `?` that the programmer needs help with.
     CanSolve,
 }
 

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -297,8 +297,10 @@ LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <cases: Comma<
 TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>
   TypeUniv { span: span(l, r) };
 
-Hole: Hole = <l: @L> "?" <r: @R> =>
-  Hole { span: span(l, r) };
+Hole: Hole = {
+  <l: @L> "_" <r: @R> => Hole { span: span(l, r), kind: HoleKind::MustSolve },
+  <l: @L> "?" <r: @R> => Hole { span: span(l, r), kind: HoleKind::CanSolve },
+}
 
 NatLit: NatLit = <l: @L> <n: "NumLit"> <r: @R> =>
   NatLit { span: span(l, r), val: n };

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -24,13 +24,16 @@ pub const DOT: &str = ".";
 pub const AT: &str = "@";
 
 /// The symbol `?`
-pub const HOLE: &str = "?";
+pub const QUESTIONMARK: &str = "?";
 
 /// The symbol `#`
 pub const HASH: &str = "#";
 
 /// The symbol `:=`
 pub const COLONEQ: &str = ":=";
+
+/// The symbol `_`
+pub const UNDERSCORE: &str = "_";
 
 // Keywords
 //

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -24,7 +24,7 @@ pub const DOT: &str = ".";
 pub const AT: &str = "@";
 
 /// The symbol `?`
-pub const QUESTIONMARK: &str = "?";
+pub const QUESTION_MARK: &str = "?";
 
 /// The symbol `#`
 pub const HASH: &str = "#";

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -376,7 +376,7 @@ impl CollectInfo for DotCall {
 
 impl CollectInfo for Hole {
     fn collect_info(&self, collector: &mut InfoCollector) {
-        let Hole { span, metavar, inferred_type, inferred_ctx, args } = self;
+        let Hole { span, kind: _, metavar, inferred_type, inferred_ctx, args } = self;
         if let Some(span) = span {
             let metavar_state = collector
                 .module

--- a/lang/renaming/src/ast.rs
+++ b/lang/renaming/src/ast.rs
@@ -311,9 +311,10 @@ impl Rename for LocalComatch {
 
 impl Rename for Hole {
     fn rename_in_ctx(self, ctx: &mut Ctx) -> Self {
-        let Hole { span, metavar, inferred_type, inferred_ctx: _, args } = self;
+        let Hole { span, kind, metavar, inferred_type, inferred_ctx: _, args } = self;
         Hole {
             span,
+            kind,
             metavar,
             inferred_type: inferred_type.rename_in_ctx(ctx),
             inferred_ctx: None, // TODO: Rename TypeCtx!

--- a/test/suites/fail-check/007.pol
+++ b/test/suites/fail-check/007.pol
@@ -1,0 +1,6 @@
+data Option(a: Type) {
+    None(a: Type) : Option(a),
+    Some(a:Type, x: a) : Option(a)
+}
+
+let example : Option(_) { None(_) }

--- a/test/suites/fail-parse/Regr-underscore.pol
+++ b/test/suites/fail-parse/Regr-underscore.pol
@@ -1,9 +1,0 @@
-codata Fun(a b: Type) {
-    Fun(a, b).ap(a b: Type, x: a): b
-}
-
-data Unit { MkUnit }
-
-def Unit.test : Unit -> Unit {
-    MkUnit => \_. _
-}

--- a/test/suites/success/017.pol
+++ b/test/suites/success/017.pol
@@ -1,0 +1,8 @@
+data Pair(a b: Type) {
+    MkPair(a b: Type,x: a, y: b) : Pair(a,b)
+}
+data Bool { True, False }
+
+let example1: Pair(Bool,Bool) {
+    MkPair(_,_, True, False)
+}

--- a/test/suites/success/018.pol
+++ b/test/suites/success/018.pol
@@ -1,0 +1,6 @@
+data Option(a: Type) {
+    None(a: Type) : Option(a),
+    Some(a:Type, x: a) : Option(a)
+}
+
+let example : Option(?) { None(?) }


### PR DESCRIPTION
Fixes #236 

- [x]  Unify MetaVarKind and HoleKind
- [x] Adapt checking for unsolved metavars to these two kinds of holes.
- [x] Fix prettyprinter for holes