### PR TITLE
Make ast Ident abstract

### DIFF
--- a/lang/ast/src/exp.rs
+++ b/lang/ast/src/exp.rs
@@ -255,8 +255,11 @@ impl Print for Exp {
                     if !dtors_group.is_nil() {
                         dtors_group = alloc.line_().append(dtors_group);
                     }
-                    dtors_group =
-                        alloc.text(DOT).append(alloc.dtor(name)).append(psubst).append(dtors_group);
+                    dtors_group = alloc
+                        .text(DOT)
+                        .append(alloc.dtor(&name.id))
+                        .append(psubst)
+                        .append(dtors_group);
                     dtor = exp;
                 }
                 dtor.print(cfg, alloc).append(dtors_group.align().group())
@@ -359,10 +362,10 @@ impl Print for Variable {
         let Variable { name, idx, .. } = self;
         if cfg.de_bruijn {
             alloc.text(format!("{name}@{idx}"))
-        } else if name.is_empty() {
+        } else if name.id.is_empty() {
             alloc.text(format!("@{idx}"))
         } else {
-            alloc.text(name)
+            alloc.text(&name.id)
         }
     }
 }
@@ -445,7 +448,7 @@ impl Print for TypCtor {
         prec: Precedence,
     ) -> Builder<'a> {
         let TypCtor { span: _, name, args } = self;
-        if name == "Fun" && args.len() == 2 && cfg.print_function_sugar {
+        if name.id == "Fun" && args.len() == 2 && cfg.print_function_sugar {
             let arg = args.args[0].print_prec(cfg, alloc, 1);
             let res = args.args[1].print_prec(cfg, alloc, 0);
             let fun = arg.append(alloc.space()).append(ARROW).append(alloc.space()).append(res);
@@ -456,7 +459,7 @@ impl Print for TypCtor {
             }
         } else {
             let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc) };
-            alloc.typ(name).append(psubst)
+            alloc.typ(&name.id).append(psubst)
         }
     }
 }
@@ -560,7 +563,7 @@ impl Print for Call {
     ) -> Builder<'a> {
         let Call { name, args, .. } = self;
         let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc) };
-        alloc.ctor(name).append(psubst)
+        alloc.ctor(&name.id).append(psubst)
     }
 }
 
@@ -913,7 +916,7 @@ impl Print for LocalMatch {
             .append(DOT)
             .append(alloc.keyword(MATCH))
             .append(match &name.user_name {
-                Some(name) => alloc.space().append(alloc.dtor(name)),
+                Some(name) => alloc.space().append(alloc.dtor(&name.id)),
                 None => alloc.nil(),
             })
             .append(motive.as_ref().map(|m| m.print(cfg, alloc)).unwrap_or(alloc.nil()))
@@ -1009,7 +1012,7 @@ impl Print for LocalComatch {
             alloc
                 .keyword(COMATCH)
                 .append(match &name.user_name {
-                    Some(name) => alloc.space().append(alloc.ctor(name)),
+                    Some(name) => alloc.space().append(alloc.ctor(&name.id)),
                     None => alloc.nil(),
                 })
                 .append(alloc.space())
@@ -1032,7 +1035,7 @@ fn print_lambda_sugar<'a>(cases: &'a [Case], cfg: &PrintCfg, alloc: &'a Alloc<'a
         .name();
     alloc
         .backslash_anno(cfg)
-        .append(var_name)
+        .append(&var_name.id)
         .append(DOT)
         .append(alloc.space())
         .append(body.print(cfg, alloc))
@@ -1169,9 +1172,9 @@ impl Print for Pattern {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Pattern { is_copattern, name, params } = self;
         if *is_copattern {
-            alloc.text(DOT).append(alloc.ctor(name)).append(params.print(cfg, alloc))
+            alloc.text(DOT).append(alloc.ctor(&name.id)).append(params.print(cfg, alloc))
         } else {
-            alloc.ctor(name).append(params.print(cfg, alloc))
+            alloc.ctor(&name.id).append(params.print(cfg, alloc))
         }
     }
 }
@@ -1318,7 +1321,7 @@ impl Named for ParamInst {
 impl Print for ParamInst {
     fn print<'a>(&'a self, _cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let ParamInst { span: _, info: _, name, typ: _ } = self;
-        alloc.text(name)
+        alloc.text(&name.id)
     }
 }
 

--- a/lang/ast/src/ident.rs
+++ b/lang/ast/src/ident.rs
@@ -7,7 +7,17 @@ use printer::{
     Alloc, Builder, Print, PrintCfg,
 };
 
-pub type Ident = String;
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+pub struct Ident {
+    pub id: String,
+}
+
+impl fmt::Display for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
 
 /// Whether the metavariable corresponds to a typed hole written by the user
 /// or whether it was inserted during lowering for an implicit argument.

--- a/lang/ast/src/traits/subst.rs
+++ b/lang/ast/src/traits/subst.rs
@@ -145,7 +145,7 @@ impl Substitution for SwapSubst {
             Box::new(Exp::Variable(Variable {
                 span: None,
                 idx: new_ctx.lvl_to_idx(new_lvl),
-                name: "".to_owned(),
+                name: Ident { id: "".to_owned() },
                 inferred_type: None,
             }))
         })

