### PR TITLE
Add MSRV 1.80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,35 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  build-msrv:
+    name: Build with Minimum Supported Rust Version (MSRV)
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.extract_rust_version.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract Rust Version
+        id: extract_rust_version
+        run: |
+          rust_version=$(awk -F '"' '/rust-version/ {print $2; exit}' Cargo.toml)
+          if [ -z "$rust_version" ]; then
+            echo "Error: rust-version not found in Cargo.toml"
+            exit 1
+          fi
+          echo "::set-output name=msrv::$rust_version"
+      - name: Set Up Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.extract_rust_version.outputs.msrv }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all
+
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all
 
@@ -32,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all
 
@@ -41,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p test-runner
 
@@ -50,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
@@ -60,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.80.1
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
       - uses: Swatinem/rust-cache@v2
       - run: cargo run -p test-runner
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
       - run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --all -- --check
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             echo "Error: rust-version not found in Cargo.toml"
             exit 1
           fi
-          echo "::set-output name=msrv::$rust_version"
+          echo "msrv=$rust_version" >> $GITHUB_OUTPUT
       - name: Set Up Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             echo "Error: rust-version not found in Cargo.toml"
             exit 1
           fi
-          echo "msrv=$rust_version" >> $GITHUB_OUTPUT
+          echo "msrv=$rust_version" >> "$GITHUB_OUTPUT"
       - name: Set Up Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default-members = ["app"]
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["Tim Süberkrüb", "David Binder"]
 license = "MIT OR Apache-2.0"
 homepage = "https://polarity-lang.github.io/"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,6 +4,7 @@ name = "polarity"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/ast/Cargo.toml
+++ b/lang/ast/Cargo.toml
@@ -4,6 +4,7 @@ name = "ast"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/elaborator/Cargo.toml
+++ b/lang/elaborator/Cargo.toml
@@ -4,6 +4,7 @@ name = "elaborator"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/lifting/Cargo.toml
+++ b/lang/lifting/Cargo.toml
@@ -4,6 +4,7 @@ name = "lifting"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/lowering/Cargo.toml
+++ b/lang/lowering/Cargo.toml
@@ -4,6 +4,7 @@ name = "lowering"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/lsp/Cargo.toml
+++ b/lang/lsp/Cargo.toml
@@ -4,6 +4,7 @@ name = "lsp-server"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/miette_util/Cargo.toml
+++ b/lang/miette_util/Cargo.toml
@@ -4,6 +4,7 @@ name = "miette_util"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/parser/Cargo.toml
+++ b/lang/parser/Cargo.toml
@@ -4,6 +4,7 @@ name = "parser"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/printer/Cargo.toml
+++ b/lang/printer/Cargo.toml
@@ -4,6 +4,7 @@ name = "printer"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/query/Cargo.toml
+++ b/lang/query/Cargo.toml
@@ -4,6 +4,7 @@ name = "query"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/renaming/Cargo.toml
+++ b/lang/renaming/Cargo.toml
@@ -4,6 +4,7 @@ name = "renaming"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/lang/xfunc/Cargo.toml
+++ b/lang/xfunc/Cargo.toml
@@ -4,6 +4,7 @@ name = "xfunc"
 # Inherited from workspace Cargo.toml
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Fixes #299 

The error message now looks like this if the version of `rustc`is too old:

```console
error: rustc 1.80.0 is not supported by the following packages:
  ast@0.1.0 requires rustc 1.81
  elaborator@0.1.0 requires rustc 1.81
  lifting@0.1.0 requires rustc 1.81
  lowering@0.1.0 requires rustc 1.81
  lsp-server@0.1.0 requires rustc 1.81
  miette_util@0.1.0 requires rustc 1.81
  parser@0.1.0 requires rustc 1.81
  parser@0.1.0 requires rustc 1.81
  parser@0.1.0 requires rustc 1.81
  polarity@0.1.0 requires rustc 1.81
  printer@0.1.0 requires rustc 1.81
  query@0.1.0 requires rustc 1.81
  renaming@0.1.0 requires rustc 1.81
  xfunc@0.1.0 requires rustc 1.81
```