### PR TITLE
Add GitHub workflow for code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,25 @@
+name: Codecov Coverage
+
+on:
+    push:
+      branches:
+        - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
Fixes #365 

I explicitly only run the coverage action on pushes to `main`, and not in Pull requests. My philosophy is that coverage should not be used as an acceptance criterion for PRs, but as a diagnostic that we can inspect and monitor as we see fit.

In order for this PR to work I still need to do some setup with codecov.io and the organisation settings.