--- a/lang/elaborator/src/normalizer/env.rs
+++ b/lang/elaborator/src/normalizer/env.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use derivative::Derivative;
 
-use ast::{Shift, ShiftRange};
+use ast::{Ident, Shift, ShiftRange};
 use pretty::DocAllocator;
 
 use ast::ctx::values::TypeCtx;
@@ -107,7 +107,7 @@ impl ToEnv for LevelCtx {
                         let idx = Idx { fst: self.bound.len() - 1 - fst, snd: v.len() - 1 - snd };
                         Rc::new(Val::Neu(Neu::Variable(Variable {
                             span: None,
-                            name: String::new(),
+                            name: Ident { id: String::new() },
                             idx,
                         })))
                     })

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 
 use ast;
 use ast::ctx::BindContext;
+use ast::Ident;
 use ast::Idx;
 use ast::MetaVar;
 use ast::Shift;
@@ -149,7 +150,7 @@ impl Print for TypCtor {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let TypCtor { span: _, name, args } = self;
         let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
-        alloc.typ(name).append(psubst)
+        alloc.typ(&name.id).append(psubst)
     }
 }
 
@@ -197,7 +198,7 @@ impl Print for Call {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let Call { span: _, kind: _, name, args } = self;
         let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
-        alloc.ctor(name).append(psubst)
+        alloc.ctor(&name.id).append(psubst)
     }
 }
 
@@ -456,7 +457,7 @@ impl Print for DotCall {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let DotCall { span: _, kind: _, exp, name, args } = self;
         let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
-        exp.print(cfg, alloc).append(DOT).append(alloc.dtor(name)).append(psubst)
+        exp.print(cfg, alloc).append(DOT).append(alloc.dtor(&name.id)).append(psubst)
     }
 }
 
@@ -644,7 +645,12 @@ impl Print for Case {
                 .nest(cfg.indent),
         };
 
-        alloc.ctor(name).append(params.print(cfg, alloc)).append(alloc.space()).append(body).group()
+        alloc
+            .ctor(&name.id)
+            .append(params.print(cfg, alloc))
+            .append(alloc.space())
+            .append(body)
+            .group()
     }
 }
 
@@ -690,7 +696,7 @@ impl Print for OpaqueCall {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let OpaqueCall { span: _, name, args } = self;
         let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc).parens() };
-        alloc.ctor(name).append(psubst)
+        alloc.ctor(&name.id).append(psubst)
     }
 }
 
