### PR TITLE
Upgrade web demo and tower-lsp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -54,43 +54,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arrayvec"
@@ -133,7 +133,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -153,13 +153,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
 dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
+ "libc",
  "predicates",
  "predicates-core",
  "predicates-tree",
@@ -223,14 +224,14 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
- "futures-lite 2.3.0",
+ "fastrand",
+ "futures-lite",
  "slab",
 ]
 
@@ -242,50 +243,30 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.3",
+ "async-io",
  "async-lock 3.4.0",
  "blocking",
- "futures-lite 2.3.0",
+ "futures-lite",
  "once_cell",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.13.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "parking",
- "polling 3.7.2",
- "rustix 0.38.34",
+ "polling",
+ "rustix",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -310,19 +291,19 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
 dependencies = [
  "async-channel 1.9.0",
  "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io",
+ "async-lock 3.4.0",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 1.13.0",
+ "futures-lite",
  "gloo-timers",
  "kv-log-macro",
  "log",
@@ -342,13 +323,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -359,35 +340,34 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
-version = "0.5.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -471,15 +451,15 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite",
  "piper",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -500,15 +480,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "census"
@@ -524,9 +507,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -534,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -562,14 +545,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan"
@@ -582,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -681,11 +664,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -744,6 +728,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -860,12 +855,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -887,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.3.1",
  "pin-project-lite",
@@ -908,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "fastdivide"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59668941c55e5c186b8b58c391629af56774ec768f73c08bbcd56f09348eb00b"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastfield_codecs"
@@ -924,24 +919,24 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "fnv"
@@ -985,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1000,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1010,15 +1005,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1027,32 +1022,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand 2.1.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -1061,32 +1041,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1122,15 +1102,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1173,6 +1153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,9 +1184,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1232,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "humansize"
@@ -1317,30 +1303,159 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1356,17 +1471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,11 +1478,11 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -1415,16 +1519,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1473,7 +1578,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1513,9 +1618,9 @@ checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"
@@ -1535,15 +1640,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1566,33 +1671,34 @@ dependencies = [
 
 [[package]]
 name = "logos"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+checksum = "5f3303189202bb8a052bcd93d66b6c03e6fe70d9c7c47c0ea5e974955e54c876"
 dependencies = [
  "beef",
  "fnv",
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
- "syn 2.0.72",
+ "regex-syntax 0.8.5",
+ "rustc_version",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+checksum = "774a1c225576486e4fdf40b74646f672c542ca3608160d348749693ae9d456e6"
 dependencies = [
  "logos-codegen",
 ]
@@ -1647,7 +1753,6 @@ dependencies = [
  "async-lock 2.8.0",
  "codespan",
  "driver",
- "lsp-types 0.93.2",
  "miette",
  "miette_util",
  "printer",
@@ -1670,15 +1775,15 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.2"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -1740,7 +1845,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1775,20 +1880,19 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1882,18 +1986,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oneshot"
@@ -1934,7 +2038,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1972,9 +2076,9 @@ checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1996,7 +2100,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2047,30 +2151,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -2080,12 +2164,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -2121,33 +2205,17 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.8.0"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.34",
+ "rustix",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2158,12 +2226,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
- "zerocopy-derive",
 ]
 
 [[package]]
@@ -2214,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
@@ -2231,43 +2298,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -2324,18 +2367,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2344,25 +2387,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2379,9 +2422,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2414,7 +2457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2477,37 +2520,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustix"
-version = "0.37.27"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2544,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -2602,30 +2640,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.204"
+name = "semver"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -2641,7 +2685,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2655,6 +2699,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -2679,19 +2729,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2711,9 +2751,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "str_indices"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "string_cache"
@@ -2774,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2785,11 +2825,28 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2904,14 +2961,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
- "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2940,7 +2998,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix 0.38.34",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2995,29 +3053,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -3036,9 +3094,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3054,32 +3112,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2",
  "windows-sys 0.52.0",
 ]
 
@@ -3095,20 +3148,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3128,29 +3180,28 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
  "pin-project-lite",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-lsp"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e094780b4447366c59f79acfd65b1375ecaa84e61dddbde1421aa506334024"
+version = "0.20.0"
+source = "git+https://github.com/tower-lsp/tower-lsp?rev=19f5a87810ff4b643d2bc394e438450bd9c74365#19f5a87810ff4b643d2bc394e438450bd9c74365"
 dependencies = [
  "async-codec-lite",
  "async-trait",
@@ -3159,47 +3210,58 @@ dependencies = [
  "dashmap",
  "futures",
  "httparse",
- "log",
- "lsp-types 0.93.2",
+ "lsp-types 0.97.0",
  "memchr",
  "serde",
  "serde_json",
  "tower",
  "tower-lsp-macros",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-lsp-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebd99eec668d0a450c177acbc4d05e0d0d13b1f8d3db13cd706c52cbec4ac04"
+version = "0.9.0"
+source = "git+https://github.com/tower-lsp/tower-lsp?rev=19f5a87810ff4b643d2bc394e438450bd9c74365#19f5a87810ff4b643d2bc394e438450bd9c74365"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.32"
+name = "tracing-attributes"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -3235,16 +3297,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-linebreak"
@@ -3253,31 +3309,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3287,9 +3334,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3298,10 +3345,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3311,9 +3370,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "serde",
@@ -3321,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
 
 [[package]]
 name = "vcpkg"
@@ -3345,12 +3404,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -3379,9 +3432,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3390,37 +3443,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "futures-core",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3428,22 +3481,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-streams"
@@ -3460,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3486,11 +3539,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3507,7 +3560,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3516,7 +3569,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3526,16 +3579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3544,7 +3588,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3553,22 +3597,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3577,21 +3606,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3601,21 +3624,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3631,21 +3642,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3655,21 +3654,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3678,10 +3665,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "yansi"
-version = "0.5.1"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3701,7 +3724,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+ "synstructure",
 ]
 
 [[package]]
@@ -3709,3 +3753,25 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ categories = ["compilers"]
 # fancy error messages
 miette = { version = "7" }
 thiserror = { version = "1" }
+# lsp server
+tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
+    "runtime-agnostic",
+] }
 # source code locations
 codespan = { git = "https://github.com/polarity-lang/codespan.git", rev = "542320ab177fd38fff3a398a97b3f0352e065149" }
 # ignoring fields when deriving traits (e.g. Eq, Hash)

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,9 +30,7 @@ log = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3"
 async-std = "1"
-tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
-    "runtime-agnostic",
-] }
+tower-lsp = { workspace = true }
 # workspace members
 driver = { path = "../lang/driver" }
 elaborator = { path = "../lang/elaborator" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,7 +30,9 @@ log = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3"
 async-std = "1"
-tower-lsp = { version = "0.17", default-features = false, features = ["runtime-agnostic"] }
+tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
+    "runtime-agnostic",
+] }
 # workspace members
 driver = { path = "../lang/driver" }
 elaborator = { path = "../lang/elaborator" }

--- a/contrib/nix/package.nix
+++ b/contrib/nix/package.nix
@@ -8,6 +8,7 @@ rustPlatform.buildRustPackage rec {
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
       "codespan-0.11.1" = "sha256-Wq99v77bqSGIOK/iyv+x/EG1563XSeaTDW5K2X3kSXU=";
+      "tower-lsp-0.20.0" = "sha256-f3S2CyFFX6yylaxMoXhB1/bfizVsLfNldLM+dXl5Y8k=";
     };
   };
 

--- a/lang/lsp/Cargo.toml
+++ b/lang/lsp/Cargo.toml
@@ -13,8 +13,7 @@ categories.workspace = true
 
 [dependencies]
 # lsp
-lsp = { version = "0.93", package = "lsp-types" }
-tower-lsp = { version = "0.17", default-features = false, features = [
+tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
     "runtime-agnostic",
 ] }
 # asynchronous locks

--- a/lang/lsp/Cargo.toml
+++ b/lang/lsp/Cargo.toml
@@ -13,9 +13,7 @@ categories.workspace = true
 
 [dependencies]
 # lsp
-tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
-    "runtime-agnostic",
-] }
+tower-lsp = { workspace = true }
 # asynchronous locks
 async-lock = "2"
 # source code spans

--- a/lang/lsp/src/capabilities.rs
+++ b/lang/lsp/src/capabilities.rs
@@ -1,24 +1,24 @@
 use tower_lsp::lsp_types::*;
 
