### PR TITLE
Hide "pol lsp" subcommand

### DIFF
--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -63,6 +63,7 @@ enum Command {
     /// De-/Refunctionalize a type in a code file
     Xfunc(xfunc::Args),
     /// Start an LSP server
+    #[clap(hide(true))]
     Lsp(lsp::Args),
     /// Lift local (co)matches of a type to the top-level
     Lift(lift::Args),


### PR DESCRIPTION
New output:

```console
> pol
Usage: pol [OPTIONS] <COMMAND>

Commands:
  run     Run the main expression of a file
  check   Typecheck a file
  fmt     Format a code file
  texify  Render a code file as a latex document
  xfunc   De-/Refunctionalize a type in a code file
  lift    Lift local (co)matches of a type to the top-level
  help    Print this message or the help of the given subcommand(s)

Options:
      --trace    Enable trace logging
      --debug    Enable debug logging
  -h, --help     Print help
  -V, --version  Print version
```