@@ -870,7 +876,7 @@ impl ReadBack for Closure {
             .map(|snd| {
                 Val::Neu(Neu::Variable(Variable {
                     span: None,
-                    name: "".to_owned(),
+                    name: Ident { id: "".to_owned() },
                     idx: Idx { fst: 0, snd },
                 }))
             })

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -31,7 +31,7 @@ impl CheckInfer for LocalComatch {
         })?;
         if uses_self(codata)? {
             return Err(TypeError::LocalComatchWithSelf {
-                type_name: codata.name.to_owned(),
+                type_name: codata.name.to_owned().id,
                 span: span.to_miette(),
             });
         }
@@ -102,9 +102,9 @@ impl<'a> WithExpectedType<'a> {
             || !dtors_duplicate.is_empty()
         {
             return Err(TypeError::invalid_match(
-                dtors_missing.cloned().collect(),
-                dtors_exessive.cloned().collect(),
-                dtors_duplicate,
+                dtors_missing.map(|i| &i.id).cloned().collect(),
+                dtors_exessive.map(|i| &i.id).cloned().collect(),
+                dtors_duplicate.into_iter().map(|i| i.id).collect(),
                 &self.expected_type.span(),
             ));
         }
@@ -159,7 +159,7 @@ impl<'a> WithExpectedType<'a> {
             let module = ctx.module.clone();
 
             params_inst.check_telescope(
-                &name,
+                &name.id,
                 ctx,
                 &params,
                 |ctx, args_out| {
@@ -237,7 +237,7 @@ impl<'a> WithExpectedType<'a> {
                                                 // - The arguments to the toplevel codefinition
                                                 // - The arguments bound by the destructor copattern.
                                                 idx: Idx { fst: 2, snd },
-                                                name: "".to_owned(),
+                                                name: Ident { id: "".to_owned() },
                                                 inferred_type: None,
                                             })))
                                         })

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -140,9 +140,9 @@ impl<'a> WithScrutinee<'a> {
             || !ctors_duplicate.is_empty()
         {
             return Err(TypeError::invalid_match(
-                ctors_missing.cloned().collect(),
-                ctors_undeclared.cloned().collect(),
-                ctors_duplicate,
+                ctors_missing.map(|i| &i.id).cloned().collect(),
+                ctors_undeclared.map(|i| &i.id).cloned().collect(),
+                ctors_duplicate.into_iter().map(|i| i.id).collect(),
                 &self.scrutinee.span(),
             ));
         }
@@ -179,7 +179,7 @@ impl<'a> WithScrutinee<'a> {
             let params = params.clone();
 
             args.check_telescope(
-                &name,
+                &name.id,
                 ctx,
                 &params,
                 |ctx, args_out| {
@@ -190,7 +190,7 @@ impl<'a> WithScrutinee<'a> {
                             Arg::UnnamedArg(Box::new(Exp::Variable(Variable {
                                 span: None,
                                 idx: Idx { fst: 1, snd },
-                                name: "".to_owned(),
+                                name: Ident { id: "".to_owned() },
                                 inferred_type: None,
                             })))
                         })

--- a/lang/elaborator/src/typechecker/exprs/mod.rs
+++ b/lang/elaborator/src/typechecker/exprs/mod.rs
@@ -120,14 +120,14 @@ impl CheckInfer for Arg {
 
 fn check_args(
     this: &Args,
-    name: &str,
+    name: &Ident,
     ctx: &mut Ctx,
     params: &Telescope,
     span: Option<Span>,
 ) -> Result<Args, TypeError> {
     if this.len() != params.len() {
         return Err(TypeError::ArgLenMismatch {
-            name: name.to_owned(),
+            name: name.to_owned().id,
             expected: params.len(),
             actual: this.len(),
             span: span.to_miette(),
@@ -262,7 +262,10 @@ impl InferTelescope for SelfParam {
         let typ_nf = typ.to_exp().normalize(&ctx.module, &mut ctx.env())?;
         let typ_out = typ.infer(ctx)?;
         let param_out = SelfParam { info: *info, name: name.clone(), typ: typ_out };
-        let elem = Binder { name: name.clone().unwrap_or_default(), typ: typ_nf };
+        let elem = Binder {
+            name: name.clone().unwrap_or_else(|| Ident { id: "".to_owned() }),
+            typ: typ_nf,
+        };
 
         // We need to shift the self parameter type here because we treat it as a 1-element telescope
         ctx.bind_single(&elem.shift((1, 0)), |ctx| f(ctx, param_out))

--- a/lang/lifting/src/lib.rs
+++ b/lang/lifting/src/lib.rs
@@ -15,7 +15,7 @@ pub fn lift(module: Arc<Module>, name: &str) -> LiftResult {
     let mut ctx = Ctx {
         name: name.to_owned(),
         new_decls: vec![],
-        curr_decl: "".to_owned(),
+        curr_decl: Ident { id: "".to_owned() },
         modified_decls: HashSet::default(),
         ctx: LevelCtx::default(),
     };
@@ -535,7 +535,7 @@ impl Ctx {
         cases: &Vec<Case>,
     ) -> Exp {
         // Only lift local matches for the specified type
-        if inferred_type.name != self.name {
+        if inferred_type.name.id != self.name {
             return Exp::LocalMatch(LocalMatch {
                 span: *span,
                 inferred_type: None,
@@ -580,7 +580,7 @@ impl Ctx {
         };
 
         // Build the new top-level definition
-        let name = self.unique_def_name(name, &inferred_type.name);
+        let name = self.unique_def_name(name, &inferred_type.name.id);
 
         let def = Def {
             span: None,
@@ -621,7 +621,7 @@ impl Ctx {
         cases: &Vec<Case>,
     ) -> Exp {
         // Only lift local matches for the specified type
-        if inferred_type.name != self.name {
+        if inferred_type.name.id != self.name {
             return Exp::LocalComatch(LocalComatch {
                 span: *span,
                 ctx: None,
@@ -647,7 +647,7 @@ impl Ctx {
         let typ = typ.subst(&mut self.ctx, &subst.in_body());
 
         // Build the new top-level definition
-        let name = self.unique_codef_name(name, &inferred_type.name);
+        let name = self.unique_codef_name(name, &inferred_type.name.id);
 
         let codef = Codef {
             span: None,
@@ -686,7 +686,7 @@ impl Ctx {
         label.user_name.clone().unwrap_or_else(|| {
             let lowered = type_name.to_lowercase();
             let id = label.id;
-            format!("d_{lowered}{id}")
+            Ident { id: format!("d_{lowered}{id}") }
         })
     }
 
@@ -694,7 +694,7 @@ impl Ctx {
     fn unique_codef_name(&self, label: &Label, type_name: &str) -> Ident {
         label.user_name.clone().unwrap_or_else(|| {
             let id = label.id;
-            format!("Mk{type_name}{id}")
+            Ident { id: format!("Mk{type_name}{id}") }
         })
     }
 }

--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -82,13 +82,13 @@ impl Ctx {
     }
 
     pub fn add_decl(&mut self, decl: ast::Decl) -> Result<(), LoweringError> {
-        if self.decls_map.contains_key(&decl.name().clone()) {
+        if self.decls_map.contains_key(&decl.name().clone().id) {
             return Err(LoweringError::AlreadyDefined {
-                name: Ident { id: decl.name().clone() },
+                name: Ident { id: decl.name().clone().id },
                 span: decl.span().to_miette(),
             });
         }
-        self.decls_map.insert(decl.name().clone(), decl);
+        self.decls_map.insert(decl.name().clone().id, decl);
         Ok(())
     }
 
@@ -122,7 +122,7 @@ impl Ctx {
         }
         let id = self.next_label_id;
         self.next_label_id += 1;
-        Ok(ast::Label { id, user_name: user_name.map(|name| name.id) })
+        Ok(ast::Label { id, user_name: user_name.map(|name| ast::Ident { id: name.id }) })
     }
 
     /// Next De Bruijn level to be assigned
@@ -176,7 +176,7 @@ impl Ctx {
                     ast::Variable {
                         span: None,
                         idx: self.level_to_index(Lvl { fst, snd }),
-                        name: name.to_owned(),
+                        name: ast::Ident { id: name.to_owned() },
                         inferred_type: None,
                     }
                     .into(),

--- a/lang/lowering/src/lower/decls/codata_declaration.rs
+++ b/lang/lowering/src/lower/decls/codata_declaration.rs
@@ -21,7 +21,7 @@ impl Lower for cst::decls::Codata {
         Ok(ast::Codata {
             span: Some(*span),
             doc: doc.lower(ctx)?,
-            name: name.id.clone(),
+            name: ast::Ident { id: name.id.clone() },
             attr: attr.lower(ctx)?,
             typ: Box::new(lower_telescope(params, ctx, |_, out| Ok(out))?),
             dtors,
@@ -69,7 +69,7 @@ fn lower_destructor(
             Ok(ast::Dtor {
                 span: Some(*span),
                 doc: doc.lower(ctx)?,
-                name: name.id.clone(),
+                name: ast::Ident { id: name.id.clone() },
                 params,
                 self_param,
                 ret_typ: ret_typ.lower(ctx)?,

--- a/lang/lowering/src/lower/decls/codefinition.rs
+++ b/lang/lowering/src/lower/decls/codefinition.rs
@@ -20,7 +20,7 @@ impl Lower for cst::decls::Codef {
             Ok(ast::Codef {
                 span: Some(*span),
                 doc: doc.lower(ctx)?,
-                name: name.id.clone(),
+                name: ast::Ident { id: name.id.clone() },
                 attr: attr.lower(ctx)?,
                 params,
                 typ: typ_ctor,

--- a/lang/lowering/src/lower/decls/data_declaration.rs
+++ b/lang/lowering/src/lower/decls/data_declaration.rs
@@ -20,7 +20,7 @@ impl Lower for cst::decls::Data {
         Ok(ast::Data {
             span: Some(*span),
             doc: doc.lower(ctx)?,
-            name: name.id.clone(),
+            name: ast::Ident { id: name.id.clone() },
             attr: attr.lower(ctx)?,
             typ: Box::new(lower_telescope(params, ctx, |_, out| Ok(out))?),
             ctors,
@@ -48,7 +48,7 @@ fn lower_constructor(
                 if type_arity == 0 {
                     ast::TypCtor {
                         span: None,
-                        name: typ_name.id.clone(),
+                        name: ast::Ident { id: typ_name.id.clone() },
                         args: ast::Args { args: vec![] },
                     }
                 } else {
@@ -64,7 +64,7 @@ fn lower_constructor(
         Ok(ast::Ctor {
             span: Some(*span),
             doc: doc.lower(ctx)?,
-            name: name.id.clone(),
+            name: ast::Ident { id: name.id.clone() },
             params,
             typ,
         })

--- a/lang/lowering/src/lower/decls/definition.rs
+++ b/lang/lowering/src/lower/decls/definition.rs
@@ -20,7 +20,7 @@ impl Lower for cst::decls::Def {
                 Ok(ast::Def {
                     span: Some(*span),
                     doc: doc.lower(ctx)?,
-                    name: name.id.clone(),
+                    name: ast::Ident { id: name.id.clone() },
                     attr: attr.lower(ctx)?,
                     params,
                     self_param,

--- a/lang/lowering/src/lower/decls/mod.rs
+++ b/lang/lowering/src/lower/decls/mod.rs
@@ -94,7 +94,7 @@ fn lower_self_param<T, F: FnOnce(&mut Ctx, ast::SelfParam) -> Result<T, Lowering
                 ctx,
                 ast::SelfParam {
                     info: Some(*span),
-                    name: name.clone().map(|name| name.id),
+                    name: name.clone().map(|name| ast::Ident { id: name.id }),
                     typ: typ_ctor,
                 },
             )
@@ -154,7 +154,8 @@ where
                 BindingSite::Var { name, .. } => name.clone(),
                 BindingSite::Wildcard { .. } => parser::cst::ident::Ident { id: "_".to_owned() },
             };
-            let param_out = ast::Param { implicit: *implicit, name: name.id, typ: typ_out };
+            let param_out =
+                ast::Param { implicit: *implicit, name: ast::Ident { id: name.id }, typ: typ_out };
             params_out.push(param_out);
             Ok(params_out)
         },

--- a/lang/lowering/src/lower/decls/toplevel_let.rs
+++ b/lang/lowering/src/lower/decls/toplevel_let.rs
@@ -15,7 +15,7 @@ impl Lower for cst::decls::Let {
             Ok(ast::Let {
                 span: Some(*span),
                 doc: doc.lower(ctx)?,
-                name: name.id.clone(),
+                name: ast::Ident { id: name.id.clone() },
                 attr: attr.lower(ctx)?,
                 params,
                 typ: typ.lower(ctx)?,

--- a/lang/query/src/info/collect.rs
+++ b/lang/query/src/info/collect.rs
@@ -110,12 +110,12 @@ impl CollectInfo for Data {
         let Data { name, span, doc, typ, ctors, .. } = self;
         if let Some(span) = span {
             // Add item
-            let item = Item::Data(name.clone());
+            let item = Item::Data(name.clone().id);
             collector.add_item(*span, item);
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
             let info =
-                DataInfo { name: name.clone(), doc, params: typ.params.print_to_string(None) };
+                DataInfo { name: name.clone().id, doc, params: typ.params.print_to_string(None) };
             collector.add_info(*span, info)
         }
 
@@ -132,12 +132,12 @@ impl CollectInfo for Codata {
         let Codata { name, doc, typ, span, dtors, .. } = self;
         if let Some(span) = span {
             // Add item
-            let item = Item::Codata(name.clone());
+            let item = Item::Codata(name.clone().id);
             collector.add_item(*span, item);
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
             let info =
-                CodataInfo { name: name.clone(), doc, params: typ.params.print_to_string(None) };
+                CodataInfo { name: name.clone().id, doc, params: typ.params.print_to_string(None) };
             collector.add_info(*span, info);
         }
 
@@ -154,7 +154,8 @@ impl CollectInfo for Def {
         let Def { name, span, self_param, cases, params, ret_typ, .. } = self;
         if let Some(span) = span {
             // Add Item
-            let item = Item::Def { name: name.clone(), type_name: self_param.typ.name.clone() };
+            let item =
+                Item::Def { name: name.clone().id, type_name: self_param.typ.name.clone().id };
             collector.add_item(*span, item);
             // Add Info
             let info = DefInfo {};
@@ -173,7 +174,7 @@ impl CollectInfo for Codef {
         let Codef { name, span, typ, cases, params, .. } = self;
         if let Some(span) = span {
             // Add item
-            let item = Item::Codef { name: name.clone(), type_name: typ.name.clone() };
+            let item = Item::Codef { name: name.clone().id, type_name: typ.name.clone().id };
             collector.add_item(*span, item);
             // Add info
             let info = CodefInfo {};
@@ -191,7 +192,7 @@ impl CollectInfo for Ctor {
         if let Some(span) = span {
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
-            let info = CtorInfo { name: name.clone(), doc };
+            let info = CtorInfo { name: name.clone().id, doc };
             collector.add_info(*span, info);
         }
         params.collect_info(collector);
@@ -205,7 +206,7 @@ impl CollectInfo for Dtor {
         if let Some(span) = span {
             // Add info
             let doc = doc.clone().map(|doc| doc.docs);
-            let info = DtorInfo { name: name.clone(), doc };
+            let info = DtorInfo { name: name.clone().id, doc };
             collector.add_info(*span, info);
         }
         self_param.collect_info(collector);
@@ -252,7 +253,7 @@ impl CollectInfo for Variable {
     fn collect_info(&self, collector: &mut InfoCollector) {
         let Variable { span, inferred_type, name, .. } = self;
         if let (Some(span), Some(typ)) = (span, inferred_type) {
-            let info = VariableInfo { typ: typ.print_to_string(None), name: name.clone() };
+            let info = VariableInfo { typ: typ.print_to_string(None), name: name.clone().id };
             collector.add_info(*span, info)
         }
     }
@@ -273,7 +274,7 @@ impl CollectInfo for TypCtor {
                 Some(Decl::Codata(d)) => d.doc.clone().map(|doc| doc.docs),
                 _ => None,
             };
-            let info = TypeCtorInfo { name: name.clone(), definition_site, doc };
+            let info = TypeCtorInfo { name: name.clone().id, definition_site, doc };
             collector.add_info(*span, info)
         }
         args.collect_info(collector)
@@ -324,7 +325,7 @@ impl CollectInfo for Call {
                 kind: *kind,
                 doc,
                 typ: typ.print_to_string(None),
-                name: name.clone(),
+                name: name.clone().id,
                 definition_site,
             };
             collector.add_info(*span, info)
@@ -363,7 +364,7 @@ impl CollectInfo for DotCall {
             let info = DotCallInfo {
                 kind: *kind,
                 doc,
-                name: name.clone(),
+                name: name.clone().id,
                 typ: typ.print_to_string(None),
                 definition_site,
             };

--- a/lang/query/src/info/data.rs
+++ b/lang/query/src/info/data.rs
@@ -293,6 +293,6 @@ impl From<TypeCtx> for Ctx {
 
 impl From<TypeCtxBinder> for Binder {
     fn from(binder: TypeCtxBinder) -> Self {
-        Binder { name: binder.name, typ: binder.typ.print_to_string(None) }
+        Binder { name: binder.name.id, typ: binder.typ.print_to_string(None) }
     }
 }

--- a/lang/query/src/xfunc.rs
+++ b/lang/query/src/xfunc.rs
@@ -40,14 +40,16 @@ impl Database {
         let mat = xfunc::as_matrix(&module)?;
 
         let type_span =
-            mat.map.get(type_name).and_then(|x| x.span).ok_or(XfuncError::Impossible {
-                message: format!("Could not resolve {type_name}"),
-                span: None,
-            })?;
+            mat.map.get(&Ident { id: type_name.to_string() }).and_then(|x| x.span).ok_or(
+                XfuncError::Impossible {
+                    message: format!("Could not resolve {type_name}"),
+                    span: None,
+                },
+            )?;
 
         let original = Original { type_span, decl_spans, xdefs };
 
-        let repr = xfunc::repr(&mat, type_name)?;
+        let repr = xfunc::repr(&mat, &Ident { id: type_name.to_string() })?;
 
         let result = match repr {
             xfunc::matrix::Repr::Data => refunctionalize(&mat, type_name),
@@ -110,7 +112,7 @@ fn generate_edits(
 }
 
 fn refunctionalize(mat: &matrix::Prg, type_name: &str) -> Result<XfuncResult, crate::Error> {
-    let (codata, codefs) = xfunc::as_codata(mat, type_name)?;
+    let (codata, codefs) = xfunc::as_codata(mat, &Ident { id: type_name.to_string() })?;
 
     let codata = codata.rename();
     let codefs = codefs.into_iter().map(|codef| codef.rename()).collect::<Vec<_>>();
@@ -122,7 +124,7 @@ fn refunctionalize(mat: &matrix::Prg, type_name: &str) -> Result<XfuncResult, cr
 }
 
 fn defunctionalize(mat: &matrix::Prg, type_name: &str) -> Result<XfuncResult, crate::Error> {
-    let (data, defs) = xfunc::as_data(mat, type_name)?;
+    let (data, defs) = xfunc::as_data(mat, &Ident { id: type_name.to_string() })?;
 
     let data = data.rename();
     let defs = defs.into_iter().map(|def| def.rename()).collect::<Vec<_>>();

--- a/lang/renaming/src/ctx.rs
+++ b/lang/renaming/src/ctx.rs
@@ -25,7 +25,7 @@ impl Context for Ctx {
     }
 
     fn push_binder(&mut self, elem: Self::Elem) {
-        assert!(elem == "_" || elem.is_empty() || !self.contains_name(&elem));
+        assert!(elem.id == "_" || elem.id.is_empty() || !self.contains_name(&elem));
         self.ctx
             .bound
             .last_mut()
@@ -51,8 +51,8 @@ impl Context for Ctx {
 
 impl Ctx {
     pub(super) fn disambiguate_name(&self, mut name: Ident) -> Ident {
-        if name == "_" || name.is_empty() {
-            "x".clone_into(&mut name);
+        if name.id == "_" || name.id.is_empty() {
+            "x".clone_into(&mut name.id);
         }
         while self.contains_name(&name) {
             name = increment_name(name);
@@ -84,6 +84,6 @@ impl ContextElem<Ctx> for ParamInst {
 
 impl ContextElem<Ctx> for SelfParam {
     fn as_element(&self) -> <Ctx as Context>::Elem {
-        self.name.to_owned().unwrap_or_default()
+        self.name.to_owned().unwrap_or_else(|| Ident { id: "".to_string() })
     }
 }

--- a/lang/renaming/src/util.rs
+++ b/lang/renaming/src/util.rs
@@ -1,12 +1,14 @@
-pub fn increment_name(mut name: String) -> String {
-    if name.ends_with('\'') {
-        name.push('\'');
+use ast::Ident;
+
+pub fn increment_name(mut name: Ident) -> Ident {
+    if name.id.ends_with('\'') {
+        name.id.push('\'');
         return name;
     }
-    let (s, digits) = split_trailing_digits(&name);
+    let (s, digits) = split_trailing_digits(&name.id);
     match digits {
-        None => format!("{s}0"),
-        Some(n) => format!("{s}{}", n + 1),
+        None => Ident { id: format!("{s}0") },
+        Some(n) => Ident { id: format!("{s}{}", n + 1) },
     }
 }
 

--- a/lang/xfunc/src/lib.rs
+++ b/lang/xfunc/src/lib.rs
@@ -1,3 +1,5 @@
+use ast::Ident;
+
 pub mod matrix;
 pub mod result;
 
@@ -5,7 +7,7 @@ pub fn as_matrix(prg: &ast::Module) -> Result<matrix::Prg, crate::result::XfuncE
     matrix::build(prg)
 }
 
-pub fn repr(prg: &matrix::Prg, name: &str) -> Result<matrix::Repr, crate::result::XfuncError> {
+pub fn repr(prg: &matrix::Prg, name: &Ident) -> Result<matrix::Repr, crate::result::XfuncError> {
     prg.map
         .get(name)
         .ok_or_else(|| crate::result::XfuncError::Impossible {
@@ -17,7 +19,7 @@ pub fn repr(prg: &matrix::Prg, name: &str) -> Result<matrix::Repr, crate::result
 
 pub fn as_data(
     prg: &matrix::Prg,
-    name: &str,
+    name: &Ident,
 ) -> Result<(ast::Data, Vec<ast::Def>), crate::result::XfuncError> {
     prg.map
         .get(name)
@@ -30,7 +32,7 @@ pub fn as_data(
 
 pub fn as_codata(
     prg: &matrix::Prg,
-    name: &str,
+    name: &Ident,
 ) -> Result<(ast::Codata, Vec<ast::Codef>), crate::result::XfuncError> {
     prg.map
         .get(name)


### PR DESCRIPTION
Pretty boring, and there is a lot of potential for API cleanup, but having an abstract Ident type for the AST is necessary to annotate it with origin information (i.e. in which module it was defined).