### PR TITLE
Fix prettyprinter bug for lists of implicitly inserted arguments

### DIFF
--- a/lang/ast/src/exp/args.rs
+++ b/lang/ast/src/exp/args.rs
@@ -173,7 +173,7 @@ impl Substitutable for Args {
 
 impl Print for Args {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        if self.args.iter().filter(|x| !x.is_inserted_implicit()).next().is_none() {
+        if !self.args.iter().any(|x| !x.is_inserted_implicit()) {
             return alloc.nil();
         }
 

--- a/lang/ast/src/exp/args.rs
+++ b/lang/ast/src/exp/args.rs
@@ -173,6 +173,10 @@ impl Substitutable for Args {
 
 impl Print for Args {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
+        if self.args.is_empty() {
+            return alloc.nil();
+        }
+
         let mut doc = alloc.nil();
         let mut first = true;
 
@@ -209,5 +213,37 @@ impl ContainsMetaVars for Args {
         let Args { args } = self;
 
         args.contains_metavars()
+    }
+}
+
+#[cfg(test)]
+mod args_tests {
+    use printer::Print;
+
+    use crate::{Arg, Call, CallKind, Ident};
+
+    use super::Args;
+
+    #[test]
+    fn print_empty_args() {
+        let args = Args { args: vec![] };
+        assert_eq!(args.print_to_string(Default::default()), "".to_string())
+    }
+
+    #[test]
+    fn print_unnamed_args() {
+        let args = Args {
+            args: vec![Arg::UnnamedArg(Box::new(
+                Call {
+                    span: None,
+                    kind: CallKind::Constructor,
+                    name: Ident::from_string("T"),
+                    args: Args { args: vec![] },
+                    inferred_type: None,
+                }
+                .into(),
+            ))],
+        };
+        assert_eq!(args.print_to_string(Default::default()), "(T)".to_string())
     }
 }

--- a/lang/ast/src/exp/args.rs
+++ b/lang/ast/src/exp/args.rs
@@ -173,7 +173,7 @@ impl Substitutable for Args {
 
 impl Print for Args {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        if self.args.iter().filter(|x| !x.is_inserted_implicit()).peekable().peek().is_none() {
+        if self.args.iter().filter(|x| !x.is_inserted_implicit()).next().is_none() {
             return alloc.nil();
         }
 

--- a/lang/ast/src/exp/call.rs
+++ b/lang/ast/src/exp/call.rs
@@ -1,6 +1,5 @@
 use codespan::Span;
 use derivative::Derivative;
-use pretty::DocAllocator;
 use printer::{theme::ThemeExt, Alloc, Builder, Precedence, Print, PrintCfg};
 
 use crate::{
@@ -98,8 +97,7 @@ impl Print for Call {
         _prec: Precedence,
     ) -> Builder<'a> {
         let Call { name, args, .. } = self;
-        let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc) };
-        alloc.ctor(&name.id).append(psubst)
+        alloc.ctor(&name.id).append(args.print(cfg, alloc))
     }
 }
 

--- a/lang/ast/src/exp/dot_call.rs
+++ b/lang/ast/src/exp/dot_call.rs
@@ -125,9 +125,11 @@ impl Print for DotCall {
         let mut dtors_group = alloc.nil();
 
         // First DotCall
-        let psubst = if self.args.is_empty() { alloc.nil() } else { self.args.print(cfg, alloc) };
-        dtors_group =
-            alloc.text(DOT).append(alloc.dtor(&self.name.id)).append(psubst).append(dtors_group);
+        dtors_group = alloc
+            .text(DOT)
+            .append(alloc.dtor(&self.name.id))
+            .append(self.args.print(cfg, alloc))
+            .append(dtors_group);
 
         // Remaining DotCalls
         let mut dtor: &Exp = &self.exp;

--- a/lang/ast/src/exp/typ_ctor.rs
+++ b/lang/ast/src/exp/typ_ctor.rs
@@ -93,8 +93,7 @@ impl Print for TypCtor {
                 fun.parens()
             }
         } else {
-            let psubst = if args.is_empty() { alloc.nil() } else { args.print(cfg, alloc) };
-            alloc.typ(&name.id).append(psubst)
+            alloc.typ(&name.id).append(args.print(cfg, alloc))
         }
     }
 }


### PR DESCRIPTION
This fixes a bug which occurs if we print a list of arguments which consist only of implicitly inserted arguments. An example of this is `Nil` which has one implicitly inserted argument for the type. Before this fix we would print `Nil()`, and after the fix we will print `Nil`. 