### PR TITLE
Simplify xfunc matrix

### DIFF
--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -81,7 +81,7 @@ impl BuildMatrix for ast::Data {
     fn build_matrix(&self, out: &mut Prg) -> Result<(), XfuncError> {
         let ast::Data { span, doc, name, attr: _, typ, ctors } = self;
 
-        let xdata = XData {
+        let mut xdata = XData {
             repr: Repr::Data,
             span: *span,
             doc: doc.clone(),
@@ -91,16 +91,11 @@ impl BuildMatrix for ast::Data {
             dtors: HashMap::default(),
             exprs: HashMap::default(),
         };
-
-        out.map.insert(name.clone(), xdata);
-
         for ctor in ctors {
-            let xdata = out.map.get_mut(name).ok_or(XfuncError::Impossible {
-                message: format!("Could not resolve {}", self.name),
-                span: None,
-            })?;
             xdata.ctors.insert(ctor.name.clone(), ctor.clone());
         }
+
+        out.map.insert(name.clone(), xdata);
         Ok(())
     }
 }
@@ -108,7 +103,7 @@ impl BuildMatrix for ast::Codata {
     fn build_matrix(&self, out: &mut Prg) -> Result<(), XfuncError> {
         let ast::Codata { span, doc, name, attr: _, typ, dtors } = self;
 
-        let xdata = XData {
+        let mut xdata = XData {
             repr: Repr::Codata,
             span: *span,
             doc: doc.clone(),
@@ -119,16 +114,11 @@ impl BuildMatrix for ast::Codata {
             exprs: HashMap::default(),
         };
 
-        out.map.insert(name.clone(), xdata);
-
         for dtor in dtors {
-            let xdata = out.map.get_mut(name).ok_or(XfuncError::Impossible {
-                message: format!("Could not resolve {}", name),
-                span: None,
-            })?;
             xdata.dtors.insert(dtor.name.clone(), dtor.clone());
         }
 
+        out.map.insert(name.clone(), xdata);
         Ok(())
     }
 }

--- a/lang/xfunc/src/matrix.rs
+++ b/lang/xfunc/src/matrix.rs
@@ -110,12 +110,15 @@ impl BuildMatrix for ast::Data {
         out.map.insert(name.clone(), xdata);
 
         for ctor in ctors {
-            ctor.build_matrix(ctx, out)?;
+            let xdata = out.map.get_mut(name).ok_or(XfuncError::Impossible {
+                message: format!("Could not resolve {}", self.name),
+                span: None,
+            })?;
+            xdata.ctors.insert(ctor.name.clone(), ctor.clone());
         }
         Ok(())
     }
 }
-
 impl BuildMatrix for ast::Codata {
     fn build_matrix(&self, ctx: &mut Ctx, out: &mut Prg) -> Result<(), XfuncError> {
         let ast::Codata { span, doc, name, attr: _, typ, dtors } = self;
@@ -138,39 +141,13 @@ impl BuildMatrix for ast::Codata {
         out.map.insert(name.clone(), xdata);
 
         for dtor in dtors {
-            dtor.build_matrix(ctx, out)?;
+            let xdata = out.map.get_mut(name).ok_or(XfuncError::Impossible {
+                message: format!("Could not resolve {}", name),
+                span: None,
+            })?;
+            xdata.dtors.insert(dtor.name.clone(), dtor.clone());
         }
 
-        Ok(())
-    }
-}
-
-impl BuildMatrix for ast::Ctor {
-    fn build_matrix(&self, ctx: &mut Ctx, out: &mut Prg) -> Result<(), XfuncError> {
-        let type_name = &ctx.type_for_xtor.get(&self.name).ok_or(XfuncError::Impossible {
-            message: format!("Could not resolve {}", self.name),
-            span: None,
-        })?;
-        let xdata = out.map.get_mut(*type_name).ok_or(XfuncError::Impossible {
-            message: format!("Could not resolve {}", self.name),
-            span: None,
-        })?;
-        xdata.ctors.insert(self.name.clone(), self.clone());
-        Ok(())
-    }
-}
-
-impl BuildMatrix for ast::Dtor {
-    fn build_matrix(&self, ctx: &mut Ctx, out: &mut Prg) -> Result<(), XfuncError> {
-        let type_name = &ctx.type_for_xtor.get(&self.name).ok_or(XfuncError::Impossible {
-            message: format!("Could not resolve {}", self.name),
-            span: None,
-        })?;
-        let xdata = out.map.get_mut(*type_name).ok_or(XfuncError::Impossible {
-            message: format!("Could not resolve {}", type_name),
-            span: None,
-        })?;
-        xdata.dtors.insert(self.name.clone(), self.clone());
         Ok(())
     }
 }


### PR DESCRIPTION
Building the matrices was way too complicated. This was an artefact of the old representation where the Xtors were not part of the data/codata type node.