### PR TITLE
Add lift action to language server

### DIFF
--- a/lang/driver/src/lift.rs
+++ b/lang/driver/src/lift.rs
@@ -1,14 +1,64 @@
-use transformations::LiftResult;
 use url::Url;
 
-use crate::database::Database;
+use ast::*;
+use miette_util::codespan::Span;
+use printer::Print;
+use transformations::LiftResult;
+
+use crate::{database::Database, DriverError, Edit};
 
 impl Database {
-    pub async fn lift(&mut self, uri: &Url, type_name: &str) -> Result<ast::Module, crate::Error> {
+    pub async fn lift(&mut self, uri: &Url, type_name: &str) -> Result<Vec<Edit>, crate::Error> {
         let prg = self.ast(uri).await?;
 
-        let LiftResult { module: prg, .. } = transformations::lift(prg, type_name);
+        let type_span = prg
+            .decls
+            .iter()
+            .find(|decl| decl.ident().id == type_name)
+            .and_then(|x| x.span())
+            .ok_or(DriverError::Impossible(format!("Could not resolve {type_name}")))?;
 
-        Ok(prg)
+        let LiftResult { module: prg, modified_decls, new_decls } =
+            transformations::lift(prg, type_name);
+
+        let edits = generate_edits(type_name, type_span, &prg, modified_decls, new_decls);
+
+        Ok(edits)
     }
+}
+
+fn generate_edits(
+    type_name: &str,
+    type_span: Span,
+    module: &ast::Module,
+    modified_decls: HashSet<IdBind>,
+    new_decls: HashSet<IdBind>,
+) -> Vec<Edit> {
+    let new_decls = module
+        .decls
+        .iter()
+        .filter(|decl| new_decls.contains(decl.ident()) || decl.ident().id == type_name)
+        .cloned()
+        .collect();
+
+    let new_items = Module {
+        uri: module.uri.clone(),
+        // Use declarations don't change, and we are only printing an excerpt of the module
+        use_decls: vec![],
+        decls: new_decls,
+        meta_vars: module.meta_vars.clone(),
+    };
+
+    let text = new_items.print_to_string(None);
+
+    let mut edits = vec![Edit { span: type_span, text }];
+
+    for name in modified_decls {
+        let decl = module.decls.iter().find(|d| d.ident() == &name).unwrap();
+        let span = decl.span().unwrap();
+        let text = decl.print_to_string(None);
+        edits.push(Edit { span, text });
+    }
+
+    edits
 }

--- a/lang/lsp/src/codeactions.rs
+++ b/lang/lsp/src/codeactions.rs
@@ -92,6 +92,11 @@ async fn lifting_action(
     let Ok(edits) = db.lift(&text_document.uri.from_lsp(), item.type_name()).await else {
         return None;
     };
+
+    if edits.is_empty() {
+        return None;
+    }
+
     let edits = edits
         .into_iter()
         .map(|edit| TextEdit {

--- a/lang/lsp/src/codeactions.rs
+++ b/lang/lsp/src/codeactions.rs
@@ -1,8 +1,10 @@
 //! Implementation of code actions provided by the LSP server
+
 use std::collections::HashMap;
+
 use tower_lsp::{jsonrpc, lsp_types::*};
 
-use driver::Xfunc;
+use driver::{Database, Item, Xfunc};
 
 use super::conversion::*;
 use super::server::*;
@@ -34,32 +36,80 @@ pub async fn code_action(
     };
 
     if let Some(item) = item {
-        let Ok(Xfunc { title, edits }) =
-            db.xfunc(&text_document.uri.from_lsp(), item.type_name()).await
-        else {
-            return Ok(None);
-        };
-        let edits = edits
-            .into_iter()
-            .map(|edit| TextEdit {
-                range: db.span_to_locations(&text_document.uri.from_lsp(), edit.span).unwrap(),
-                new_text: edit.text,
-            })
-            .collect();
+        let mut res = vec![];
 
-        #[allow(clippy::mutable_key_type)]
-        let mut changes = HashMap::new();
-        changes.insert(text_document.uri, edits);
+        if let Some(action) = xfunc_action(&mut db, &text_document, &item).await {
+            res.push(action);
+        }
 
-        let res = vec![CodeActionOrCommand::CodeAction(CodeAction {
-            title,
-            kind: Some(CodeActionKind::REFACTOR_REWRITE),
-            edit: Some(WorkspaceEdit { changes: Some(changes), ..Default::default() }),
-            ..Default::default()
-        })];
+        if let Some(action) = lifting_action(&mut db, &text_document, &item).await {
+            res.push(action);
+        }
 
         Ok(Some(res))
     } else {
         Ok(Some(vec![]))
     }
+}
+
+async fn xfunc_action(
+    db: &mut Database,
+    text_document: &TextDocumentIdentifier,
+    item: &Item,
+) -> Option<CodeActionOrCommand> {
+    let Ok(Xfunc { title, edits }) =
+        db.xfunc(&text_document.uri.from_lsp(), item.type_name()).await
+    else {
+        return None;
+    };
+    let edits = edits
+        .into_iter()
+        .map(|edit| TextEdit {
+            range: db.span_to_locations(&text_document.uri.from_lsp(), edit.span).unwrap(),
+            new_text: edit.text,
+        })
+        .collect();
+
+    #[allow(clippy::mutable_key_type)]
+    let mut changes = HashMap::new();
+    changes.insert(text_document.uri.clone(), edits);
+
+    let res = CodeActionOrCommand::CodeAction(CodeAction {
+        title,
+        kind: Some(CodeActionKind::REFACTOR_REWRITE),
+        edit: Some(WorkspaceEdit { changes: Some(changes), ..Default::default() }),
+        ..Default::default()
+    });
+
+    Some(res)
+}
+
+async fn lifting_action(
+    db: &mut Database,
+    text_document: &TextDocumentIdentifier,
+    item: &Item,
+) -> Option<CodeActionOrCommand> {
+    let Ok(edits) = db.lift(&text_document.uri.from_lsp(), item.type_name()).await else {
+        return None;
+    };
+    let edits = edits
+        .into_iter()
+        .map(|edit| TextEdit {
+            range: db.span_to_locations(&text_document.uri.from_lsp(), edit.span).unwrap(),
+            new_text: edit.text,
+        })
+        .collect();
+
+    #[allow(clippy::mutable_key_type)]
+    let mut changes = HashMap::new();
+    changes.insert(text_document.uri.clone(), edits);
+
+    let res = CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Lift {}", item.type_name()),
+        kind: Some(CodeActionKind::REFACTOR_REWRITE),
+        edit: Some(WorkspaceEdit { changes: Some(changes), ..Default::default() }),
+        ..Default::default()
+    });
+
+    Some(res)
 }


### PR DESCRIPTION
As a preparation to adding a lift code action to the language server, I adjust `Database::lift` to generating edits, rather than the full modified module.
I add an initial lift action that works similar to the xfunc action in that the user can lift all local (co)matches of a type to the top-level.