### PR TITLE
Add examples/index.json

### DIFF
--- a/.github/workflows/examples-index.yml
+++ b/.github/workflows/examples-index.yml
@@ -1,0 +1,24 @@
+name: Check Examples Index
+
+on:
+  push:
+    paths:
+      - 'examples/**'
+      - 'examples/index.json'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - 'examples/index.json'
+
+jobs:
+  check-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Check index
+        run: |
+          ./scripts/check_examples_index.sh

--- a/.github/workflows/examples-index.yml
+++ b/.github/workflows/examples-index.yml
@@ -10,6 +10,10 @@ on:
       - 'examples/**'
       - 'examples/index.json'
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   check-index:
     runs-on: ubuntu-latest

--- a/examples/index.json
+++ b/examples/index.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "Lawful Functor Class",
+        "path": "functor.pol"
+    },
+    {
+        "name": "Martin-Löf Equality Type",
+        "path": "eq.pol"
+    },
+    {
+        "name": "STLC Type Soundness",
+        "path": "stlc.pol"
+    },
+    {
+        "name": "Strong Existentials Demystified",
+        "path": "strong_existentials.pol"
+    },
+    {
+        "name": "Tutorial",
+        "path": "tutorial.pol"
+    },
+    {
+        "name": "Π Is Not Built-In",
+        "path": "pi.pol"
+    },
+    {
+        "name": "λ-Encoding: Church",
+        "path": "encoding_church.pol"
+    },
+    {
+        "name": "λ-Encoding: Fu & Stump",
+        "path": "encoding_fu_stump.pol"
+    },
+    {
+        "name": "λ-Encoding: Parigot",
+        "path": "encoding_parigot.pol"
+    },
+    {
+        "name": "λ-Encoding: Scott",
+        "path": "encoding_scott.pol"
+    }
+  ]

--- a/scripts/check_examples_index.sh
+++ b/scripts/check_examples_index.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get the list of .pol files in the examples directory
+pol_files=$(find examples -maxdepth 1 -name "*.pol" -printf "%f\n" | sort)
+
+# Extract the 'path' entries from index.json
+index_paths=$(jq -r '.[].path' examples/index.json | sort)
+
+# Compare the two lists
+if diff <(echo "$pol_files") <(echo "$index_paths") >/dev/null; then
+  echo "Success: index.json and .pol files are in sync."
+else
+  echo "Error: index.json and .pol files in examples/ are not in sync."
+  echo "Diff:"
+  diff <(echo "$pol_files") <(echo "$index_paths")
+fi

--- a/scripts/check_examples_index.sh
+++ b/scripts/check_examples_index.sh
@@ -9,9 +9,9 @@ index_paths=$(jq -r '.[].path' examples/index.json | sort)
 
 # Compare the two lists
 if diff <(echo "$pol_files") <(echo "$index_paths") >/dev/null; then
-  echo "Success: index.json and .pol files are in sync."
+  echo "Success: examples/index.json and examples/*.pol files are in sync."
 else
-  echo "Error: index.json and .pol files in examples/ are not in sync."
+  echo "Error: examples/index.json and examples/*.pol are not in sync."
   echo "Diff:"
   diff <(echo "$pol_files") <(echo "$index_paths")
 fi

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -8,4 +8,5 @@ set -e
 cargo test --all
 cargo clippy --all -- -Dwarnings
 cargo fmt --all --check
+./scripts/check_examples_index.sh
 (cd web; make lint)


### PR DESCRIPTION
This index file will determine the names of examples displayed in the example selection on the website. It is currently generated by a script in the website repo based on the filenames alone. By manually specifying the index, we can improve the titles displayed to the user.

@BinderDavid please feel free to improve the titles by pushing to this branch.

After this has been merged, we can remove the script from the website repo.