### PR TITLE
Reimplement multi module lowering (4/n)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "num-bigint",
  "parser",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/lang/lowering/Cargo.toml
+++ b/lang/lowering/Cargo.toml
@@ -18,6 +18,7 @@ codespan = { workspace = true }
 # big integers
 num-bigint = { workspace = true }
 log = { workspace = true }
+url = { workspace = true }
 
 # workspace members
 parser = { path = "../parser" }

--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -9,7 +9,7 @@ use ast::{Idx, Lvl};
 use parser::cst::exp::BindingSite;
 use parser::cst::ident::Ident;
 
-use crate::lookup_table::LookupTable;
+use crate::symbol_table::SymbolTable;
 
 use super::result::LoweringError;
 
@@ -23,7 +23,7 @@ pub struct Ctx {
     /// Bound variables in this map are De-Bruijn levels rather than indices:
     local_map: HashMap<Ident, Vec<Lvl>>,
     /// Metadata for top-level names
-    pub lookup_table: LookupTable,
+    pub symbol_table: SymbolTable,
     /// Counts the number of entries for each De-Bruijn level
     levels: Vec<usize>,
     /// Counter for unique label ids
@@ -37,10 +37,10 @@ pub struct Ctx {
 }
 
 impl Ctx {
-    pub fn empty(lookup_table: LookupTable) -> Self {
+    pub fn empty(symbol_table: SymbolTable) -> Self {
         Self {
             local_map: HashMap::default(),
-            lookup_table,
+            symbol_table,
             levels: Vec::new(),
             next_label_id: 0,
             user_labels: HashSet::default(),
@@ -60,7 +60,7 @@ impl Ctx {
         info: &Span,
     ) -> Result<ast::Label, LoweringError> {
         if let Some(user_name) = &user_name {
-            if self.lookup_table.lookup_exists(user_name) {
+            if self.symbol_table.lookup_exists(user_name) {
                 return Err(LoweringError::LabelNotUnique {
                     name: user_name.id.to_owned(),
                     span: info.to_miette(),

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -1,7 +1,7 @@
 mod ctx;
-mod lookup_table;
 mod lower;
 mod result;
+mod symbol_table;
 
 use ast::{self};
 use parser::cst;
@@ -9,18 +9,18 @@ use parser::cst;
 use crate::lower::Lower;
 
 pub use ctx::*;
-pub use lookup_table::build::build_lookup_table;
-pub use lookup_table::LookupTable;
 pub use result::*;
+pub use symbol_table::build::build_symbol_table;
+pub use symbol_table::SymbolTable;
 
 /// Lower a module
 ///
-/// The caller of this function needs to resolve module dependencies, lower all dependencies, and provide a lookup table with all symbols from these dependencies and the lookup table of the current module.
-pub fn lower_module_with_lookup_table(
+/// The caller of this function needs to resolve module dependencies, lower all dependencies, and provide a symbol table with all symbols from these dependencies and the symbol table of the current module.
+pub fn lower_module_with_symbol_table(
     prg: &cst::decls::Module,
-    lookup_table: &LookupTable,
+    symbol_table: &SymbolTable,
 ) -> Result<ast::Module, LoweringError> {
-    let mut ctx = Ctx::empty(lookup_table.clone());
+    let mut ctx = Ctx::empty(symbol_table.clone());
 
     let use_decls = prg.use_decls.lower(&mut ctx)?;
     let decls = prg.decls.lower(&mut ctx)?;

--- a/lang/lowering/src/lookup_table/build.rs
+++ b/lang/lowering/src/lookup_table/build.rs
@@ -5,10 +5,10 @@ use parser::cst::*;
 
 use crate::LoweringError;
 
-use super::{DeclMeta, LookupTable};
+use super::{DeclMeta, ModuleLookupTable};
 
-pub fn build_lookup_table(module: &Module) -> Result<LookupTable, LoweringError> {
-    let mut lookup_table = LookupTable { map: HashMap::default() };
+pub fn build_lookup_table(module: &Module) -> Result<ModuleLookupTable, LoweringError> {
+    let mut lookup_table = HashMap::default();
 
     let Module { decls, .. } = module;
 
@@ -20,11 +20,11 @@ pub fn build_lookup_table(module: &Module) -> Result<LookupTable, LoweringError>
 }
 
 trait BuildLookupTable {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError>;
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError>;
 }
 
 impl BuildLookupTable for Decl {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         match self {
             Decl::Data(data) => data.build(lookup_table),
             Decl::Codata(codata) => codata.build(lookup_table),
@@ -36,9 +36,9 @@ impl BuildLookupTable for Decl {
 }
 
 impl BuildLookupTable for Data {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Data { span, name, params, ctors, .. } = self;
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -47,7 +47,7 @@ impl BuildLookupTable for Data {
             }
             None => {
                 let meta = DeclMeta::Data { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         for ctor in ctors {
@@ -58,9 +58,9 @@ impl BuildLookupTable for Data {
 }
 
 impl BuildLookupTable for Ctor {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Ctor { span, name, params, .. } = self;
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -69,7 +69,7 @@ impl BuildLookupTable for Ctor {
             }
             None => {
                 let meta = DeclMeta::Ctor { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         Ok(())
@@ -77,9 +77,9 @@ impl BuildLookupTable for Ctor {
 }
 
 impl BuildLookupTable for Codata {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Codata { span, name, params, dtors, .. } = self;
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -88,7 +88,7 @@ impl BuildLookupTable for Codata {
             }
             None => {
                 let meta = DeclMeta::Codata { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         for dtor in dtors {
@@ -99,9 +99,9 @@ impl BuildLookupTable for Codata {
 }
 
 impl BuildLookupTable for Dtor {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Dtor { span, name, params, .. } = self;
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -110,7 +110,7 @@ impl BuildLookupTable for Dtor {
             }
             None => {
                 let meta = DeclMeta::Dtor { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         Ok(())
@@ -118,10 +118,10 @@ impl BuildLookupTable for Dtor {
 }
 
 impl BuildLookupTable for Def {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Def { span, name, params, .. } = self;
 
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -130,7 +130,7 @@ impl BuildLookupTable for Def {
             }
             None => {
                 let meta = DeclMeta::Def { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         Ok(())
@@ -138,10 +138,10 @@ impl BuildLookupTable for Def {
 }
 
 impl BuildLookupTable for Codef {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Codef { span, name, params, .. } = self;
 
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -150,7 +150,7 @@ impl BuildLookupTable for Codef {
             }
             None => {
                 let meta = DeclMeta::Codef { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         Ok(())
@@ -158,9 +158,9 @@ impl BuildLookupTable for Codef {
 }
 
 impl BuildLookupTable for Let {
-    fn build(&self, lookup_table: &mut LookupTable) -> Result<(), LoweringError> {
+    fn build(&self, lookup_table: &mut ModuleLookupTable) -> Result<(), LoweringError> {
         let Let { span, name, params, .. } = self;
-        match lookup_table.map.get(name) {
+        match lookup_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
                     name: name.to_owned(),
@@ -169,7 +169,7 @@ impl BuildLookupTable for Let {
             }
             None => {
                 let meta = DeclMeta::Let { params: params.clone() };
-                lookup_table.map.insert(name.clone(), meta);
+                lookup_table.insert(name.clone(), meta);
             }
         }
         Ok(())

--- a/lang/lowering/src/lookup_table/lookup.rs
+++ b/lang/lowering/src/lookup_table/lookup.rs
@@ -6,15 +6,23 @@ use crate::LoweringError;
 use super::{DeclMeta, LookupTable};
 
 impl LookupTable {
-    /// Check whether the identifier already exists.
+    /// Check whether the identifier already exists in any of the symbol tables.
     pub fn lookup_exists(&self, name: &Ident) -> bool {
-        self.map.contains_key(name)
+        for symbol_table in self.map.values() {
+            if symbol_table.contains_key(name) {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn lookup(&self, name: &Ident) -> Result<&DeclMeta, LoweringError> {
-        self.map.get(name).ok_or_else(|| LoweringError::UndefinedIdent {
-            name: name.clone(),
-            span: name.span.to_miette(),
-        })
+        for symbol_table in self.map.values() {
+            match symbol_table.get(name) {
+                Some(meta) => return Ok(meta),
+                None => continue,
+            }
+        }
+        Err(LoweringError::UndefinedIdent { name: name.clone(), span: name.span.to_miette() })
     }
 }

--- a/lang/lowering/src/lookup_table/mod.rs
+++ b/lang/lowering/src/lookup_table/mod.rs
@@ -2,16 +2,25 @@ use ast::HashMap;
 use decls::*;
 use ident::Ident;
 use parser::cst::*;
+use url::Url;
 
 pub mod build;
 pub mod lookup;
 
+/// The lookup table for a single module.
+pub type ModuleLookupTable = HashMap<Ident, DeclMeta>;
+
+/// The lookup table for a module and all of its imported modules.
 #[derive(Debug, Default, Clone)]
 pub struct LookupTable {
-    map: HashMap<Ident, DeclMeta>,
+    // Maps modules to their respective symbol tables.
+    map: HashMap<Url, ModuleLookupTable>,
 }
 
 impl LookupTable {
+    pub fn insert(&mut self, url: Url, other: ModuleLookupTable) {
+        self.map.insert(url, other);
+    }
     pub fn append(&mut self, other: LookupTable) {
         self.map.extend(other.map);
     }

--- a/lang/lowering/src/symbol_table/lookup.rs
+++ b/lang/lowering/src/symbol_table/lookup.rs
@@ -3,9 +3,9 @@ use parser::cst::ident::Ident;
 
 use crate::LoweringError;
 
-use super::{DeclMeta, LookupTable};
+use super::{DeclMeta, SymbolTable};
 
-impl LookupTable {
+impl SymbolTable {
     /// Check whether the identifier already exists in any of the symbol tables.
     pub fn lookup_exists(&self, name: &Ident) -> bool {
         for symbol_table in self.map.values() {

--- a/lang/lowering/src/symbol_table/mod.rs
+++ b/lang/lowering/src/symbol_table/mod.rs
@@ -7,21 +7,21 @@ use url::Url;
 pub mod build;
 pub mod lookup;
 
-/// The lookup table for a single module.
-pub type ModuleLookupTable = HashMap<Ident, DeclMeta>;
+/// The symbol table for a single module.
+pub type ModuleSymbolTable = HashMap<Ident, DeclMeta>;
 
-/// The lookup table for a module and all of its imported modules.
+/// The symbol table for a module and all of its imported modules.
 #[derive(Debug, Default, Clone)]
-pub struct LookupTable {
+pub struct SymbolTable {
     // Maps modules to their respective symbol tables.
-    map: HashMap<Url, ModuleLookupTable>,
+    map: HashMap<Url, ModuleSymbolTable>,
 }
 
-impl LookupTable {
-    pub fn insert(&mut self, url: Url, other: ModuleLookupTable) {
+impl SymbolTable {
+    pub fn insert(&mut self, url: Url, other: ModuleSymbolTable) {
         self.map.insert(url, other);
     }
-    pub fn append(&mut self, other: LookupTable) {
+    pub fn append(&mut self, other: SymbolTable) {
         self.map.extend(other.map);
     }
 }

--- a/lang/query/src/database.rs
+++ b/lang/query/src/database.rs
@@ -301,7 +301,7 @@ impl Database {
         let cst = self.load_cst(uri)?;
         log::debug!("Lowering module");
         let new_lookup_table = lowering::build_lookup_table(&cst)?;
-        cst_lookup_table.append(new_lookup_table);
+        cst_lookup_table.insert(uri.clone(), new_lookup_table);
         lowering::lower_module_with_lookup_table(&cst, cst_lookup_table).map_err(Error::Lowering)
     }
 

--- a/lang/query/src/database.rs
+++ b/lang/query/src/database.rs
@@ -29,7 +29,7 @@ pub struct Database {
     /// The CST of each file (once parsed)
     pub cst: Cache<Result<Arc<cst::decls::Module>, Error>>,
     /// The symbol table constructed during lowering
-    pub cst_lookup_table: Cache<lowering::LookupTable>,
+    pub cst_lookup_table: Cache<lowering::SymbolTable>,
     /// The AST of each file (once parsed and lowered, may be type-annotated)
     pub ast: Cache<Result<Arc<ast::Module>, Error>>,
     /// The symbol table constructed during typechecking
@@ -125,7 +125,7 @@ impl Database {
 
     pub fn print_to_string(&mut self, uri: &Url) -> Result<String, Error> {
         let module =
-            self.load_ast(uri, &mut lowering::LookupTable::default(), &mut LookupTable::default())?;
+            self.load_ast(uri, &mut lowering::SymbolTable::default(), &mut LookupTable::default())?;
         let module = (*module).clone().rename();
         Ok(printer::Print::print_to_string(&module, None))
     }
@@ -141,7 +141,7 @@ impl Database {
         self.deps.print_dependency_tree();
         log::trace!("");
 
-        let mut cst_lookup_table = lowering::LookupTable::default();
+        let mut cst_lookup_table = lowering::SymbolTable::default();
         let mut ast_lookup_table = LookupTable::default();
         self.load_module_impl(&mut cst_lookup_table, &mut ast_lookup_table, module_uri)
     }
@@ -149,7 +149,7 @@ impl Database {
     pub fn load_imports(
         &mut self,
         module_uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut LookupTable,
     ) -> Result<(), Error> {
         self.build_dependency_dag()?;
@@ -231,7 +231,7 @@ impl Database {
 
     fn load_module_impl(
         &mut self,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut LookupTable,
         module_uri: &Url,
     ) -> Result<Arc<ast::Module>, Error> {
@@ -239,7 +239,7 @@ impl Database {
         let direct_dependencies = self.deps.get(module_uri).unwrap_or(&empty_vec).clone();
 
         for dep_url in direct_dependencies {
-            let mut dep_cst_lookup_table = lowering::LookupTable::default();
+            let mut dep_cst_lookup_table = lowering::SymbolTable::default();
             let mut dep_ast_lookup_table = LookupTable::default();
             self.load_module_impl(&mut dep_cst_lookup_table, &mut dep_ast_lookup_table, &dep_url)?;
             cst_lookup_table.append(dep_cst_lookup_table);
@@ -252,7 +252,7 @@ impl Database {
     pub fn load_ast(
         &mut self,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut LookupTable,
     ) -> Result<Arc<ast::Module>, Error> {
         log::trace!("Loading AST: {}", uri);
@@ -294,15 +294,15 @@ impl Database {
     pub fn load_ust(
         &mut self,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
     ) -> Result<ast::Module, Error> {
         log::trace!("Loading UST: {}", uri);
 
         let cst = self.load_cst(uri)?;
         log::debug!("Lowering module");
-        let new_lookup_table = lowering::build_lookup_table(&cst)?;
+        let new_lookup_table = lowering::build_symbol_table(&cst)?;
         cst_lookup_table.insert(uri.clone(), new_lookup_table);
-        lowering::lower_module_with_lookup_table(&cst, cst_lookup_table).map_err(Error::Lowering)
+        lowering::lower_module_with_symbol_table(&cst, cst_lookup_table).map_err(Error::Lowering)
     }
 
     pub fn load_cst(&mut self, uri: &Url) -> Result<Arc<cst::decls::Module>, Error> {

--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -23,7 +23,7 @@ pub trait Phase {
     fn run(
         db: &mut Database,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err>;
 }
@@ -35,7 +35,7 @@ pub trait Phase {
 pub struct PartialRun<O> {
     case: Case,
     database: Database,
-    cst_lookup_table: RefCell<lowering::LookupTable>,
+    cst_lookup_table: RefCell<lowering::SymbolTable>,
     ast_lookup_table: RefCell<elaborator::LookupTable>,
     /// The result of the last run phase.
     result: Result<O, PhasesError>,
@@ -56,7 +56,7 @@ impl PartialRun<()> {
         source.insert(case.uri(), case.content().unwrap());
         let source = source.fallback_to(FileSystemSource::new(&case.path));
         let database = Database::from_source(source);
-        let cst_lookup_table = RefCell::new(lowering::LookupTable::default());
+        let cst_lookup_table = RefCell::new(lowering::SymbolTable::default());
         let ast_lookup_table = RefCell::new(elaborator::LookupTable::default());
         PartialRun {
             case,
@@ -245,7 +245,7 @@ impl Phase for Parse {
     fn run(
         db: &mut Database,
         uri: &Url,
-        _: &mut lowering::LookupTable,
+        _: &mut lowering::SymbolTable,
         _: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err> {
         db.load_cst(uri)
@@ -271,7 +271,7 @@ impl Phase for Imports {
     fn run(
         db: &mut Database,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err> {
         db.load_imports(uri, cst_lookup_table, ast_lookup_table)
@@ -302,7 +302,7 @@ impl Phase for Lower {
     fn run(
         db: &mut Database,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         _: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err> {
         db.load_ust(uri, cst_lookup_table)
@@ -334,7 +334,7 @@ impl Phase for Check {
     fn run(
         db: &mut Database,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err> {
         db.load_ast(uri, cst_lookup_table, ast_lookup_table)
@@ -367,7 +367,7 @@ impl Phase for Print {
     fn run(
         db: &mut Database,
         uri: &Url,
-        cst_lookup_table: &mut lowering::LookupTable,
+        cst_lookup_table: &mut lowering::SymbolTable,
         ast_lookup_table: &mut elaborator::LookupTable,
     ) -> Result<Self::Out, Self::Err> {
         let output = db.print_to_string(uri)?;


### PR DESCRIPTION
Introduces the new type `ModuleLookupTable` which contains information about all the symbols declared in one specific module.

The semantics is currently:
- You can have multiple imports which define the same symbol. In that case, the symbol resolves to the first symbol found in the hashmaps. In the future we probably want to throw an ambiguous occurrence warning.