### PR TITLE
Remove type cst

### DIFF
--- a/lang/lowering/src/lower/decls/mod.rs
+++ b/lang/lowering/src/lower/decls/mod.rs
@@ -1,6 +1,6 @@
 use ast::VarBind;
+use exp::bs_to_name;
 use miette_util::ToMiette;
-use parser::cst::exp::BindingSite;
 use parser::cst::{self};
 
 use super::*;
@@ -154,12 +154,7 @@ where
             let mut params_out = params_out?;
             let cst::decls::Param { implicit, name, names: _, typ } = param; // The `names` field has been removed by `desugar_telescope`.
             let typ_out = typ.lower(ctx)?;
-            let name = match name {
-                BindingSite::Var { name, .. } => name.clone(),
-                BindingSite::Wildcard { span } => {
-                    parser::cst::ident::Ident { span: *span, id: "_".to_owned() }
-                }
-            };
+            let name = bs_to_name(name)?;
             let name = VarBind { span: Some(name.span), id: name.id.clone() };
             let param_out = ast::Param { implicit: *implicit, name, typ: typ_out, erased: false };
             params_out.push(param_out);

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -292,7 +292,12 @@ impl Lower for cst::exp::Call {
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
         let cst::exp::Call { span, name, args } = self;
 
+        // The type universe "Type" is treated as an ordinary call in the lexer and parser.
+        // For this reason we have to special case the logic for lowering the type universe here.
         if name.id == "Type" {
+            if args.len() != 0 {
+                return Err(LoweringError::TypeUnivArgs { span: span.to_miette() });
+            }
             return Ok(TypeUniv { span: Some(*span) }.into());
         }
 

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -28,7 +28,6 @@ impl Lower for cst::exp::Exp {
             cst::exp::Exp::Call(e) => e.lower(ctx),
             cst::exp::Exp::DotCall(e) => e.lower(ctx),
             cst::exp::Exp::Anno(e) => e.lower(ctx),
-            cst::exp::Exp::TypeUniv(e) => e.lower(ctx),
             cst::exp::Exp::LocalMatch(e) => e.lower(ctx),
             cst::exp::Exp::LocalComatch(e) => e.lower(ctx),
             cst::exp::Exp::Hole(e) => e.lower(ctx),
@@ -400,15 +399,6 @@ impl Lower for cst::exp::Anno {
             normalized_type: None,
         }
         .into())
-    }
-}
-
-impl Lower for cst::exp::TypeUniv {
-    type Target = ast::Exp;
-
-    fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::TypeUniv { span } = self;
-        Ok(TypeUniv { span: Some(*span) }.into())
     }
 }
 

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -295,7 +295,7 @@ impl Lower for cst::exp::Call {
         // The type universe "Type" is treated as an ordinary call in the lexer and parser.
         // For this reason we have to special case the logic for lowering the type universe here.
         if name.id == "Type" {
-            if args.len() != 0 {
+            if !args.is_empty() {
                 return Err(LoweringError::TypeUnivArgs { span: span.to_miette() });
             }
             return Ok(TypeUniv { span: Some(*span) }.into());

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -292,6 +292,10 @@ impl Lower for cst::exp::Call {
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
         let cst::exp::Call { span, name, args } = self;
 
+        if name.id == "Type" {
+            return Ok(TypeUniv { span: Some(*span) }.into());
+        }
+
         // If we find the identifier in the local context then we have to lower
         // it to a variable.
         if let Some(idx) = ctx.lookup_local(name) {

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -102,6 +102,7 @@ pub enum LoweringError {
     },
     #[error("\"Type\" is not a valid identifier")]
     #[diagnostic(code("L-016"))]
+    #[diagnostic(help("\"Type\" is the name of the impredicative type universe."))]
     TypeUnivIdentifier {
         #[label]
         span: SourceSpan,

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -100,6 +100,12 @@ pub enum LoweringError {
         #[label]
         span: SourceSpan,
     },
+    #[error("\"Type\" is not a valid identifier")]
+    #[diagnostic(code("L-016"))]
+    TypeUnivIdentifier {
+        #[label]
+        span: SourceSpan,
+    },
     #[error("An unexpected internal error occurred: {message}")]
     #[diagnostic(code("L-XXX"))]
     /// This error should not occur.

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -94,6 +94,12 @@ pub enum LoweringError {
         #[label]
         span: SourceSpan,
     },
+    #[error("Type universe \"Type\" does not take arguments")]
+    #[diagnostic(code("L-015"))]
+    TypeUnivArgs {
+        #[label]
+        span: SourceSpan,
+    },
     #[error("An unexpected internal error occurred: {message}")]
     #[diagnostic(code("L-XXX"))]
     /// This error should not occur.

--- a/lang/lowering/src/symbol_table/build.rs
+++ b/lang/lowering/src/symbol_table/build.rs
@@ -1,4 +1,5 @@
 use ast::HashMap;
+use codespan::Span;
 use decls::*;
 use miette_util::ToMiette;
 use parser::cst::*;
@@ -17,6 +18,13 @@ pub fn build_symbol_table(module: &Module) -> Result<ModuleSymbolTable, Lowering
     }
 
     Ok(symbol_table)
+}
+
+fn check_ident(ident: &Ident, span: &Span) -> Result<(), LoweringError> {
+    if ident.id == "Type" {
+        return Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() });
+    }
+    Ok(())
 }
 
 trait BuildSymbolTable {
@@ -38,6 +46,7 @@ impl BuildSymbolTable for Decl {
 impl BuildSymbolTable for Data {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Data { span, name, params, ctors, .. } = self;
+        check_ident(name, span)?;
         match symbol_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
@@ -60,6 +69,7 @@ impl BuildSymbolTable for Data {
 impl BuildSymbolTable for Ctor {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Ctor { span, name, params, .. } = self;
+        check_ident(name, span)?;
         match symbol_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
@@ -79,6 +89,7 @@ impl BuildSymbolTable for Ctor {
 impl BuildSymbolTable for Codata {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Codata { span, name, params, dtors, .. } = self;
+        check_ident(name, span)?;
         match symbol_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
@@ -101,6 +112,7 @@ impl BuildSymbolTable for Codata {
 impl BuildSymbolTable for Dtor {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Dtor { span, name, params, .. } = self;
+        check_ident(name, span)?;
         match symbol_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {
@@ -120,6 +132,7 @@ impl BuildSymbolTable for Dtor {
 impl BuildSymbolTable for Def {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Def { span, name, params, .. } = self;
+        check_ident(name, span)?;
 
         match symbol_table.get(name) {
             Some(_) => {
@@ -140,6 +153,7 @@ impl BuildSymbolTable for Def {
 impl BuildSymbolTable for Codef {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Codef { span, name, params, .. } = self;
+        check_ident(name, span)?;
 
         match symbol_table.get(name) {
             Some(_) => {
@@ -160,6 +174,7 @@ impl BuildSymbolTable for Codef {
 impl BuildSymbolTable for Let {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Let { span, name, params, .. } = self;
+        check_ident(name, span)?;
         match symbol_table.get(name) {
             Some(_) => {
                 return Err(LoweringError::AlreadyDefined {

--- a/lang/lowering/src/symbol_table/build.rs
+++ b/lang/lowering/src/symbol_table/build.rs
@@ -20,9 +20,20 @@ pub fn build_symbol_table(module: &Module) -> Result<ModuleSymbolTable, Lowering
     Ok(symbol_table)
 }
 
-fn check_ident(ident: &Ident, span: &Span) -> Result<(), LoweringError> {
-    if ident.id == "Type" {
+/// Checks whether the identifier is reserved or already defined.
+fn check_name(
+    symbol_table: &mut ModuleSymbolTable,
+    name: &Ident,
+    span: &Span,
+) -> Result<(), LoweringError> {
+    if name.id == "Type" {
         return Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() });
+    }
+    if symbol_table.get(name).is_some() {
+        return Err(LoweringError::AlreadyDefined {
+            name: name.to_owned(),
+            span: span.to_miette(),
+        });
     }
     Ok(())
 }
@@ -46,19 +57,12 @@ impl BuildSymbolTable for Decl {
 impl BuildSymbolTable for Data {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Data { span, name, params, ctors, .. } = self;
-        check_ident(name, span)?;
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Data { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+
+        check_name(symbol_table, name, span)?;
+
+        let meta = DeclMeta::Data { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         for ctor in ctors {
             ctor.build(symbol_table)?;
         }
@@ -69,19 +73,11 @@ impl BuildSymbolTable for Data {
 impl BuildSymbolTable for Ctor {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Ctor { span, name, params, .. } = self;
-        check_ident(name, span)?;
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Ctor { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        check_name(symbol_table, name, span)?;
+
+        let meta = DeclMeta::Ctor { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         Ok(())
     }
 }
@@ -89,19 +85,11 @@ impl BuildSymbolTable for Ctor {
 impl BuildSymbolTable for Codata {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Codata { span, name, params, dtors, .. } = self;
-        check_ident(name, span)?;
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Codata { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        check_name(symbol_table, name, span)?;
+
+        let meta = DeclMeta::Codata { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         for dtor in dtors {
             dtor.build(symbol_table)?;
         }
@@ -112,19 +100,11 @@ impl BuildSymbolTable for Codata {
 impl BuildSymbolTable for Dtor {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Dtor { span, name, params, .. } = self;
-        check_ident(name, span)?;
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Dtor { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        check_name(symbol_table, name, span)?;
+
+        let meta = DeclMeta::Dtor { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         Ok(())
     }
 }
@@ -132,20 +112,11 @@ impl BuildSymbolTable for Dtor {
 impl BuildSymbolTable for Def {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Def { span, name, params, .. } = self;
-        check_ident(name, span)?;
+        check_name(symbol_table, name, span)?;
 
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Def { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        let meta = DeclMeta::Def { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         Ok(())
     }
 }
@@ -153,20 +124,11 @@ impl BuildSymbolTable for Def {
 impl BuildSymbolTable for Codef {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Codef { span, name, params, .. } = self;
-        check_ident(name, span)?;
+        check_name(symbol_table, name, span)?;
 
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Codef { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        let meta = DeclMeta::Codef { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         Ok(())
     }
 }
@@ -174,19 +136,11 @@ impl BuildSymbolTable for Codef {
 impl BuildSymbolTable for Let {
     fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
         let Let { span, name, params, .. } = self;
-        check_ident(name, span)?;
-        match symbol_table.get(name) {
-            Some(_) => {
-                return Err(LoweringError::AlreadyDefined {
-                    name: name.to_owned(),
-                    span: span.to_miette(),
-                });
-            }
-            None => {
-                let meta = DeclMeta::Let { params: params.clone() };
-                symbol_table.insert(name.clone(), meta);
-            }
-        }
+        check_name(symbol_table, name, span)?;
+
+        let meta = DeclMeta::Let { params: params.clone() };
+        symbol_table.insert(name.clone(), meta);
+
         Ok(())
     }
 }

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -54,7 +54,6 @@ pub enum Exp {
     Call(Call),
     DotCall(DotCall),
     Anno(Anno),
-    TypeUniv(TypeUniv),
     LocalMatch(LocalMatch),
     LocalComatch(LocalComatch),
     Hole(Hole),
@@ -69,7 +68,6 @@ impl Exp {
             Exp::Call(call) => call.span,
             Exp::DotCall(dot_call) => dot_call.span,
             Exp::Anno(anno) => anno.span,
-            Exp::TypeUniv(type_univ) => type_univ.span,
             Exp::LocalMatch(local_match) => local_match.span,
             Exp::LocalComatch(local_comatch) => local_comatch.span,
             Exp::Hole(hole) => hole.span,
@@ -103,12 +101,6 @@ pub struct Anno {
     pub span: Span,
     pub exp: Box<Exp>,
     pub typ: Box<Exp>,
-}
-
-#[derive(Debug, Clone)]
-/// The Type universe (Type in Type)
-pub struct TypeUniv {
-    pub span: Span,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -28,7 +28,6 @@ extern {
     "as" => Token::As,
     "comatch" => Token::Comatch,
     "absurd" => Token::Absurd,
-    "Type" => Token::Type,
     "implicit" => Token::Implicit,
     "use" => Token::Use,
 
@@ -247,11 +246,6 @@ pub Ops = {
 pub App = {
     <e: CallWithArgs> => Box::new(Exp::Call(e)),
     <e: LocalComatch> => Box::new(Exp::LocalComatch(e)),
-    Builtins,
-}
-
-pub Builtins: Box<Exp> = {
-    <e: TypeUniv> => Box::new(Exp::TypeUniv(e)),
     Holes,
 }
 
@@ -293,9 +287,6 @@ CallWithoutArgs: Call = <l: @L> <name: Ident> <r: @R> =>
 
 LocalComatch: LocalComatch = <l: @L> "comatch" <name: Ident?> "{" <cases: Comma<Case<Copattern>>> "}" <r: @R> =>
   LocalComatch { span: span(l, r), name, is_lambda_sugar: false, cases };
-
-TypeUniv: TypeUniv = <l: @L> "Type" <r: @R> =>
-  TypeUniv { span: span(l, r) };
 
 Hole: Hole = {
   <l: @L> "_" <r: @R> => Hole { span: span(l, r), kind: HoleKind::MustSolve },

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -39,8 +39,6 @@ pub enum Token {
     Comatch,
     #[token("absurd")]
     Absurd,
-    #[token("Type")]
-    Type,
     #[token("implicit")]
     Implicit,
     #[token("use")]

--- a/test/suites/fail-lower/L-015.expected
+++ b/test/suites/fail-lower/L-015.expected
@@ -1,0 +1,7 @@
+L-015
+
+  × Type universe "Type" does not take arguments
+   ╭─[L-015.pol:1:13]
+ 1 │ let foo() : Type(?) { ? }
+   ·             ───────
+   ╰────

--- a/test/suites/fail-lower/L-015.pol
+++ b/test/suites/fail-lower/L-015.pol
@@ -1,0 +1,1 @@
+let foo() : Type(?) { ? }

--- a/test/suites/fail-lower/L-016a.expected
+++ b/test/suites/fail-lower/L-016a.expected
@@ -5,3 +5,4 @@ L-016
  1 │ data Type {}
    · ────────────
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016a.expected
+++ b/test/suites/fail-lower/L-016a.expected
@@ -1,0 +1,7 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016a.pol:1:1]
+ 1 │ data Type {}
+   · ────────────
+   ╰────

--- a/test/suites/fail-lower/L-016a.pol
+++ b/test/suites/fail-lower/L-016a.pol
@@ -1,0 +1,1 @@
+data Type {}

--- a/test/suites/fail-lower/L-016b.expected
+++ b/test/suites/fail-lower/L-016b.expected
@@ -5,3 +5,4 @@ L-016
  1 │ codata Type {}
    · ──────────────
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016b.expected
+++ b/test/suites/fail-lower/L-016b.expected
@@ -1,0 +1,7 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016b.pol:1:1]
+ 1 │ codata Type {}
+   · ──────────────
+   ╰────

--- a/test/suites/fail-lower/L-016b.pol
+++ b/test/suites/fail-lower/L-016b.pol
@@ -1,0 +1,1 @@
+codata Type {}

--- a/test/suites/fail-lower/L-016c.expected
+++ b/test/suites/fail-lower/L-016c.expected
@@ -1,0 +1,7 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016c.pol:1:12]
+ 1 │ data Foo { Type : Foo }
+   ·            ───────────
+   ╰────

--- a/test/suites/fail-lower/L-016c.expected
+++ b/test/suites/fail-lower/L-016c.expected
@@ -5,3 +5,4 @@ L-016
  1 │ data Foo { Type : Foo }
    ·            ───────────
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016c.pol
+++ b/test/suites/fail-lower/L-016c.pol
@@ -1,0 +1,1 @@
+data Foo { Type : Foo }

--- a/test/suites/fail-lower/L-016d.expected
+++ b/test/suites/fail-lower/L-016d.expected
@@ -6,3 +6,4 @@ L-016
  2 │ codata Foo { .Type : Bool }
    ·              ────────────
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016d.expected
+++ b/test/suites/fail-lower/L-016d.expected
@@ -1,0 +1,8 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016d.pol:2:14]
+ 1 │ data Bool { T, F }
+ 2 │ codata Foo { .Type : Bool }
+   ·              ────────────
+   ╰────

--- a/test/suites/fail-lower/L-016d.pol
+++ b/test/suites/fail-lower/L-016d.pol
@@ -1,0 +1,2 @@
+data Bool { T, F }
+codata Foo { .Type : Bool }

--- a/test/suites/fail-lower/L-016e.expected
+++ b/test/suites/fail-lower/L-016e.expected
@@ -1,0 +1,8 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016e.pol:2:1]
+ 1 │ data Bool { T, F }
+ 2 │ let Type : Bool { T }
+   · ─────────────────────
+   ╰────

--- a/test/suites/fail-lower/L-016e.expected
+++ b/test/suites/fail-lower/L-016e.expected
@@ -6,3 +6,4 @@ L-016
  2 │ let Type : Bool { T }
    · ─────────────────────
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016e.pol
+++ b/test/suites/fail-lower/L-016e.pol
@@ -1,0 +1,2 @@
+data Bool { T, F }
+let Type : Bool { T }

--- a/test/suites/fail-lower/L-016f.expected
+++ b/test/suites/fail-lower/L-016f.expected
@@ -1,0 +1,8 @@
+L-016
+
+  × "Type" is not a valid identifier
+   ╭─[L-016f.pol:1:9]
+ 1 │ let foo(Type: Type): Type {
+   ·         ────
+ 2 │    Type
+   ╰────

--- a/test/suites/fail-lower/L-016f.expected
+++ b/test/suites/fail-lower/L-016f.expected
@@ -6,3 +6,4 @@ L-016
    ·         ────
  2 │    Type
    ╰────
+  help: "Type" is the name of the impredicative type universe.

--- a/test/suites/fail-lower/L-016f.pol
+++ b/test/suites/fail-lower/L-016f.pol
@@ -1,0 +1,3 @@
+let foo(Type: Type): Type {
+   Type
+}


### PR DESCRIPTION
Fixes #439 

Simplifies the parser, and is also forwards compatible if we ever want to pass arguments to type universes. (E.g. `Type(0)`, `Type(1)` etc.