### PR TITLE
Reimplement multi module lowering (1/n)

### DIFF
--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -14,21 +14,15 @@ pub use result::*;
 
 /// Lower a module
 ///
-/// The caller of this function needs to resolve module dependencies, lower all dependencies, and provide a lookup table with all symbols from these dependencies.
-/// The symbols from the current module will be appended to the lookup table.
+/// The caller of this function needs to resolve module dependencies, lower all dependencies, and provide a lookup table with all symbols from these dependencies and the lookup table of the current module.
 pub fn lower_module_with_lookup_table(
     prg: &cst::decls::Module,
-    lookup_table: &mut LookupTable,
+    lookup_table: &LookupTable,
 ) -> Result<ast::Module, LoweringError> {
-    let mut combined_table = std::mem::take(lookup_table);
-    combined_table.append(build_lookup_table(prg)?);
-
-    let mut ctx = Ctx::empty(combined_table);
+    let mut ctx = Ctx::empty(lookup_table.clone());
 
     let use_decls = prg.use_decls.lower(&mut ctx)?;
     let decls = prg.decls.lower(&mut ctx)?;
-
-    *lookup_table = ctx.lookup_table;
 
     Ok(ast::Module { uri: prg.uri.clone(), use_decls, decls, meta_vars: ctx.meta_vars })
 }

--- a/lang/lowering/src/lookup_table.rs
+++ b/lang/lowering/src/lookup_table.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use ast::HashMap;
 use codespan::Span;
 use decls::*;
@@ -44,45 +42,6 @@ pub enum DeclMeta {
     Ctor { params: Telescope },
     Dtor { params: Telescope },
     Let { params: Telescope },
-}
-
-impl DeclMeta {
-    pub fn kind(&self) -> DeclKind {
-        match self {
-            DeclMeta::Data { .. } => DeclKind::Data,
-            DeclMeta::Codata { .. } => DeclKind::Codata,
-            DeclMeta::Def { .. } => DeclKind::Def,
-            DeclMeta::Codef { .. } => DeclKind::Codef,
-            DeclMeta::Ctor { .. } => DeclKind::Ctor,
-            DeclMeta::Dtor { .. } => DeclKind::Dtor,
-            DeclMeta::Let { .. } => DeclKind::Let,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum DeclKind {
-    Data,
-    Codata,
-    Def,
-    Codef,
-    Ctor,
-    Dtor,
-    Let,
-}
-
-impl fmt::Display for DeclKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DeclKind::Data => write!(f, "data type"),
-            DeclKind::Codata => write!(f, "codata type"),
-            DeclKind::Def => write!(f, "definition"),
-            DeclKind::Codef => write!(f, "codefinition"),
-            DeclKind::Ctor => write!(f, "constructor"),
-            DeclKind::Dtor => write!(f, "destructor"),
-            DeclKind::Let => write!(f, "toplevel let"),
-        }
-    }
 }
 
 pub fn build_lookup_table(module: &Module) -> Result<LookupTable, LoweringError> {

--- a/lang/lowering/src/lookup_table.rs
+++ b/lang/lowering/src/lookup_table.rs
@@ -21,7 +21,7 @@ impl LookupTable {
         if self.map.contains_key(name) {
             return Err(LoweringError::AlreadyDefined {
                 name: name.to_owned(),
-                span: Some(span.to_miette()),
+                span: span.to_miette(),
             });
         }
         self.map.insert(name.clone(), decl_meta);

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -2,8 +2,6 @@ use miette::{Diagnostic, SourceSpan};
 use parser::cst::ident::Ident;
 use thiserror::Error;
 
-use crate::lookup_table::DeclKind;
-
 #[derive(Error, Diagnostic, Debug, Clone)]
 pub enum LoweringError {
     #[error("Undefined identifier {}", name.id)]
@@ -42,9 +40,6 @@ pub enum LoweringError {
         #[label]
         span: SourceSpan,
     },
-    #[error("Expected {name} to be a {expected}, but it is a {actual}")]
-    #[diagnostic(code("L-006"))]
-    InvalidDeclarationKind { name: String, expected: DeclKind, actual: DeclKind },
     #[error("The annotated label {name} is shadowed by a local variable")]
     #[diagnostic(code("L-007"))]
     LabelShadowed {

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -16,7 +16,7 @@ pub enum LoweringError {
     AlreadyDefined {
         name: Ident,
         #[label]
-        span: Option<SourceSpan>,
+        span: SourceSpan,
     },
     #[error("{} must be used as destructor", name.id)]
     #[diagnostic(code("L-003"))]

--- a/lang/query/src/database.rs
+++ b/lang/query/src/database.rs
@@ -299,6 +299,8 @@ impl Database {
 
         let cst = self.load_cst(uri)?;
         log::debug!("Lowering module");
+        let new_lookup_table = lowering::build_lookup_table(&cst)?;
+        cst_lookup_table.append(new_lookup_table);
         lowering::lower_module_with_lookup_table(&cst, cst_lookup_table).map_err(Error::Lowering)
     }
 


### PR DESCRIPTION
First step of reimplementing the logic for multi-module lowering. The logic for combining multiple lowering lookup tables should reside in the driver, not in the lowering module.