### PR TITLE
Simplify lowering folds

### DIFF
--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -213,10 +213,7 @@ impl Ctx {
             iter,
             acc,
             |this, acc, x| {
-                Result::<_, ()>::Ok((|this, acc, x: T| BindElem {
-                    elem: x.as_element(),
-                    ret: f_acc(this, acc, x),
-                })(this, acc, x))
+                Result::<_, ()>::Ok(BindElem { elem: x.as_element(), ret: f_acc(this, acc, x) })
             },
             f_inner,
         )


### PR DESCRIPTION
Only `bind_fold` and `bind_single` are ever used during lowering.  The functions `bind_fold2`, `bind_fold_failable` and `bind_iter` are therefore just verbose wrappers which can be inlined.