### PR TITLE
Fix nix development shell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,3 +31,5 @@ jobs:
       - name: Build and run a static polarity exe
         if: matrix.os == 'ubuntu-latest'
         run: nix -Lv run .#polarity-static -- --help
+      - name: Drop into nix devshell and run tests
+        run: nix develop -Lv -c bash -c "make test"

--- a/contrib/nix/shell.nix
+++ b/contrib/nix/shell.nix
@@ -12,5 +12,11 @@ pkgs.mkShell.override { inherit stdenv; } {
     pkgs.rustfmt
 
     pkgs.nixfmt-rfc-style
+
+    pkgs.pkg-config
+    pkgs.openssl
   ];
+
+  PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+
 }


### PR DESCRIPTION
Previously `nix develop` + `make test` would lead to an error while building `openssl-probe` dependency.
A similar error is described in https://nixos.wiki/wiki/Rust#Building_Rust_crates_that_require_external_system_libraries.

This PR also adds a CI run to test the nix shell.