-pub fn capabilities() -> lsp::ServerCapabilities {
+pub fn capabilities() -> ServerCapabilities {
     let text_document_sync = {
-        let options = lsp::TextDocumentSyncOptions {
+        let options = TextDocumentSyncOptions {
             open_close: Some(true),
-            change: Some(lsp::TextDocumentSyncKind::FULL),
+            change: Some(TextDocumentSyncKind::FULL),
             ..Default::default()
         };
-        Some(lsp::TextDocumentSyncCapability::Options(options))
+        Some(TextDocumentSyncCapability::Options(options))
     };
 
     let hover_provider = Some(HoverProviderCapability::Simple(true));
 
-    let code_action_provider = Some(lsp::CodeActionProviderCapability::Simple(true));
+    let code_action_provider = Some(CodeActionProviderCapability::Simple(true));
 
-    let document_formatting_provider = Some(lsp::OneOf::Left(true));
+    let document_formatting_provider = Some(OneOf::Left(true));
 
-    let definition_provider = Some(lsp::OneOf::Left(true));
+    let definition_provider = Some(OneOf::Left(true));
 
-    lsp::ServerCapabilities {
+    ServerCapabilities {
         text_document_sync,
         hover_provider,
         code_action_provider,

--- a/lang/lsp/src/codeactions.rs
+++ b/lang/lsp/src/codeactions.rs
@@ -16,29 +16,40 @@ pub async fn code_action(
 
     server
         .client
-        .log_message(MessageType::INFO, format!("Code action request: {}", text_document.uri))
+        .log_message(
+            MessageType::INFO,
+            format!("Code action request: {}", text_document.uri.as_str()),
+        )
         .await;
 
     let mut db = server.database.write().await;
-    let span_start = db.location_to_index(&text_document.uri, range.start.from_lsp());
-    let span_end = db.location_to_index(&text_document.uri, range.end.from_lsp());
+    let span_start = db.location_to_index(&text_document.uri.from_lsp(), range.start.from_lsp());
+    let span_end = db.location_to_index(&text_document.uri.from_lsp(), range.end.from_lsp());
     let span = span_start.and_then(|start| span_end.map(|end| codespan::Span::new(start, end)));
-    let item =
-        if let Some(span) = span { db.item_at_span(&text_document.uri, span).await } else { None };
+    let item = if let Some(span) = span {
+        db.item_at_span(&text_document.uri.from_lsp(), span).await
+    } else {
+        None
+    };
 
     if let Some(item) = item {
-        let Ok(Xfunc { title, edits }) = db.xfunc(&text_document.uri, item.type_name()).await
+        let Ok(Xfunc { title, edits }) =
+            db.xfunc(&text_document.uri.from_lsp(), item.type_name()).await
         else {
             return Ok(None);
         };
         let edits = edits
             .into_iter()
             .map(|edit| TextEdit {
-                range: db.span_to_locations(&text_document.uri, edit.span).unwrap().to_lsp(),
+                range: db
+                    .span_to_locations(&text_document.uri.from_lsp(), edit.span)
+                    .unwrap()
+                    .to_lsp(),
                 new_text: edit.text,
             })
             .collect();
 
+        #[allow(clippy::mutable_key_type)]
         let mut changes = HashMap::new();
         changes.insert(text_document.uri, edits);
 

--- a/lang/lsp/src/conversion/mod.rs
+++ b/lang/lsp/src/conversion/mod.rs
@@ -1,7 +1,8 @@
-use lsp::DiagnosticSeverity;
 use miette::Severity;
+use tower_lsp::lsp_types::DiagnosticSeverity;
 
 mod spans;
+mod uri_to_url;
 
 pub trait FromLsp {
     type Target;

--- a/lang/lsp/src/conversion/uri_to_url.rs
+++ b/lang/lsp/src/conversion/uri_to_url.rs
@@ -1,0 +1,21 @@
+use std::str::FromStr;
+
+use tower_lsp::lsp_types::Uri;
+
+use super::{FromLsp, ToLsp};
+
+impl FromLsp for &Uri {
+    type Target = url::Url;
+
+    fn from_lsp(self) -> Self::Target {
+        url::Url::parse(self.as_str()).expect("Failed to parse URI")
+    }
+}
+
+impl ToLsp for &url::Url {
+    type Target = Uri;
+
+    fn to_lsp(self) -> Self::Target {
+        Uri::from_str(self.as_str()).expect("Failed to parse URL")
+    }
+}

--- a/lang/lsp/src/format.rs
+++ b/lang/lsp/src/format.rs
@@ -2,6 +2,8 @@
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
+use crate::conversion::FromLsp;
+
 use super::server::*;
 use printer::{Print, PrintCfg};
 
@@ -13,12 +15,15 @@ pub async fn formatting(
 
     server
         .client
-        .log_message(MessageType::INFO, format!("Formatting request: {}", text_document.uri))
+        .log_message(
+            MessageType::INFO,
+            format!("Formatting request: {}", text_document.uri.from_lsp()),
+        )
         .await;
 
     let mut db = server.database.write().await;
 
-    let prg = match db.ust(&text_document.uri).await {
+    let prg = match db.ust(&text_document.uri.from_lsp()).await {
         Ok(prg) => prg,
         Err(_) => return Ok(None),
     };

--- a/lang/lsp/src/gotodefinition.rs
+++ b/lang/lsp/src/gotodefinition.rs
@@ -16,14 +16,17 @@ pub async fn goto_definition(
 
     server
         .client
-        .log_message(MessageType::INFO, format!("GotoDefinition request: {}", text_document.uri))
+        .log_message(
+            MessageType::INFO,
+            format!("GotoDefinition request: {}", text_document.uri.from_lsp()),
+        )
         .await;
 
     let pos = pos_params.position;
     let mut db = server.database.write().await;
-    let info = db.location_to_index(&text_document.uri, pos.from_lsp());
+    let info = db.location_to_index(&text_document.uri.from_lsp(), pos.from_lsp());
     let info = match info {
-        Some(idx) => db.hoverinfo_at_index(&text_document.uri, idx).await,
+        Some(idx) => db.hoverinfo_at_index(&text_document.uri.from_lsp(), idx).await,
         None => None,
     };
     let res = info.and_then(|info| info_to_jump(&db, info));
@@ -36,17 +39,17 @@ fn info_to_jump(db: &Database, info: Info) -> Option<GotoDefinitionResponse> {
     Some(GotoDefinitionResponse::Scalar(jump_location))
 }
 
-fn span_to_location(span: &Span, uri: &Url, db: &Database) -> Option<Location> {
-    let range = db.span_to_locations(uri, *span).map(ToLsp::to_lsp)?;
+fn span_to_location(span: &Span, uri: &Uri, db: &Database) -> Option<Location> {
+    let range = db.span_to_locations(&uri.from_lsp(), *span).map(ToLsp::to_lsp)?;
     Some(Location { uri: uri.clone(), range })
 }
 
 trait ToJumpTarget {
-    fn to_jump_target(&self) -> Option<(Url, Span)>;
+    fn to_jump_target(&self) -> Option<(Uri, Span)>;
 }
 
 impl ToJumpTarget for InfoContent {
-    fn to_jump_target(&self) -> Option<(Url, Span)> {
+    fn to_jump_target(&self) -> Option<(Uri, Span)> {
         match self {
             InfoContent::TypeCtorInfo(i) => i.to_jump_target(),
             InfoContent::CallInfo(i) => i.to_jump_target(),
@@ -58,28 +61,28 @@ impl ToJumpTarget for InfoContent {
 }
 
 impl ToJumpTarget for UseInfo {
-    fn to_jump_target(&self) -> Option<(Url, Span)> {
-        Some((self.uri.clone(), Span::default()))
+    fn to_jump_target(&self) -> Option<(Uri, Span)> {
+        Some((self.uri.to_lsp(), Span::default()))
     }
 }
 
 impl ToJumpTarget for TypeCtorInfo {
-    fn to_jump_target(&self) -> Option<(Url, Span)> {
+    fn to_jump_target(&self) -> Option<(Uri, Span)> {
         let TypeCtorInfo { definition_site, .. } = self;
-        definition_site.clone()
+        definition_site.clone().map(|(url, span)| (url.to_lsp(), span))
     }
 }
 
 impl ToJumpTarget for CallInfo {
-    fn to_jump_target(&self) -> Option<(Url, Span)> {
+    fn to_jump_target(&self) -> Option<(Uri, Span)> {
         let CallInfo { definition_site, .. } = self;
-        definition_site.clone()
+        definition_site.clone().map(|(url, span)| (url.to_lsp(), span))
     }
 }
 
 impl ToJumpTarget for DotCallInfo {
-    fn to_jump_target(&self) -> Option<(Url, Span)> {
+    fn to_jump_target(&self) -> Option<(Uri, Span)> {
         let DotCallInfo { definition_site, .. } = self;
-        definition_site.clone()
+        definition_site.clone().map(|(url, span)| (url.to_lsp(), span))
     }
 }

--- a/lang/lsp/src/hover.rs
+++ b/lang/lsp/src/hover.rs
@@ -15,15 +15,15 @@ pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Opti
 
     server
         .client
-        .log_message(MessageType::INFO, format!("Hover request: {}", text_document.uri))
+        .log_message(MessageType::INFO, format!("Hover request: {}", text_document.uri.from_lsp()))
         .await;
 
     let pos = pos_params.position;
     let mut db = server.database.write().await;
-    let info = db.location_to_index(&text_document.uri, pos.from_lsp());
+    let info = db.location_to_index(&text_document.uri.from_lsp(), pos.from_lsp());
 
     let info = match info {
-        Some(idx) => db.hoverinfo_at_index(&text_document.uri, idx).await,
+        Some(idx) => db.hoverinfo_at_index(&text_document.uri.from_lsp(), idx).await,
         None => None,
     };
 
@@ -31,8 +31,8 @@ pub async fn hover(server: &Server, params: HoverParams) -> jsonrpc::Result<Opti
     Ok(res)
 }
 
-fn info_to_hover(db: &Database, uri: &Url, info: Info) -> Hover {
-    let range = db.span_to_locations(uri, info.span).map(ToLsp::to_lsp);
+fn info_to_hover(db: &Database, uri: &Uri, info: Info) -> Hover {
+    let range = db.span_to_locations(&uri.from_lsp(), info.span).map(ToLsp::to_lsp);
     let contents = info.content.to_hover_content();
     Hover { contents, range }
 }

--- a/lang/lsp/src/server.rs
+++ b/lang/lsp/src/server.rs
@@ -33,6 +33,8 @@ impl LanguageServer for Server {
         let capabilities = capabilities();
         #[cfg(not(target_arch = "wasm32"))]
         // FIXME: Use `workspace_folders` instead of `root_uri`.
+        // `root_uri` is deprecated in in favor of `workspace_folders`, see:
+        // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
         #[allow(deprecated)]
         if let Some(root_uri) = params.root_uri {
             let root_path =

--- a/lang/lsp/src/server.rs
+++ b/lang/lsp/src/server.rs
@@ -6,6 +6,8 @@ use driver::Database;
 #[cfg(not(target_arch = "wasm32"))]
 use driver::{FileSource, FileSystemSource, InMemorySource};
 
+use crate::conversion::FromLsp;
+
 use super::capabilities::*;
 use super::diagnostics::*;
 
@@ -30,9 +32,11 @@ impl LanguageServer for Server {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         let capabilities = capabilities();
         #[cfg(not(target_arch = "wasm32"))]
+        // FIXME: Use `workspace_folders` instead of `root_uri`.
+        #[allow(deprecated)]
         if let Some(root_uri) = params.root_uri {
             let root_path =
-                root_uri.to_file_path().map_err(|_| jsonrpc::Error::internal_error())?;
+                root_uri.from_lsp().to_file_path().map_err(|_| jsonrpc::Error::internal_error())?;
             let source = InMemorySource::new().fallback_to(FileSystemSource::new(root_path));
             let mut database = self.database.write().await;
             let source_mut = database.file_source_mut();
@@ -52,46 +56,52 @@ impl LanguageServer for Server {
         Ok(())
     }
 
-    async fn did_open(&self, params: lsp::DidOpenTextDocumentParams) {
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let text_document = params.text_document;
         let mut db = self.database.write().await;
 
         self.client
-            .log_message(MessageType::INFO, format!("Opened file: {}", text_document.uri))
+            .log_message(
+                MessageType::INFO,
+                format!("Opened file: {}", text_document.uri.from_lsp()),
+            )
             .await;
 
         let source_mut = db.file_source_mut();
-        assert!(source_mut.manage(&text_document.uri));
-        source_mut.write_string(&text_document.uri, &text_document.text).await.unwrap();
+        assert!(source_mut.manage(&text_document.uri.from_lsp()));
+        source_mut.write_string(&text_document.uri.from_lsp(), &text_document.text).await.unwrap();
 
-        let res = db.ast(&text_document.uri).await.map(|_| ());
-        let diags = db.diagnostics(&text_document.uri, res);
+        let res = db.ast(&text_document.uri.from_lsp()).await.map(|_| ());
+        let diags = db.diagnostics(&text_document.uri.from_lsp(), res);
         self.send_diagnostics(text_document.uri, diags).await;
     }
 
-    async fn did_change(&self, params: lsp::DidChangeTextDocumentParams) {
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let text_document = params.text_document;
         let mut content_changes = params.content_changes;
 
         self.client
-            .log_message(MessageType::INFO, format!("Changed file: {}", text_document.uri))
+            .log_message(
+                MessageType::INFO,
+                format!("Changed file: {}", text_document.uri.from_lsp()),
+            )
             .await;
 
         let mut db = self.database.write().await;
         let text = content_changes.drain(0..).next().unwrap().text;
 
         let source_mut = db.file_source_mut();
-        assert!(source_mut.manage(&text_document.uri));
-        source_mut.write_string(&text_document.uri, &text).await.unwrap();
+        assert!(source_mut.manage(&text_document.uri.from_lsp()));
+        source_mut.write_string(&text_document.uri.from_lsp(), &text).await.unwrap();
 
-        let res = db.invalidate(&text_document.uri).await;
+        let res = db.invalidate(&text_document.uri.from_lsp()).await;
 
         let res = match res {
-            Ok(()) => db.ast(&text_document.uri).await.map(|_| ()),
+            Ok(()) => db.ast(&text_document.uri.from_lsp()).await.map(|_| ()),
             Err(_) => Ok(()),
         };
 
-        let diags = db.diagnostics(&text_document.uri, res);
+        let diags = db.diagnostics(&text_document.uri.from_lsp(), res);
         self.send_diagnostics(text_document.uri, diags).await;
     }
 
@@ -119,7 +129,7 @@ impl LanguageServer for Server {
 }
 
 impl Server {
-    pub(crate) async fn send_diagnostics(&self, url: Url, diags: Vec<Diagnostic>) {
-        self.client.publish_diagnostics(url, diags, None).await;
+    pub(crate) async fn send_diagnostics(&self, uri: Uri, diags: Vec<Diagnostic>) {
+        self.client.publish_diagnostics(uri, diags, None).await;
     }
 }

--- a/web/crates/browser/Cargo.toml
+++ b/web/crates/browser/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 # async
 async-trait = "0.1"
 futures = "0.3"
-tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false }
+tower-lsp = { workspace = true }
 # web platform
 console_error_panic_hook = "0.1"
 js-sys = "0.3"

--- a/web/crates/browser/Cargo.toml
+++ b/web/crates/browser/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 # async
 async-trait = "0.1"
 futures = "0.3"
-tower-lsp = { version = "0.17", default-features = false }
+tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false }
 # web platform
 console_error_panic_hook = "0.1"
 js-sys = "0.3"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6,7 +6,10 @@
     "": {
       "workspaces": [
         "packages/app"
-      ]
+      ],
+      "dependencies": {
+        "vm-browserify": "^1.1.2"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -112,6 +115,534 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-11.1.1.tgz",
+      "integrity": "sha512-qOH9PKUDol9r/TRAFMuy4UrVX4u45t72VqQNOeVMDAz5j28U5KEzyOunINt88Jaay3h5kd/PN4VmpFjvmIlznA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-bulk-edit-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bulk-edit-service-override/-/monaco-vscode-bulk-edit-service-override-11.1.1.tgz",
+      "integrity": "sha512-XP+qyvJktu/HvoNVw3tuGhlvCMAXa/sHkyLN9kCj/qYzr8QdOwVeREU2qURG6n+1WDgy2dFoZVpYFphK9UJt7Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common/-/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common-11.1.1.tgz",
+      "integrity": "sha512-JRNFSVJbPkwID9SgIvlw/inhIH/w0rSu+Yc04lojcLFzI+hENqby9MaBb/prs0ypojHd92vV3mljeDSFF4ie4Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common/-/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common-11.1.1.tgz",
+      "integrity": "sha512-/dpN3H+HF2RZOjWh20zf5wX0qoJYQeBzvCJ8sPBuLyubAPg25cCOIXq0gFgbISZJPZ2g03VMFOHnawnP8EMJnQ==",
+      "dependencies": {
+        "marked": "~14.0.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-chat-extensions-notebook-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-notebook-common/-/monaco-vscode-chat-extensions-notebook-common-11.1.1.tgz",
+      "integrity": "sha512-DwyHIPpW0E3QwKagTvNzzBw6tgNPX/FgsTFD9UA/En//3PgMgrHIuDiZMh1UHiN3825hkF8hZwm9ms685NgN5A==",
+      "dependencies": {
+        "@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common/-/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common-11.1.1.tgz",
+      "integrity": "sha512-vBJN8LfojTQjkOmhHi4Ex0MYS7NVGQsoT+5IvpKX+odTFqmKNOHBumO6lT/XsxC32FARNvqz7p3AOSwAKR9xcg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-comments-extensions-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-comments-extensions-common/-/monaco-vscode-comments-extensions-common-11.1.1.tgz",
+      "integrity": "sha512-CAr0G8luD5JEC7A+ReW0bycCN4cLlx9zBKj9T26jTHECzUWjM8pdRmiOih0NjTXCAdy6emJ/3sFIdnyTnozFnw==",
+      "dependencies": {
+        "@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-configuration-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-11.1.1.tgz",
+      "integrity": "sha512-0JwEneQ5cj4qjnEa9a/TruKJ4BjUA2jumKswgpR6nO0NdeV4Gd7/L1xhBxV5xDtNJMf+qmIJ6cTgRyLC2SARuw==",
+      "dependencies": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-cpp-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cpp-default-extension/-/monaco-vscode-cpp-default-extension-11.1.1.tgz",
+      "integrity": "sha512-Gx7HM709ETGZE9vbPlOvJQWnxyKAQ1jJs4VzLK3ENtru+s5FZKhFlcgyJkleFPQSkCL5FakSbxe9AuEGNBkvBA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-editor-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-11.1.1.tgz",
+      "integrity": "sha512-ZDlhR3l5OZHlL/zHtcKpU2tFUbg6M6Z1kzPxzkq/XmHP+iRqkjBfORLFcl7Z/PzDyWBOXQ8Jfy3Js2bpRqMXWg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-11.1.1.tgz",
+      "integrity": "sha512-lZIWykTUQYbx4NERF8Ha5drfITRmglA2jcRBr6/FT1l+AfDJqcabzNYRVoUCdyOO7keofPSMAJj97X6Fk7d5mw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common/-/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-2R1AjmcocrG5zwPxOHrHkYmO230wOTqr+P6MqCf5GPxZFdgChl0oG7bs2FsiNSaAoI/Kuicu5Ncc+AD3x00pKw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-11.1.1.tgz",
+      "integrity": "sha512-QWoNOB1lYxEp7RxGFjlxdfBViwYBInm+AUWIwKr+b9oJGsxTZ/rpHS32J3yHXnIBngyEcotzWUDYzxFW+gA8kA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-11.1.1.tgz",
+      "integrity": "sha512-Lj+3N6VZBJepAgBscfZnSQu6K4FVNip14z9R+xX4K4n5WnazOWNYgO8tHmbtOewN3SsJGDZxZa8ctXeowVJtxQ==",
+      "dependencies": {
+        "@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": "11.1.1",
+        "@codingame/monaco-vscode-chat-extensions-notebook-common": "11.1.1",
+        "@codingame/monaco-vscode-comments-extensions-common": "11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-11.1.1.tgz",
+      "integrity": "sha512-L2cb4Apm8I49M3HIWmWDasPP5LWt/F4EDXSjIeSPRBooq7jVx6IfMMXFWCdH1pRXnTkiqLpiuRQWdBDH0MBETg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-groovy-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-groovy-default-extension/-/monaco-vscode-groovy-default-extension-11.1.1.tgz",
+      "integrity": "sha512-fenQ5w/ZZ2HrPce9jB+CDbHQmnO7XIz/2CqrYd0dp21tv8bW5FQ68PoXEHmJurMqGrSHDug+MKNLeKRRv5t9jw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-11.1.1.tgz",
+      "integrity": "sha512-owF9veg11ZpV3Xu6V8K2UVumqmoq5bY/jPhEiK/k7hWmVonCq9qY99GS7j4082YIf9yNK0w0m2BwOrMe/q46Ow==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-java-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-java-default-extension/-/monaco-vscode-java-default-extension-11.1.1.tgz",
+      "integrity": "sha512-kVzBvD482q2j/7rATp/5QiyW+Xe2hMfUh8SrlZ/IbJPtVgNduBEbZi0DQDuC31Og1djkzL2EkZBbye/ncADbAA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-javascript-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-javascript-default-extension/-/monaco-vscode-javascript-default-extension-11.1.1.tgz",
+      "integrity": "sha512-H5ubzMEC9hGGfnOrRYeL5AQPzzX+brwf8Tq09GpLiSCFdJKIOOSQ3lzHaYZlTKWcn5PEpJ+hko1O4PXnNhfDLA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-json-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-json-default-extension/-/monaco-vscode-json-default-extension-11.1.1.tgz",
+      "integrity": "sha512-1iDFXzmvWgvAGeN/0D/Lftd398nRWG1nwXWGo41vXSjqB9ZaQMyUpI+Ru+JJ/ubWFfJEv9vPfw30P68wdMbVRA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-11.1.1.tgz",
+      "integrity": "sha512-XGNBeSAuwJZipwh0mEaYt5KQdSUNSE96okAK9Jxb9FsjjJGQHEsci1fzHIUYKy/GW1Geseh08MihQOmK01salg==",
+      "dependencies": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-cs": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-11.1.1.tgz",
+      "integrity": "sha512-3lWgJIpbTIXHpYHaLt9GUbM7mg32jT0E0fiqf8J8FKAFez03gWT+hi1SYLJ9G/hToE75E+LYM2MXq46CgMLLFg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-de": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-11.1.1.tgz",
+      "integrity": "sha512-RO0iM397afjcNUEMRN2rfIuA8byLH2Ob1wNTjXg8oP6xCXqIOvucB/8ljQG5fqK1gwebVTJaAdwZ50Yi36wxJA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-es": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-11.1.1.tgz",
+      "integrity": "sha512-ikiQhm01kzV2VHyKmkKRVgGGENmNBouzXJld6qBF+OAcreUgIxGv6mEUw3AElzlIju0ISkecoTj8uMEwD4tCcg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-fr": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-11.1.1.tgz",
+      "integrity": "sha512-5ozuyt+XiKprxGhT4dpFKckhrX4CZSTISiQ02l/dlgbEQPCjKyb3Tt2hYcI+ePSb6r7URWhDdtNgUvVerbKsDg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-it": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-11.1.1.tgz",
+      "integrity": "sha512-hg9U1Y72dkpDfdd8AyoToYBgxH+EDFbGIlNQvRQycgigsFf8EM3HBnIsIZ7jtL2M3mLy6lF3BrC1HGivCZSRWA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-ja": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-11.1.1.tgz",
+      "integrity": "sha512-9gWlbwf2gfThQkN/GdpVKZIPClGUIOfN3eUazZQe/WrXv5L7OR1N+tlcTYuy2Ny13COAsLpLLmQZZjowH4kRBg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-ko": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-11.1.1.tgz",
+      "integrity": "sha512-2AM2oR56tY5+S4aN7EDTq8b68ldf0pshcO+LhHsVRLhqi+XfidQh3ierGu92j8R6Cp7Yt8MWMoZBYXOJSbhCdw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-pl": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-11.1.1.tgz",
+      "integrity": "sha512-Zsx4ZcvQg2En8Fl9VyEdPYWGFiuP4K2itvfaurpRBjS3uSFYZ0/q5iQ9RntgEsKuz+LyaNz1Xg8CAMYYwdwAjw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-pt-br": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-11.1.1.tgz",
+      "integrity": "sha512-ZWFSk4r/x4N7AXbC8ksjrHOb8n5aQaPYMz0rnr8GCvVhIl2LwP0yclYBIXM5fDYjVos9hRe9znjjujyz3OaTmA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-qps-ploc": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-11.1.1.tgz",
+      "integrity": "sha512-dHPiti8l8zdc78I5ilLy1iXbNeOTpoqd9Uq8lnmX1bsQDiIEDw2v+epWSHDxyLR2eqX4o7ReBGd1fxi6o7CE0w==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-ru": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-11.1.1.tgz",
+      "integrity": "sha512-qctRF7YebAfICTS3efofVRWkhvOdB4Nd5wqM3l96pBYxd5QlWCgphOb6U60xg5iAHcvW97l9CcVmFnn6W7auRA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-tr": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-11.1.1.tgz",
+      "integrity": "sha512-q5gdqDrPCJjv8Nyrz4uyCdmeElgU+IxBxaLKBCPKtT2DumpKXJ0wv6ZPYjAJf05RfteWMt9jw/40C9Cj22AUeA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-zh-hans": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-11.1.1.tgz",
+      "integrity": "sha512-+kvpKeORWTv3hnaNFtNINIGbTkMxC5++423DlGjXaZE1uBmPqe3lN2+fku88X+diwWymZNbB8b0q8I72++DX1Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-language-pack-zh-hant": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-11.1.1.tgz",
+      "integrity": "sha512-1c4cObExQqhpzDLURdd5VaiG5jhk7kOUcHay2p8I+5nf0UKvRBfOJMsHMBiJ8py4eO39sWt9T9unv8IGh8TTiA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-languages-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-11.1.1.tgz",
+      "integrity": "sha512-8TC3AWZgXQGvXtV4fD3w9b0KCtoX1LqhfFGetaMHA8tUMOzBCVRQndTRD3zAW/MKigYuqBvBgUWCUq7mwpxJCA==",
+      "dependencies": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-11.1.1.tgz",
+      "integrity": "sha512-oQ2aN0jIudyB1rDcgYUWpEvw7XQFx5NvpyF5u5cePb9hGTiOnMn6fqCMOgPEeLoq96HdKCh7SHztTTidWdFA4Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-lifecycle-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-lifecycle-service-override/-/monaco-vscode-lifecycle-service-override-11.1.1.tgz",
+      "integrity": "sha512-nrNY2JwNUAfFSJjazhfec8RAPcmIi7d54Jw9x+HyXasOA4zDht0mBgyi7v9Z228OfWy15rSzFIs5gY8dRiDA9Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-localization-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-11.1.1.tgz",
+      "integrity": "sha512-9E06bF+LQk8MuF3BUzZyEz1ohwOzP/UFPZ4Fg4XtDbycwu9taZrFb52t3ppYzPzAwoAjXr8LJX26tQDrqDq76A==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-log-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-11.1.1.tgz",
+      "integrity": "sha512-hOPC0jF9bQyQVTeRG/J/oT/6ZYeu5vQsWQCit89tx3za8XuAEgPy1EEJLPXJFaAEzJF5A9B4rqXDoDtU9tu5Tw==",
+      "dependencies": {
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-model-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-11.1.1.tgz",
+      "integrity": "sha512-Sy/u5jzj9jk4VaGM+FebPlOU37uMkSR/poE+RvFthdrIQ9SnQwBywiyre6XQY7jRt8xsnTLfs6fQkNjXer7nNw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-monarch-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-11.1.1.tgz",
+      "integrity": "sha512-7Dm2IzylcpcPX7ZJZzsuTLZ/cGw0wHaI8IzQJALT1SW6pgZyh+npiDiaep427zkp9/9/nA20FlCgCh4fHGNb2A==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-notifications-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-notifications-workbench-common/-/monaco-vscode-notifications-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-MxVDAufqflKsIPaH4GBbyXEGQozDS8OQPY39j5xiEhjLsG18OsVcOAJVAXNEVvST6TucJW5gIh7t7Mb4LcwW5Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-python-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-python-default-extension/-/monaco-vscode-python-default-extension-11.1.1.tgz",
+      "integrity": "sha512-PiQRmKQzHDt3gOWh53UdEFjKNZs6STnEFavYV5bqG20IpgG+0epIVWRxQwuYFa8EoqoSJPoRj2f3YIUX1BbInQ==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-11.1.1.tgz",
+      "integrity": "sha512-gVLQXKufvRVEtA9Pq9s29ep24DMi/fLmIyhylN2MfHmcgeDnFS7yDdgNYl6xLLoR4m1qrD3D8i05elboBCOIvA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-remote-agent-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-remote-agent-service-override/-/monaco-vscode-remote-agent-service-override-11.1.1.tgz",
+      "integrity": "sha512-FHwSnVX653opN/dyadch4kbAVNNlSQtQhOjG7vvwKs1hSi2y/QxwxuUk3FHbuEPgUOh+2cUxKHWrUOV4HkTJiQ==",
+      "dependencies": {
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-secret-storage-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-secret-storage-service-override/-/monaco-vscode-secret-storage-service-override-11.1.1.tgz",
+      "integrity": "sha512-T+9yhaYpd7kULpx4b9ZCOVEo3EhBXwMyU5DUST9/uQgILatfyM/4alt2HkrQBU9Pur7I1m2464p6N9BuMNAX4Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-standalone-json-language-features": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-json-language-features/-/monaco-vscode-standalone-json-language-features-11.1.1.tgz",
+      "integrity": "sha512-kzEs79gJNaNSX/GFSDsIl7XpX5MFxdMk+AUC+yEzCTv+IRFTS095VbLS5TTn6vPsDNeCkD7WjqctP0A5SNDQqA==",
+      "dependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-standalone-languages": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-languages/-/monaco-vscode-standalone-languages-11.1.1.tgz",
+      "integrity": "sha512-l/2SvZHo8bNtcivJscpqotDeWiXvlQSK1A8wD7sLPRcm72Mt5LWi8jnNckGoiW0FXWRCdzsUBm0BLOSdjzZOcA==",
+      "dependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-standalone-typescript-language-features": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-typescript-language-features/-/monaco-vscode-standalone-typescript-language-features-11.1.1.tgz",
+      "integrity": "sha512-Y3nV09N0DXghN5CBdDHNpoXHw6Q93kX99OIF0gZzw4Q8HYayvHQ32AjqZl9B1uH+6IPyCfL2MZxKmELEr9bnaw==",
+      "dependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-textmate-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-11.1.1.tgz",
+      "integrity": "sha512-nRGZjU1GkHd/7omJFSR1rRxP8/BvJPlrrRkOCbwJYKmyaQoY5Brr8oa9QMqJ/E6myRTa3OLfieK+QHVS9XDqSA==",
+      "dependencies": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1",
+        "vscode-oniguruma": "1.7.0",
+        "vscode-textmate": "9.1.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-11.1.1.tgz",
+      "integrity": "sha512-cprp1Jyex8aVm/oIhL9rr97y+zUztW6KXWGqaeHPSiDqMYmIbitFv9DYeqcfA/3+2O0jenEanBt28uQi6Zkhbw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-theme-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-11.1.1.tgz",
+      "integrity": "sha512-RjSUTwP0Xo0P590aKKrOdmmMfjusyPUn2OwbMoDe8IT8K8eCTH5Qt6CW79muQbu9boNNDhGDwUkoE02Iq4E22A==",
+      "dependencies": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-typescript-basics-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-basics-default-extension/-/monaco-vscode-typescript-basics-default-extension-11.1.1.tgz",
+      "integrity": "sha512-0fIcS3ZJ899uaVwZfkUUXblIY3I8z2TLQScuJ86g04Ksrq0do8TEBGZo0mZrKnwUr9p+gCa0lWQZcEXF7voF1Q==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-typescript-language-features-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-language-features-default-extension/-/monaco-vscode-typescript-language-features-default-extension-11.1.1.tgz",
+      "integrity": "sha512-maazeZhi5Te93Dl1H0d7Cd3GuljOy/gI9uSqSDUT/yJemKOPKYT0sK5j0EknZxQ2uO8kG2T2Bxvj7CeAnSSKrw==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-view-banner-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-banner-service-override/-/monaco-vscode-view-banner-service-override-11.1.1.tgz",
+      "integrity": "sha512-4P8JwTaLsugRC7aeEHUDEmJiA/6DBvRByRLfGypGo9rG8Mg1PHmqA0QRtm85NOVzCjPTbNBMJJ8VA3+uU5a9pQ==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-view-common-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-service-override/-/monaco-vscode-view-common-service-override-11.1.1.tgz",
+      "integrity": "sha512-uTnMMnwWKi7G4z0qBU3sBD2y9paIgKymfPJdS00NMn72KQmOQFtuV/R/5QtWmMqxl/mhWUIoiU6R+G9m03HwEA==",
+      "dependencies": {
+        "@codingame/monaco-vscode-bulk-edit-service-override": "11.1.1",
+        "@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-view-common-views-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-views-workbench-common/-/monaco-vscode-view-common-views-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-7VVlaZqRwjLUG9I8roJYQMVn6ULyQjNH+a73ghLaZCzoQsquaZ+FvykzsVpxmuxIYF/gKImv7NCYdYh4FZB5Aw==",
+      "dependencies": {
+        "@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-view-status-bar-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-status-bar-service-override/-/monaco-vscode-view-status-bar-service-override-11.1.1.tgz",
+      "integrity": "sha512-Lkiq9+NLD90K0XGHplBCEqE+4QNXewrcv5Vxr0Xo1CBtDX+8EaPDYREOWYZGqGaOAhgRXJ7qP1C0LHKEqewocg==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-view-title-bar-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-title-bar-service-override/-/monaco-vscode-view-title-bar-service-override-11.1.1.tgz",
+      "integrity": "sha512-0YCdfoDGvVh0mKuJ8oUBJiYDRbR+rZW8hJM4GlGS7FOxpGf5aOmce8AP2zAJs5COWw6X1/ZI3pmdJWBSC1YVOA==",
+      "dependencies": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-views-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-views-service-override/-/monaco-vscode-views-service-override-11.1.1.tgz",
+      "integrity": "sha512-FycqsM9SPnP9EFTekNXc1aI74jU9m2FP/7Q/WTE4j36HWISyvOjxYiZ1JZGYrfg5TcE4hUejFi2V9HDZzMnMXA==",
+      "dependencies": {
+        "@codingame/monaco-vscode-keybindings-service-override": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-workbench-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-workbench-service-override/-/monaco-vscode-workbench-service-override-11.1.1.tgz",
+      "integrity": "sha512-WH+Q7VCPZXZBfUf9QgifzrFRllv3olXQm3NvUCI8cSgwVcpsav33HWaFBao+96vRRimJukQK+5T3yCVmtbrBeg==",
+      "dependencies": {
+        "@codingame/monaco-vscode-keybindings-service-override": "11.1.1",
+        "@codingame/monaco-vscode-notifications-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-banner-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-view-status-bar-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-title-bar-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -309,6 +840,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typefox/monaco-editor-react": {
+      "version": "6.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/@typefox/monaco-editor-react/-/monaco-editor-react-6.0.0-next.9.tgz",
+      "integrity": "sha512-bjFPQApM2GqzVMEzrHrcYccw2+G+umhgnZ89k6j9/DKAzDr9ygx5FiJUaVplSlw4FnkXnMjiSASVPAHZ9GOQqg==",
+      "dependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "monaco-editor-wrapper": "~6.0.0-next.9",
+        "monaco-languageclient": "~9.0.0-next.9",
+        "react": "~18.3.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1"
+      },
+      "peerDependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "monaco-editor-wrapper": "~6.0.0-next.9",
+        "monaco-languageclient": "~9.0.0-next.9",
+        "react": "~18.3.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1"
+      },
+      "peerDependenciesMeta": {
+        "monaco-editor": {
+          "optional": false
+        },
+        "monaco-editor-wrapper": {
+          "optional": false
+        },
+        "react": {
+          "optional": false
+        },
+        "vscode": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "dev": true,
@@ -474,6 +1038,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -658,6 +1228,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vscode/iconv-lite-umd": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz",
+      "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -1165,6 +1740,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1492,6 +2068,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/connect-history-api-fallback": {
@@ -1702,8 +2279,15 @@
       }
     },
     "node_modules/debounce": {
-      "version": "1.2.1",
-      "license": "MIT"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2854,6 +3438,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/global-modules": {
@@ -2956,27 +3541,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -3674,8 +4238,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3686,6 +4249,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -3800,6 +4371,17 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "dev": true,
@@ -3833,6 +4415,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -4005,21 +4598,13 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minimist-options": {
@@ -4045,15 +4630,101 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/monaco-languageclient": {
-      "version": "1.1.0",
-      "license": "MIT",
+    "node_modules/monaco-editor": {
+      "name": "@codingame/monaco-vscode-editor-api",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-11.1.1.tgz",
+      "integrity": "sha512-QTFaL6FBR/o6kB0x/uKYTKImKPhClEFxX9H09sbtgNKh0yi/lsy9BxJvI535Mw3CCY7wpzBMTTbfZrelz/vW7g==",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageclient": "8.0.1",
-        "vscode-languageserver-textdocument": "1.0.5",
-        "vscode-uri": "3.0.3"
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "node_modules/monaco-editor-core": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.52.0.tgz",
+      "integrity": "sha512-Ur6BNCVgBcmOc4ZizEBl+rGiYtuozztOi4fgRFnAV64sRgKOxkwC1RxGfvJa3pHedoJ2eepV8Frjnr4PbhLcYA=="
+    },
+    "node_modules/monaco-editor-wrapper": {
+      "version": "6.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-6.0.0-next.9.tgz",
+      "integrity": "sha512-xWDPiDUPPXXYwGxEWtFr4ghUk+v5+DaYY1UZoyv7p3mCqtq4Cyu1HTt4C3U/blLcPHAX/fHXs7ZfqIu6j8A4Ow==",
+      "dependencies": {
+        "@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common": "~11.1.1",
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-editor-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-cs": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-de": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-es": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-fr": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-it": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ja": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ko": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-pl": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-pt-br": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-qps-ploc": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ru": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-tr": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-zh-hans": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-zh-hant": "~11.1.1",
+        "@codingame/monaco-vscode-monarch-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-textmate-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-theme-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-views-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-workbench-service-override": "~11.1.1",
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver-protocol": "~3.17.5",
+        "vscode-ws-jsonrpc": "~3.3.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "monaco-languageclient": "~9.0.0-next.9",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1"
+      },
+      "peerDependenciesMeta": {
+        "monaco-editor": {
+          "optional": false
+        },
+        "monaco-languageclient": {
+          "optional": false
+        },
+        "vscode": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/monaco-languageclient": {
+      "version": "9.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-9.0.0-next.9.tgz",
+      "integrity": "sha512-mVzHtw9M1kFt1gKr/T8vZqUqCUTT/rhsu/yHTd63PlWaUjEMYK2j2VQTaGj2zcYQtM69QWNQdmEP7WalfU3cmg==",
+      "dependencies": {
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-extensions-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-languages-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-localization-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-log-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-model-service-override": "~11.1.1",
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "~9.0.1"
+      },
+      "engines": {
+        "node": ">=16.11.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1"
+      },
+      "peerDependenciesMeta": {
+        "monaco-editor": {
+          "optional": false
+        },
+        "vscode": {
+          "optional": false
+        }
       }
     },
     "node_modules/monaco-lsp-streams": {
@@ -4821,6 +5492,17 @@
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -6082,19 +6764,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6197,44 +6866,112 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "node_modules/vscode": {
+      "name": "@codingame/monaco-vscode-api",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-11.1.1.tgz",
+      "integrity": "sha512-m2hGKexUeQ9CfTcjdI+YLNmSwBqTOJD7m7iOkvSo5l7obDg59lgwdCutQIWl0vEZaZorNyyfDvJvgyupMMn3uw==",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "11.1.1",
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "@codingame/monaco-vscode-extensions-service-override": "11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "@codingame/monaco-vscode-host-service-override": "11.1.1",
+        "@codingame/monaco-vscode-layout-service-override": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@vscode/iconv-lite-umd": "0.7.0",
+        "jschardet": "3.1.4",
+        "marked": "~14.0.0"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.0.1",
-      "license": "MIT",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.0.1",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.1",
-      "license": "MIT",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageserver-types": "3.17.1"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.5",
-      "license": "MIT"
-    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.1",
-      "license": "MIT"
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
-    "node_modules/vscode-uri": {
-      "version": "3.0.3",
-      "license": "MIT"
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
+    "node_modules/vscode-textmate": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.1.0.tgz",
+      "integrity": "sha512-lxKSVp2DkFOx9RDAvpiYUrB9/KT1fAfi1aE8CBGstP8N7rLF+Seifj8kDA198X0mYj1CjQUC+81+nQf8CO0nVA=="
+    },
+    "node_modules/vscode-ws-jsonrpc": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-3.3.2.tgz",
+      "integrity": "sha512-jxGHxAuow67sNRkkS2svsW00ZACX+Zrbury9Au2A22px6sg4pe858Nnnwvtg0Pm4D0L/W9Yzn7N7X3R/RIMxsQ==",
+      "dependencies": {
+        "vscode-jsonrpc": "~8.2.1"
+      },
+      "engines": {
+        "node": ">=16.11.0",
+        "npm": ">=8.0.0"
+      }
+    },
+    "node_modules/vscode-ws-jsonrpc/node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.2",
@@ -6548,12 +7285,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "dev": true,
@@ -6628,14 +7359,42 @@
       "version": "0.0.0",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
-        "debounce": "^1.2.1",
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-cpp-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-environment-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-explorer-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-groovy-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-java-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-javascript-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-json-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-keybindings-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-lifecycle-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-localization-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-python-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-remote-agent-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-secret-storage-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-json-language-features": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-languages": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-typescript-language-features": "~11.1.1",
+        "@codingame/monaco-vscode-textmate-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-theme-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-typescript-basics-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-typescript-language-features-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-views-service-override": "~11.1.1",
+        "@typefox/monaco-editor-react": "~6.0.0-next.9",
+        "debounce": "^2.2.0",
         "json-rpc-2.0": "^1.3.0",
-        "monaco-editor-core": "^0.33.0",
-        "monaco-languageclient": "^1.0.1",
-        "vscode-languageserver-protocol": "^3.17.1"
+        "monaco-editor-core": "^0.52.0",
+        "monaco-editor-wrapper": "~6.0.0-next.9",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
         "@types/debounce": "^1.2.1",
+        "@types/vscode": "~1.95.0",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
         "clean-webpack-plugin": "^4.0.0",
@@ -6646,7 +7405,6 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "file-loader": "^6.2.0",
-        "handlebars": "^4.7.7",
         "html-loader": "^4.2.0",
         "html-webpack-plugin": "^5.5.0",
         "path-browserify": "^1.0.1",
@@ -6657,15 +7415,11 @@
         "stylelint-config-standard": "^28.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.3",
+        "vm-browserify": "^1.1.2",
         "webpack": "^5.94.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.1"
       }
-    },
-    "packages/app/node_modules/monaco-editor-core": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.33.0.tgz",
-      "integrity": "sha512-Kzxak8jnMS8vI08DcseBuOfeQlcVPpGXO210D8M+QnaNR92s4IYzgUeiow/Hld9Gi5pGvjDbPsdUXkPewoTA5g=="
     }
   },
   "dependencies": {
@@ -6751,6 +7505,534 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@codingame/monaco-vscode-base-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-11.1.1.tgz",
+      "integrity": "sha512-qOH9PKUDol9r/TRAFMuy4UrVX4u45t72VqQNOeVMDAz5j28U5KEzyOunINt88Jaay3h5kd/PN4VmpFjvmIlznA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-bulk-edit-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bulk-edit-service-override/-/monaco-vscode-bulk-edit-service-override-11.1.1.tgz",
+      "integrity": "sha512-XP+qyvJktu/HvoNVw3tuGhlvCMAXa/sHkyLN9kCj/qYzr8QdOwVeREU2qURG6n+1WDgy2dFoZVpYFphK9UJt7Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common/-/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common-11.1.1.tgz",
+      "integrity": "sha512-JRNFSVJbPkwID9SgIvlw/inhIH/w0rSu+Yc04lojcLFzI+hENqby9MaBb/prs0ypojHd92vV3mljeDSFF4ie4Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common/-/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common-11.1.1.tgz",
+      "integrity": "sha512-/dpN3H+HF2RZOjWh20zf5wX0qoJYQeBzvCJ8sPBuLyubAPg25cCOIXq0gFgbISZJPZ2g03VMFOHnawnP8EMJnQ==",
+      "requires": {
+        "marked": "~14.0.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-chat-extensions-notebook-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-notebook-common/-/monaco-vscode-chat-extensions-notebook-common-11.1.1.tgz",
+      "integrity": "sha512-DwyHIPpW0E3QwKagTvNzzBw6tgNPX/FgsTFD9UA/En//3PgMgrHIuDiZMh1UHiN3825hkF8hZwm9ms685NgN5A==",
+      "requires": {
+        "@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common/-/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common-11.1.1.tgz",
+      "integrity": "sha512-vBJN8LfojTQjkOmhHi4Ex0MYS7NVGQsoT+5IvpKX+odTFqmKNOHBumO6lT/XsxC32FARNvqz7p3AOSwAKR9xcg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-comments-extensions-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-comments-extensions-common/-/monaco-vscode-comments-extensions-common-11.1.1.tgz",
+      "integrity": "sha512-CAr0G8luD5JEC7A+ReW0bycCN4cLlx9zBKj9T26jTHECzUWjM8pdRmiOih0NjTXCAdy6emJ/3sFIdnyTnozFnw==",
+      "requires": {
+        "@codingame/monaco-vscode-chat-comments-extensions-interactive-notebook-search-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-configuration-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-11.1.1.tgz",
+      "integrity": "sha512-0JwEneQ5cj4qjnEa9a/TruKJ4BjUA2jumKswgpR6nO0NdeV4Gd7/L1xhBxV5xDtNJMf+qmIJ6cTgRyLC2SARuw==",
+      "requires": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-cpp-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cpp-default-extension/-/monaco-vscode-cpp-default-extension-11.1.1.tgz",
+      "integrity": "sha512-Gx7HM709ETGZE9vbPlOvJQWnxyKAQ1jJs4VzLK3ENtru+s5FZKhFlcgyJkleFPQSkCL5FakSbxe9AuEGNBkvBA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-editor-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-11.1.1.tgz",
+      "integrity": "sha512-ZDlhR3l5OZHlL/zHtcKpU2tFUbg6M6Z1kzPxzkq/XmHP+iRqkjBfORLFcl7Z/PzDyWBOXQ8Jfy3Js2bpRqMXWg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-environment-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-11.1.1.tgz",
+      "integrity": "sha512-lZIWykTUQYbx4NERF8Ha5drfITRmglA2jcRBr6/FT1l+AfDJqcabzNYRVoUCdyOO7keofPSMAJj97X6Fk7d5mw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common/-/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-2R1AjmcocrG5zwPxOHrHkYmO230wOTqr+P6MqCf5GPxZFdgChl0oG7bs2FsiNSaAoI/Kuicu5Ncc+AD3x00pKw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-explorer-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-11.1.1.tgz",
+      "integrity": "sha512-QWoNOB1lYxEp7RxGFjlxdfBViwYBInm+AUWIwKr+b9oJGsxTZ/rpHS32J3yHXnIBngyEcotzWUDYzxFW+gA8kA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-extensions-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-11.1.1.tgz",
+      "integrity": "sha512-Lj+3N6VZBJepAgBscfZnSQu6K4FVNip14z9R+xX4K4n5WnazOWNYgO8tHmbtOewN3SsJGDZxZa8ctXeowVJtxQ==",
+      "requires": {
+        "@codingame/monaco-vscode-chat-extensions-interactive-notebook-search-terminal-common": "11.1.1",
+        "@codingame/monaco-vscode-chat-extensions-notebook-common": "11.1.1",
+        "@codingame/monaco-vscode-comments-extensions-common": "11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-files-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-11.1.1.tgz",
+      "integrity": "sha512-L2cb4Apm8I49M3HIWmWDasPP5LWt/F4EDXSjIeSPRBooq7jVx6IfMMXFWCdH1pRXnTkiqLpiuRQWdBDH0MBETg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-groovy-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-groovy-default-extension/-/monaco-vscode-groovy-default-extension-11.1.1.tgz",
+      "integrity": "sha512-fenQ5w/ZZ2HrPce9jB+CDbHQmnO7XIz/2CqrYd0dp21tv8bW5FQ68PoXEHmJurMqGrSHDug+MKNLeKRRv5t9jw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-host-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-11.1.1.tgz",
+      "integrity": "sha512-owF9veg11ZpV3Xu6V8K2UVumqmoq5bY/jPhEiK/k7hWmVonCq9qY99GS7j4082YIf9yNK0w0m2BwOrMe/q46Ow==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-java-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-java-default-extension/-/monaco-vscode-java-default-extension-11.1.1.tgz",
+      "integrity": "sha512-kVzBvD482q2j/7rATp/5QiyW+Xe2hMfUh8SrlZ/IbJPtVgNduBEbZi0DQDuC31Og1djkzL2EkZBbye/ncADbAA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-javascript-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-javascript-default-extension/-/monaco-vscode-javascript-default-extension-11.1.1.tgz",
+      "integrity": "sha512-H5ubzMEC9hGGfnOrRYeL5AQPzzX+brwf8Tq09GpLiSCFdJKIOOSQ3lzHaYZlTKWcn5PEpJ+hko1O4PXnNhfDLA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-json-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-json-default-extension/-/monaco-vscode-json-default-extension-11.1.1.tgz",
+      "integrity": "sha512-1iDFXzmvWgvAGeN/0D/Lftd398nRWG1nwXWGo41vXSjqB9ZaQMyUpI+Ru+JJ/ubWFfJEv9vPfw30P68wdMbVRA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-keybindings-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-11.1.1.tgz",
+      "integrity": "sha512-XGNBeSAuwJZipwh0mEaYt5KQdSUNSE96okAK9Jxb9FsjjJGQHEsci1fzHIUYKy/GW1Geseh08MihQOmK01salg==",
+      "requires": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-cs": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-11.1.1.tgz",
+      "integrity": "sha512-3lWgJIpbTIXHpYHaLt9GUbM7mg32jT0E0fiqf8J8FKAFez03gWT+hi1SYLJ9G/hToE75E+LYM2MXq46CgMLLFg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-de": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-11.1.1.tgz",
+      "integrity": "sha512-RO0iM397afjcNUEMRN2rfIuA8byLH2Ob1wNTjXg8oP6xCXqIOvucB/8ljQG5fqK1gwebVTJaAdwZ50Yi36wxJA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-es": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-11.1.1.tgz",
+      "integrity": "sha512-ikiQhm01kzV2VHyKmkKRVgGGENmNBouzXJld6qBF+OAcreUgIxGv6mEUw3AElzlIju0ISkecoTj8uMEwD4tCcg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-fr": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-11.1.1.tgz",
+      "integrity": "sha512-5ozuyt+XiKprxGhT4dpFKckhrX4CZSTISiQ02l/dlgbEQPCjKyb3Tt2hYcI+ePSb6r7URWhDdtNgUvVerbKsDg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-it": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-11.1.1.tgz",
+      "integrity": "sha512-hg9U1Y72dkpDfdd8AyoToYBgxH+EDFbGIlNQvRQycgigsFf8EM3HBnIsIZ7jtL2M3mLy6lF3BrC1HGivCZSRWA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-ja": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-11.1.1.tgz",
+      "integrity": "sha512-9gWlbwf2gfThQkN/GdpVKZIPClGUIOfN3eUazZQe/WrXv5L7OR1N+tlcTYuy2Ny13COAsLpLLmQZZjowH4kRBg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-ko": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-11.1.1.tgz",
+      "integrity": "sha512-2AM2oR56tY5+S4aN7EDTq8b68ldf0pshcO+LhHsVRLhqi+XfidQh3ierGu92j8R6Cp7Yt8MWMoZBYXOJSbhCdw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-pl": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-11.1.1.tgz",
+      "integrity": "sha512-Zsx4ZcvQg2En8Fl9VyEdPYWGFiuP4K2itvfaurpRBjS3uSFYZ0/q5iQ9RntgEsKuz+LyaNz1Xg8CAMYYwdwAjw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-pt-br": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-11.1.1.tgz",
+      "integrity": "sha512-ZWFSk4r/x4N7AXbC8ksjrHOb8n5aQaPYMz0rnr8GCvVhIl2LwP0yclYBIXM5fDYjVos9hRe9znjjujyz3OaTmA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-qps-ploc": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-11.1.1.tgz",
+      "integrity": "sha512-dHPiti8l8zdc78I5ilLy1iXbNeOTpoqd9Uq8lnmX1bsQDiIEDw2v+epWSHDxyLR2eqX4o7ReBGd1fxi6o7CE0w==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-ru": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-11.1.1.tgz",
+      "integrity": "sha512-qctRF7YebAfICTS3efofVRWkhvOdB4Nd5wqM3l96pBYxd5QlWCgphOb6U60xg5iAHcvW97l9CcVmFnn6W7auRA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-tr": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-11.1.1.tgz",
+      "integrity": "sha512-q5gdqDrPCJjv8Nyrz4uyCdmeElgU+IxBxaLKBCPKtT2DumpKXJ0wv6ZPYjAJf05RfteWMt9jw/40C9Cj22AUeA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-zh-hans": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-11.1.1.tgz",
+      "integrity": "sha512-+kvpKeORWTv3hnaNFtNINIGbTkMxC5++423DlGjXaZE1uBmPqe3lN2+fku88X+diwWymZNbB8b0q8I72++DX1Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-language-pack-zh-hant": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-11.1.1.tgz",
+      "integrity": "sha512-1c4cObExQqhpzDLURdd5VaiG5jhk7kOUcHay2p8I+5nf0UKvRBfOJMsHMBiJ8py4eO39sWt9T9unv8IGh8TTiA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-languages-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-11.1.1.tgz",
+      "integrity": "sha512-8TC3AWZgXQGvXtV4fD3w9b0KCtoX1LqhfFGetaMHA8tUMOzBCVRQndTRD3zAW/MKigYuqBvBgUWCUq7mwpxJCA==",
+      "requires": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-layout-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-11.1.1.tgz",
+      "integrity": "sha512-oQ2aN0jIudyB1rDcgYUWpEvw7XQFx5NvpyF5u5cePb9hGTiOnMn6fqCMOgPEeLoq96HdKCh7SHztTTidWdFA4Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-lifecycle-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-lifecycle-service-override/-/monaco-vscode-lifecycle-service-override-11.1.1.tgz",
+      "integrity": "sha512-nrNY2JwNUAfFSJjazhfec8RAPcmIi7d54Jw9x+HyXasOA4zDht0mBgyi7v9Z228OfWy15rSzFIs5gY8dRiDA9Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-localization-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-11.1.1.tgz",
+      "integrity": "sha512-9E06bF+LQk8MuF3BUzZyEz1ohwOzP/UFPZ4Fg4XtDbycwu9taZrFb52t3ppYzPzAwoAjXr8LJX26tQDrqDq76A==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-log-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-11.1.1.tgz",
+      "integrity": "sha512-hOPC0jF9bQyQVTeRG/J/oT/6ZYeu5vQsWQCit89tx3za8XuAEgPy1EEJLPXJFaAEzJF5A9B4rqXDoDtU9tu5Tw==",
+      "requires": {
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-model-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-11.1.1.tgz",
+      "integrity": "sha512-Sy/u5jzj9jk4VaGM+FebPlOU37uMkSR/poE+RvFthdrIQ9SnQwBywiyre6XQY7jRt8xsnTLfs6fQkNjXer7nNw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-monarch-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-11.1.1.tgz",
+      "integrity": "sha512-7Dm2IzylcpcPX7ZJZzsuTLZ/cGw0wHaI8IzQJALT1SW6pgZyh+npiDiaep427zkp9/9/nA20FlCgCh4fHGNb2A==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-notifications-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-notifications-workbench-common/-/monaco-vscode-notifications-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-MxVDAufqflKsIPaH4GBbyXEGQozDS8OQPY39j5xiEhjLsG18OsVcOAJVAXNEVvST6TucJW5gIh7t7Mb4LcwW5Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-python-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-python-default-extension/-/monaco-vscode-python-default-extension-11.1.1.tgz",
+      "integrity": "sha512-PiQRmKQzHDt3gOWh53UdEFjKNZs6STnEFavYV5bqG20IpgG+0epIVWRxQwuYFa8EoqoSJPoRj2f3YIUX1BbInQ==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-11.1.1.tgz",
+      "integrity": "sha512-gVLQXKufvRVEtA9Pq9s29ep24DMi/fLmIyhylN2MfHmcgeDnFS7yDdgNYl6xLLoR4m1qrD3D8i05elboBCOIvA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-remote-agent-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-remote-agent-service-override/-/monaco-vscode-remote-agent-service-override-11.1.1.tgz",
+      "integrity": "sha512-FHwSnVX653opN/dyadch4kbAVNNlSQtQhOjG7vvwKs1hSi2y/QxwxuUk3FHbuEPgUOh+2cUxKHWrUOV4HkTJiQ==",
+      "requires": {
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-secret-storage-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-secret-storage-service-override/-/monaco-vscode-secret-storage-service-override-11.1.1.tgz",
+      "integrity": "sha512-T+9yhaYpd7kULpx4b9ZCOVEo3EhBXwMyU5DUST9/uQgILatfyM/4alt2HkrQBU9Pur7I1m2464p6N9BuMNAX4Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-standalone-json-language-features": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-json-language-features/-/monaco-vscode-standalone-json-language-features-11.1.1.tgz",
+      "integrity": "sha512-kzEs79gJNaNSX/GFSDsIl7XpX5MFxdMk+AUC+yEzCTv+IRFTS095VbLS5TTn6vPsDNeCkD7WjqctP0A5SNDQqA==",
+      "requires": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-standalone-languages": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-languages/-/monaco-vscode-standalone-languages-11.1.1.tgz",
+      "integrity": "sha512-l/2SvZHo8bNtcivJscpqotDeWiXvlQSK1A8wD7sLPRcm72Mt5LWi8jnNckGoiW0FXWRCdzsUBm0BLOSdjzZOcA==",
+      "requires": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-standalone-typescript-language-features": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-typescript-language-features/-/monaco-vscode-standalone-typescript-language-features-11.1.1.tgz",
+      "integrity": "sha512-Y3nV09N0DXghN5CBdDHNpoXHw6Q93kX99OIF0gZzw4Q8HYayvHQ32AjqZl9B1uH+6IPyCfL2MZxKmELEr9bnaw==",
+      "requires": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-textmate-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-11.1.1.tgz",
+      "integrity": "sha512-nRGZjU1GkHd/7omJFSR1rRxP8/BvJPlrrRkOCbwJYKmyaQoY5Brr8oa9QMqJ/E6myRTa3OLfieK+QHVS9XDqSA==",
+      "requires": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1",
+        "vscode-oniguruma": "1.7.0",
+        "vscode-textmate": "9.1.0"
+      }
+    },
+    "@codingame/monaco-vscode-theme-defaults-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-11.1.1.tgz",
+      "integrity": "sha512-cprp1Jyex8aVm/oIhL9rr97y+zUztW6KXWGqaeHPSiDqMYmIbitFv9DYeqcfA/3+2O0jenEanBt28uQi6Zkhbw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-theme-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-11.1.1.tgz",
+      "integrity": "sha512-RjSUTwP0Xo0P590aKKrOdmmMfjusyPUn2OwbMoDe8IT8K8eCTH5Qt6CW79muQbu9boNNDhGDwUkoE02Iq4E22A==",
+      "requires": {
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-typescript-basics-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-basics-default-extension/-/monaco-vscode-typescript-basics-default-extension-11.1.1.tgz",
+      "integrity": "sha512-0fIcS3ZJ899uaVwZfkUUXblIY3I8z2TLQScuJ86g04Ksrq0do8TEBGZo0mZrKnwUr9p+gCa0lWQZcEXF7voF1Q==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-typescript-language-features-default-extension": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-language-features-default-extension/-/monaco-vscode-typescript-language-features-default-extension-11.1.1.tgz",
+      "integrity": "sha512-maazeZhi5Te93Dl1H0d7Cd3GuljOy/gI9uSqSDUT/yJemKOPKYT0sK5j0EknZxQ2uO8kG2T2Bxvj7CeAnSSKrw==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-view-banner-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-banner-service-override/-/monaco-vscode-view-banner-service-override-11.1.1.tgz",
+      "integrity": "sha512-4P8JwTaLsugRC7aeEHUDEmJiA/6DBvRByRLfGypGo9rG8Mg1PHmqA0QRtm85NOVzCjPTbNBMJJ8VA3+uU5a9pQ==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-view-common-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-service-override/-/monaco-vscode-view-common-service-override-11.1.1.tgz",
+      "integrity": "sha512-uTnMMnwWKi7G4z0qBU3sBD2y9paIgKymfPJdS00NMn72KQmOQFtuV/R/5QtWmMqxl/mhWUIoiU6R+G9m03HwEA==",
+      "requires": {
+        "@codingame/monaco-vscode-bulk-edit-service-override": "11.1.1",
+        "@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-view-common-views-workbench-common": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-views-workbench-common/-/monaco-vscode-view-common-views-workbench-common-11.1.1.tgz",
+      "integrity": "sha512-7VVlaZqRwjLUG9I8roJYQMVn6ULyQjNH+a73ghLaZCzoQsquaZ+FvykzsVpxmuxIYF/gKImv7NCYdYh4FZB5Aw==",
+      "requires": {
+        "@codingame/monaco-vscode-explorer-outline-timeline-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-view-status-bar-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-status-bar-service-override/-/monaco-vscode-view-status-bar-service-override-11.1.1.tgz",
+      "integrity": "sha512-Lkiq9+NLD90K0XGHplBCEqE+4QNXewrcv5Vxr0Xo1CBtDX+8EaPDYREOWYZGqGaOAhgRXJ7qP1C0LHKEqewocg==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-view-title-bar-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-title-bar-service-override/-/monaco-vscode-view-title-bar-service-override-11.1.1.tgz",
+      "integrity": "sha512-0YCdfoDGvVh0mKuJ8oUBJiYDRbR+rZW8hJM4GlGS7FOxpGf5aOmce8AP2zAJs5COWw6X1/ZI3pmdJWBSC1YVOA==",
+      "requires": {
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-views-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-views-service-override/-/monaco-vscode-views-service-override-11.1.1.tgz",
+      "integrity": "sha512-FycqsM9SPnP9EFTekNXc1aI74jU9m2FP/7Q/WTE4j36HWISyvOjxYiZ1JZGYrfg5TcE4hUejFi2V9HDZzMnMXA==",
+      "requires": {
+        "@codingame/monaco-vscode-keybindings-service-override": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "@codingame/monaco-vscode-workbench-service-override": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-workbench-service-override/-/monaco-vscode-workbench-service-override-11.1.1.tgz",
+      "integrity": "sha512-WH+Q7VCPZXZBfUf9QgifzrFRllv3olXQm3NvUCI8cSgwVcpsav33HWaFBao+96vRRimJukQK+5T3yCVmtbrBeg==",
+      "requires": {
+        "@codingame/monaco-vscode-keybindings-service-override": "11.1.1",
+        "@codingame/monaco-vscode-notifications-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-banner-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-common-views-workbench-common": "11.1.1",
+        "@codingame/monaco-vscode-view-status-bar-service-override": "11.1.1",
+        "@codingame/monaco-vscode-view-title-bar-service-override": "11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
     },
     "@cspotcode/source-map-support": {
@@ -6893,6 +8175,18 @@
     "@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true
+    },
+    "@typefox/monaco-editor-react": {
+      "version": "6.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/@typefox/monaco-editor-react/-/monaco-editor-react-6.0.0-next.9.tgz",
+      "integrity": "sha512-bjFPQApM2GqzVMEzrHrcYccw2+G+umhgnZ89k6j9/DKAzDr9ygx5FiJUaVplSlw4FnkXnMjiSASVPAHZ9GOQqg==",
+      "requires": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "monaco-editor-wrapper": "~6.0.0-next.9",
+        "monaco-languageclient": "~9.0.0-next.9",
+        "react": "~18.3.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1"
+      }
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -7040,6 +8334,12 @@
         "@types/node": "*"
       }
     },
+    "@types/vscode": {
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "8.5.3",
       "dev": true,
@@ -7125,6 +8425,11 @@
         "@typescript-eslint/types": "5.30.5",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@vscode/iconv-lite-umd": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz",
+      "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -7511,6 +8816,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7714,7 +9020,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "connect-history-api-fallback": {
       "version": "2.0.0",
@@ -7844,7 +9151,9 @@
       "dev": true
     },
     "debounce": {
-      "version": "1.2.1"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -8612,7 +9921,8 @@
       }
     },
     "glob-to-regexp": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "global-modules": {
       "version": "2.0.0",
@@ -8688,19 +9998,6 @@
     "handle-thing": {
       "version": "2.0.1",
       "dev": true
-    },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
     },
     "hard-rejection": {
       "version": "2.1.0",
@@ -9135,8 +10432,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -9144,6 +10440,11 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -9226,6 +10527,14 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "lower-case": {
       "version": "2.0.2",
       "dev": true,
@@ -9248,6 +10557,11 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
+    },
+    "marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -9357,15 +10671,10 @@
     },
     "minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -9386,37 +10695,116 @@
         }
       }
     },
-    "monaco-languageclient": {
-      "version": "1.1.0",
+    "monaco-editor": {
+      "version": "npm:@codingame/monaco-vscode-editor-api@11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-11.1.1.tgz",
+      "integrity": "sha512-QTFaL6FBR/o6kB0x/uKYTKImKPhClEFxX9H09sbtgNKh0yi/lsy9BxJvI535Mw3CCY7wpzBMTTbfZrelz/vW7g==",
       "requires": {
-        "glob-to-regexp": "^0.4.1",
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageclient": "8.0.1",
-        "vscode-languageserver-textdocument": "1.0.5",
-        "vscode-uri": "3.0.3"
+        "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
+      }
+    },
+    "monaco-editor-core": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.52.0.tgz",
+      "integrity": "sha512-Ur6BNCVgBcmOc4ZizEBl+rGiYtuozztOi4fgRFnAV64sRgKOxkwC1RxGfvJa3pHedoJ2eepV8Frjnr4PbhLcYA=="
+    },
+    "monaco-editor-wrapper": {
+      "version": "6.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-6.0.0-next.9.tgz",
+      "integrity": "sha512-xWDPiDUPPXXYwGxEWtFr4ghUk+v5+DaYY1UZoyv7p3mCqtq4Cyu1HTt4C3U/blLcPHAX/fHXs7ZfqIu6j8A4Ow==",
+      "requires": {
+        "@codingame/monaco-vscode-chat-extensions-notebook-task-terminal-testing-common": "~11.1.1",
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-editor-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-cs": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-de": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-es": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-fr": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-it": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ja": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ko": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-pl": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-pt-br": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-qps-ploc": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-ru": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-tr": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-zh-hans": "~11.1.1",
+        "@codingame/monaco-vscode-language-pack-zh-hant": "~11.1.1",
+        "@codingame/monaco-vscode-monarch-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-textmate-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-theme-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-views-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-workbench-service-override": "~11.1.1",
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "~9.0.1",
+        "vscode-languageserver-protocol": "~3.17.5",
+        "vscode-ws-jsonrpc": "~3.3.2"
+      }
+    },
+    "monaco-languageclient": {
+      "version": "9.0.0-next.9",
+      "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-9.0.0-next.9.tgz",
+      "integrity": "sha512-mVzHtw9M1kFt1gKr/T8vZqUqCUTT/rhsu/yHTd63PlWaUjEMYK2j2VQTaGj2zcYQtM69QWNQdmEP7WalfU3cmg==",
+      "requires": {
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-extensions-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-languages-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-localization-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-log-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-model-service-override": "~11.1.1",
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.1",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "~9.0.1"
       }
     },
     "monaco-lsp-streams": {
       "version": "file:packages/app",
       "requires": {
+        "@codingame/monaco-vscode-configuration-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-cpp-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-environment-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-explorer-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-groovy-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-java-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-javascript-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-json-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-keybindings-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-lifecycle-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-localization-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-python-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-remote-agent-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-secret-storage-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-json-language-features": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-languages": "~11.1.1",
+        "@codingame/monaco-vscode-standalone-typescript-language-features": "~11.1.1",
+        "@codingame/monaco-vscode-textmate-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-theme-service-override": "~11.1.1",
+        "@codingame/monaco-vscode-typescript-basics-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-typescript-language-features-default-extension": "~11.1.1",
+        "@codingame/monaco-vscode-views-service-override": "~11.1.1",
+        "@typefox/monaco-editor-react": "~6.0.0-next.9",
         "@types/debounce": "^1.2.1",
+        "@types/vscode": "~1.95.0",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.1",
-        "debounce": "^1.2.1",
+        "debounce": "^2.2.0",
         "esbuild-loader": "^2.19.0",
         "eslint": "^8.17.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
         "file-loader": "^6.2.0",
-        "handlebars": "^4.7.7",
         "html-loader": "^4.2.0",
         "html-webpack-plugin": "^5.5.0",
         "json-rpc-2.0": "^1.3.0",
-        "monaco-editor-core": "^0.33.0",
-        "monaco-languageclient": "^1.0.1",
+        "monaco-editor-core": "^0.52.0",
+        "monaco-editor-wrapper": "~6.0.0-next.9",
         "path-browserify": "^1.0.1",
         "prettier": "^2.6.2",
         "source-map-loader": "^4.0.0",
@@ -9425,17 +10813,13 @@
         "stylelint-config-standard": "^28.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.3",
-        "vscode-languageserver-protocol": "^3.17.1",
+        "vm-browserify": "^1.1.2",
+        "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+        "vscode-languageclient": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
         "webpack": "^5.94.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.1"
-      },
-      "dependencies": {
-        "monaco-editor-core": {
-          "version": "0.33.0",
-          "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.33.0.tgz",
-          "integrity": "sha512-Kzxak8jnMS8vI08DcseBuOfeQlcVPpGXO210D8M+QnaNR92s4IYzgUeiow/Hld9Gi5pGvjDbPsdUXkPewoTA5g=="
-        }
       }
     },
     "ms": {
@@ -9904,6 +11288,14 @@
             "safer-buffer": ">= 2.1.2 < 3"
           }
         }
+      }
+    },
+    "react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "requires": {
+        "loose-envify": "^1.1.0"
       }
     },
     "read-pkg": {
@@ -10763,13 +12155,6 @@
       "version": "4.7.4",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10831,32 +12216,99 @@
       "version": "1.1.2",
       "dev": true
     },
+    "vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+    },
+    "vscode": {
+      "version": "npm:@codingame/monaco-vscode-api@11.1.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-11.1.1.tgz",
+      "integrity": "sha512-m2hGKexUeQ9CfTcjdI+YLNmSwBqTOJD7m7iOkvSo5l7obDg59lgwdCutQIWl0vEZaZorNyyfDvJvgyupMMn3uw==",
+      "requires": {
+        "@codingame/monaco-vscode-base-service-override": "11.1.1",
+        "@codingame/monaco-vscode-environment-service-override": "11.1.1",
+        "@codingame/monaco-vscode-extensions-service-override": "11.1.1",
+        "@codingame/monaco-vscode-files-service-override": "11.1.1",
+        "@codingame/monaco-vscode-host-service-override": "11.1.1",
+        "@codingame/monaco-vscode-layout-service-override": "11.1.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "11.1.1",
+        "@vscode/iconv-lite-umd": "0.7.0",
+        "jschardet": "3.1.4",
+        "marked": "~14.0.0"
+      }
+    },
     "vscode-jsonrpc": {
-      "version": "8.0.1"
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
     },
     "vscode-languageclient": {
-      "version": "8.0.1",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "requires": {
-        "minimatch": "^3.0.4",
-        "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.1"
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.1",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "requires": {
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageserver-types": "3.17.1"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
-    "vscode-languageserver-textdocument": {
-      "version": "1.0.5"
-    },
     "vscode-languageserver-types": {
-      "version": "3.17.1"
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
-    "vscode-uri": {
-      "version": "3.0.3"
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
+    "vscode-textmate": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.1.0.tgz",
+      "integrity": "sha512-lxKSVp2DkFOx9RDAvpiYUrB9/KT1fAfi1aE8CBGstP8N7rLF+Seifj8kDA198X0mYj1CjQUC+81+nQf8CO0nVA=="
+    },
+    "vscode-ws-jsonrpc": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-3.3.2.tgz",
+      "integrity": "sha512-jxGHxAuow67sNRkkS2svsW00ZACX+Zrbury9Au2A22px6sg4pe858Nnnwvtg0Pm4D0L/W9Yzn7N7X3R/RIMxsQ==",
+      "requires": {
+        "vscode-jsonrpc": "~8.2.1"
+      },
+      "dependencies": {
+        "vscode-jsonrpc": {
+          "version": "8.2.1",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+          "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="
+        }
+      }
     },
     "watchpack": {
       "version": "2.4.2",
@@ -11048,12 +12500,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wrappy": {

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,5 @@
   "private": true,
   "workspaces": [
     "packages/app"
-  ],
-  "dependencies": {}
+  ]
 }

--- a/web/packages/app/declarations.d.ts
+++ b/web/packages/app/declarations.d.ts
@@ -1,1 +1,6 @@
 declare module "*.module.css";
+
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/web/packages/app/package.json
+++ b/web/packages/app/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/debounce": "^1.2.1",
+    "@types/vscode": "~1.95.0",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "clean-webpack-plugin": "^4.0.0",
@@ -48,13 +49,20 @@
     "typescript": "^4.7.3",
     "webpack": "^5.94.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.9.1"
+    "webpack-dev-server": "^4.9.1",
+    "vm-browserify": "^1.1.2"
   },
   "dependencies": {
-    "debounce": "^1.2.1",
+    "debounce": "^2.2.0",
     "json-rpc-2.0": "^1.3.0",
-    "monaco-editor-core": "^0.33.0",
-    "monaco-languageclient": "^1.0.1",
-    "vscode-languageserver-protocol": "^3.17.1"
+    "monaco-editor-core": "^0.52.0",
+    "monaco-editor-wrapper": "~6.0.0-next.9",
+    "vscode-languageserver-protocol": "^3.17.5",
+    "vscode-languageclient": "^9.0.1",
+    "vscode": "npm:@codingame/monaco-vscode-api@~11.1.1",
+    "@codingame/monaco-vscode-keybindings-service-override": "~11.1.1",
+    "@codingame/monaco-vscode-theme-defaults-default-extension": "~11.1.1",
+    "@codingame/monaco-vscode-textmate-service-override": "~11.1.1",
+    "@codingame/monaco-vscode-files-service-override": "~11.1.1"
   }
 }

--- a/web/packages/app/src/editor/app.ts
+++ b/web/packages/app/src/editor/app.ts
@@ -194,7 +194,7 @@ export default class App {
     const server = await Server.initialize(intoServer, fromServer);
     await this.createEditor(client);
     await Promise.all([server.start(), client.start()]);
-  };
+  }
 
   private async updateInMemoryFileContent(newContent: string): Promise<void> {
     const encoder = new TextEncoder();

--- a/web/packages/app/src/editor/app.ts
+++ b/web/packages/app/src/editor/app.ts
@@ -188,18 +188,13 @@ export default class App {
   }
 
   async run(): Promise<void> {
-    console.log("run");
-
     const fromServer = FromServer.create();
     const intoServer = new IntoServer();
     const client = new Client(fromServer, intoServer);
     const server = await Server.initialize(intoServer, fromServer);
     await this.createEditor(client);
-
-    console.log("client.start");
-
     await Promise.all([server.start(), client.start()]);
-  }
+  };
 
   private async updateInMemoryFileContent(newContent: string): Promise<void> {
     const encoder = new TextEncoder();

--- a/web/packages/app/src/editor/language-configuration.json
+++ b/web/packages/app/src/editor/language-configuration.json
@@ -1,0 +1,17 @@
+{
+  "comments": {
+    "lineComment": "--"
+  },
+  "brackets": [
+    ["(", ")"],
+    ["{", "}"]
+  ],
+  "autoClosingPairs": [
+    ["(", ")"],
+    ["{", "}"]
+  ],
+  "surroundingPairs": [
+    ["(", ")"],
+    ["{", "}"]
+  ]
+}

--- a/web/packages/app/src/editor/language.ts
+++ b/web/packages/app/src/editor/language.ts
@@ -1,162 +1,69 @@
-// import * as jsrpc from "json-rpc-2.0";
-import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from "monaco-languageclient";
-import * as monaco from "monaco-editor-core";
+import * as vscode from "vscode";
 import * as proto from "vscode-languageserver-protocol";
-
+import { createConverter as createCodeConverter } from "vscode-languageclient/lib/common/codeConverter.js";
+import { createConverter as createProtocolConverter } from "vscode-languageclient/lib/common/protocolConverter.js";
 import Client from "./client";
 
-export const monacoToProtocol = new MonacoToProtocolConverter(monaco);
-export const protocolToMonaco = new ProtocolToMonacoConverter(monaco);
+const code2Protocol = createCodeConverter();
+const protocol2Code = createProtocolConverter(undefined, true, true);
 
-let language: null | Language;
+export default class Language {
+  static id: string = "polarity";
 
-export default class Language implements monaco.languages.ILanguageExtensionPoint {
-  readonly id: string;
-  readonly aliases: string[];
-  readonly extensions: string[];
-  readonly mimetypes: string[];
-
-  private constructor(client: Client) {
-    const { id, aliases, extensions, mimetypes } = Language.extensionPoint();
-    this.id = id;
-    this.aliases = aliases;
-    this.extensions = extensions;
-    this.mimetypes = mimetypes;
-    this.registerLanguage(client);
-  }
-
-  static extensionPoint(): monaco.languages.ILanguageExtensionPoint & {
-    aliases: string[];
-    extensions: string[];
-    mimetypes: string[];
-  } {
-    const id = "pol";
-    const aliases: string[] = [];
-    const extensions = [".pol"];
-    const mimetypes: string[] = [];
-    return { id, extensions, aliases, mimetypes };
-  }
-
-  private registerLanguage(client: Client): void {
-    void client;
-    monaco.languages.register(Language.extensionPoint());
-    monaco.languages.setMonarchTokensProvider(this.id, Language.syntaxDefinition());
-    monaco.languages.registerDocumentSymbolProvider(this.id, {
-      async provideDocumentSymbols(model, token): Promise<monaco.languages.DocumentSymbol[]> {
+  static registerLanguageFeatures(client: Client): void {
+    vscode.languages.registerHoverProvider(this.id, {
+      async provideHover(document, position, token) {
         void token;
-        const response = await (client.request(proto.DocumentSymbolRequest.type.method, {
-          textDocument: monacoToProtocol.asTextDocumentIdentifier(model),
-        } as proto.DocumentSymbolParams) as Promise<proto.SymbolInformation[]>);
+        const response = (await client.request(proto.HoverRequest.type.method, {
+          textDocument: code2Protocol.asTextDocumentIdentifier(document),
+          position: code2Protocol.asPosition(position),
+        })) as proto.Hover | null;
 
-        const uri = model.uri.toString();
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const result: monaco.languages.DocumentSymbol[] = protocolToMonaco.asSymbolInformations(response, uri);
-
-        return result;
-      },
-    });
-    monaco.languages.registerHoverProvider(this.id, {
-      async provideHover(model, position, token): Promise<monaco.languages.Hover> {
-        void token;
-        const response = await (client.request(proto.HoverRequest.type.method, {
-          textDocument: {
-            version: 0,
-            uri: model.uri.toString(),
-          },
-          position: monacoToProtocol.asPosition(position.lineNumber, position.column),
-        } as proto.TextDocumentPositionParams) as Promise<proto.Hover>);
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const result: monaco.languages.Hover = protocolToMonaco.asHover(response);
-
-        return result;
-      },
-    });
-    monaco.languages.registerCodeActionProvider(this.id, {
-      async provideCodeActions(model, range, context, token): Promise<monaco.languages.CodeActionList> {
-        void token;
-        const response = await (client.request(proto.CodeActionRequest.type.method, {
-          textDocument: {
-            version: 0,
-            uri: model.uri.toString(),
-          },
-          range: monacoToProtocol.asRange(range),
-          context: monacoToProtocol.asCodeActionContext(context, []),
-        } as proto.CodeActionParams) as Promise<proto.CodeAction[]>);
-
-        if (response === null) {
-          return { actions: [], dispose: () => undefined };
+        if (!response) {
+          return undefined;
         }
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const result: monaco.languages.CodeActionList = protocolToMonaco.asCodeActionList(response);
-
-        return result;
+        return protocol2Code.asHover(response);
       },
     });
 
-    monaco.languages.registerDocumentFormattingEditProvider(this.id, {
-      async provideDocumentFormattingEdits(model, options, token) {
+    vscode.languages.registerCodeActionsProvider(this.id, {
+      async provideCodeActions(document, range, context, token) {
         void token;
-        const response = await (client.request(proto.DocumentFormattingRequest.type.method, {
-          textDocument: {
-            version: 0,
-            uri: model.uri.toString(),
-          },
-          options: { tabSize: options.tabSize, insertSpaces: options.insertSpaces },
-        } as proto.DocumentFormattingParams) as Promise<proto.TextEdit[]>);
+        const pContext = await code2Protocol.asCodeActionContext(context);
+        pContext.diagnostics = pContext.diagnostics ?? [];
 
-        if (response === null) {
+        const response = (await client.request(proto.CodeActionRequest.type.method, {
+          textDocument: code2Protocol.asTextDocumentIdentifier(document),
+          range: code2Protocol.asRange(range),
+          context: pContext,
+        })) as proto.CodeAction[] | null;
+
+        if (!response) {
           return [];
         }
 
-        const result = protocolToMonaco.asTextEdits(response) as monaco.languages.TextEdit[];
-        return result;
+        const actions = await Promise.all(response.map((action) => protocol2Code.asCodeAction(action)));
+        return actions.filter((a): a is vscode.CodeAction => a !== undefined);
       },
     });
-  }
 
-  private static syntaxDefinition(): monaco.languages.IMonarchLanguage {
-    return {
-      keywords: ["data", "codata", "let", "def", "codef", "match", "comatch", "absurd", "Type", "implicit", "use"],
+    vscode.languages.registerDocumentFormattingEditProvider(this.id, {
+      async provideDocumentFormattingEdits(document, options, token) {
+        void token;
+        const response = (await client.request(proto.DocumentFormattingRequest.type.method, {
+          textDocument: code2Protocol.asTextDocumentIdentifier(document),
+          options: {
+            tabSize: options.tabSize,
+            insertSpaces: options.insertSpaces,
+          },
+        })) as proto.TextEdit[] | null;
 
-      typeKeywords: ["Type"],
-
-      operators: [";", "=>", ",", ":", "."],
-
-      tokenizer: {
-        root: [
-          // identifiers and keywords
-          [
-            /[a-z_][a-zA-Z0-9_]*[']*/,
-            { cases: { "@typeKeywords": "keyword", "@keywords": "keyword", "@default": "identifier" } },
-          ],
-          [/[A-Z][a-zA-Z0-9_]*[']*/, "type.identifier"],
-
-          // whitespace
-          { include: "@whitespace" },
-
-          // delimiter
-          [/[;,.]/, "delimiter"],
-        ],
-
-        comment: [[/--/, "comment"]],
-
-        whitespace: [
-          [/[ \t\r\n]+/, "white"],
-          [/--.*$/, "comment"],
-        ],
+        if (response) {
+          const textEdits = await protocol2Code.asTextEdits(response);
+          return textEdits || [];
+        }
+        return [];
       },
-    };
-  }
-
-  static initialize(client: Client): Language {
-    if (null == language) {
-      language = new Language(client);
-    } else {
-      console.warn("Language already initialized; ignoring");
-    }
-    return language;
+    });
   }
 }

--- a/web/packages/app/src/editor/pol.tmLanguage.json
+++ b/web/packages/app/src/editor/pol.tmLanguage.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "pol",
+  "patterns": [
+    { "include": "#keywords" },
+    { "include": "#symbols" },
+    { "include": "#comments" },
+    { "include": "#strings" }
+  ],
+  "repository": {
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control",
+          "match": "\\b(data|codata|let|def|codef|match|comatch|absurd|Type|implicit|use)\\b"
+        }
+      ]
+    },
+    "symbols": {
+      "patterns": [
+        {
+          "match": "(;|=>|,|:|\\.)",
+          "name": "keyword.syntax"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "match": "--.*$",
+          "name": "comment.line.double-dash.syntax"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "source.pol"
+}

--- a/web/packages/app/src/editor/workers.ts
+++ b/web/packages/app/src/editor/workers.ts
@@ -1,0 +1,19 @@
+import { Logger } from "monaco-languageclient/tools";
+import { useWorkerFactory } from "monaco-editor-wrapper/workerFactory";
+
+export const configureMonacoWorkers = (logger?: Logger) => {
+  useWorkerFactory({
+    workerOverrides: {
+      ignoreMapping: true,
+      workerLoaders: {
+        TextEditorWorker: () =>
+          new Worker(new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url), { type: "module" }),
+        TextMateWorker: () =>
+          new Worker(new URL("@codingame/monaco-vscode-textmate-service-override/worker", import.meta.url), {
+            type: "module",
+          }),
+      },
+    },
+    logger,
+  });
+};

--- a/web/packages/app/webpack.config.js
+++ b/web/packages/app/webpack.config.js
@@ -33,11 +33,10 @@ module.exports = (env, argv) => {
       "editor.worker": "monaco-editor-core/esm/vs/editor/editor.worker.js",
     },
     resolve: {
-      alias: {
-        vscode: require.resolve("monaco-languageclient/vscode-compatibility"),
-      },
       extensions: [".ts", ".js", ".json", ".ttf"],
       fallback: {
+        vm: require.resolve("vm-browserify"),
+        module: false,
         fs: false,
         child_process: false,
         net: false,
@@ -114,6 +113,9 @@ module.exports = (env, argv) => {
         writeToDisk: true,
       },
     },
+    // Otherwise webpack fails the build with:
+    // WARNING in ../../node_modules/vscode/vscode/src/vs/amdX.js 142:14-31
+    ignoreWarnings: [/Critical dependency: the request of a dependency is an expression/],
   };
   return config;
 };


### PR DESCRIPTION
The purpose of this PR is twofold:

1. Upgrade `tower-lsp` to use the latest [community fork](https://github.com/tower-lsp/tower-lsp) commit. The original `tower-lsp` library is unmaintained and the maintainer is unresponsive.
2. Upgrade the web demo to use a more up-to-date VS Code/Monaco. This brings us closer to reusing (parts of) the VS Code extension for the web demo. As a starting point, in this PR I copied the language configuration and TextMate grammer from the extension repository. This can be deduplicated in the future.
