### PR TITLE
fix nix devshell again: add a dependency if running on macos

### DIFF
--- a/contrib/nix/shell.nix
+++ b/contrib/nix/shell.nix
@@ -15,7 +15,7 @@ pkgs.mkShell.override { inherit stdenv; } {
 
     pkgs.pkg-config
     pkgs.openssl
-  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv darwin.apple_sdk.frameworks.SystemConfiguration ]);
 
   PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
 

--- a/contrib/nix/shell.nix
+++ b/contrib/nix/shell.nix
@@ -15,7 +15,7 @@ pkgs.mkShell.override { inherit stdenv; } {
 
     pkgs.pkg-config
     pkgs.openssl
-  ];
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
 
   PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
 


### PR DESCRIPTION
similar to
https://github.com/DeterminateSystems/zero-to-nix/issues/203 and https://github.com/DeterminateSystems/zero-to-nix/pull/204