### PR TITLE
Make substitution fallible

### DIFF
--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -1184,10 +1184,15 @@ pub struct Param {
 }
 
 impl Substitutable for Param {
-    type Result = Param;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self {
+    type Target = Param;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let Param { implicit, name, typ, erased } = self;
-        Param { implicit: *implicit, name: name.clone(), typ: typ.subst(ctx, by), erased: *erased }
+        Ok(Param {
+            implicit: *implicit,
+            name: name.clone(),
+            typ: typ.subst(ctx, by)?,
+            erased: *erased,
+        })
     }
 }
 

--- a/lang/ast/src/exp/anno.rs
+++ b/lang/ast/src/exp/anno.rs
@@ -61,16 +61,16 @@ impl HasType for Anno {
 }
 
 impl Substitutable for Anno {
-    type Result = Anno;
+    type Target = Anno;
 
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let Anno { span, exp, typ, .. } = self;
-        Anno {
+        Ok(Anno {
             span: *span,
-            exp: exp.subst(ctx, by),
-            typ: typ.subst(ctx, by),
+            exp: exp.subst(ctx, by)?,
+            typ: typ.subst(ctx, by)?,
             normalized_type: None,
-        }
+        })
     }
 }
 

--- a/lang/ast/src/exp/args.rs
+++ b/lang/ast/src/exp/args.rs
@@ -99,17 +99,17 @@ impl HasType for Arg {
 }
 
 impl Substitutable for Arg {
-    type Result = Arg;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = Arg;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         match self {
             Arg::UnnamedArg { arg, erased } => {
-                Arg::UnnamedArg { arg: arg.subst(ctx, by), erased: *erased }
+                Ok(Arg::UnnamedArg { arg: arg.subst(ctx, by)?, erased: *erased })
             }
             Arg::NamedArg { name: var, arg, erased } => {
-                Arg::NamedArg { name: var.clone(), arg: arg.subst(ctx, by), erased: *erased }
+                Ok(Arg::NamedArg { name: var.clone(), arg: arg.subst(ctx, by)?, erased: *erased })
             }
             Arg::InsertedImplicitArg { hole, erased } => {
-                Arg::InsertedImplicitArg { hole: hole.subst(ctx, by), erased: *erased }
+                Ok(Arg::InsertedImplicitArg { hole: hole.subst(ctx, by)?, erased: *erased })
             }
         }
     }
@@ -189,9 +189,10 @@ impl Shift for Args {
 }
 
 impl Substitutable for Args {
-    type Result = Args;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self {
-        Args { args: self.args.subst(ctx, by) }
+    type Target = Args;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        let args = self.args.iter().map(|arg| arg.subst(ctx, by)).collect::<Result<Vec<_>, _>>()?;
+        Ok(Args { args })
     }
 }
 

--- a/lang/ast/src/exp/call.rs
+++ b/lang/ast/src/exp/call.rs
@@ -76,16 +76,16 @@ impl HasType for Call {
 }
 
 impl Substitutable for Call {
-    type Result = Call;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = Call;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let Call { span, name, args, kind, .. } = self;
-        Call {
+        Ok(Call {
             span: *span,
             kind: *kind,
             name: name.clone(),
-            args: args.subst(ctx, by),
+            args: args.subst(ctx, by)?,
             inferred_type: None,
-        }
+        })
     }
 }
 

--- a/lang/ast/src/exp/dot_call.rs
+++ b/lang/ast/src/exp/dot_call.rs
@@ -79,17 +79,17 @@ impl HasType for DotCall {
 }
 
 impl Substitutable for DotCall {
-    type Result = DotCall;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = DotCall;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let DotCall { span, kind, exp, name, args, .. } = self;
-        DotCall {
+        Ok(DotCall {
             span: *span,
             kind: *kind,
-            exp: exp.subst(ctx, by),
+            exp: exp.subst(ctx, by)?,
             name: name.clone(),
-            args: args.subst(ctx, by),
+            args: args.subst(ctx, by)?,
             inferred_type: None,
-        }
+        })
     }
 }
 

--- a/lang/ast/src/exp/local_comatch.rs
+++ b/lang/ast/src/exp/local_comatch.rs
@@ -64,18 +64,18 @@ impl HasType for LocalComatch {
 }
 
 impl Substitutable for LocalComatch {
-    type Result = LocalComatch;
+    type Target = LocalComatch;
 
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let LocalComatch { span, name, is_lambda_sugar, cases, .. } = self;
-        LocalComatch {
+        Ok(LocalComatch {
             span: *span,
             ctx: None,
             name: name.clone(),
             is_lambda_sugar: *is_lambda_sugar,
-            cases: cases.iter().map(|case| case.subst(ctx, by)).collect(),
+            cases: cases.iter().map(|case| case.subst(ctx, by)).collect::<Result<Vec<_>, _>>()?,
             inferred_type: None,
-        }
+        })
     }
 }
 

--- a/lang/ast/src/exp/local_match.rs
+++ b/lang/ast/src/exp/local_match.rs
@@ -69,19 +69,19 @@ impl HasType for LocalMatch {
 }
 
 impl Substitutable for LocalMatch {
-    type Result = LocalMatch;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = LocalMatch;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let LocalMatch { span, name, on_exp, motive, ret_typ, cases, .. } = self;
-        LocalMatch {
+        Ok(LocalMatch {
             span: *span,
             ctx: None,
             name: name.clone(),
-            on_exp: on_exp.subst(ctx, by),
-            motive: motive.subst(ctx, by),
-            ret_typ: ret_typ.subst(ctx, by),
-            cases: cases.iter().map(|case| case.subst(ctx, by)).collect(),
+            on_exp: on_exp.subst(ctx, by)?,
+            motive: motive.as_ref().map(|m| m.subst(ctx, by)).transpose()?,
+            ret_typ: ret_typ.as_ref().map(|t| t.subst(ctx, by)).transpose()?,
+            cases: cases.iter().map(|case| case.subst(ctx, by)).collect::<Result<Vec<_>, _>>()?,
             inferred_type: None,
-        }
+        })
     }
 }
 

--- a/lang/ast/src/exp/mod.rs
+++ b/lang/ast/src/exp/mod.rs
@@ -152,18 +152,18 @@ impl HasType for Exp {
 }
 
 impl Substitutable for Exp {
-    type Result = Exp;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = Exp;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         match self {
-            Exp::Variable(e) => *e.subst(ctx, by),
-            Exp::TypCtor(e) => e.subst(ctx, by).into(),
-            Exp::Call(e) => e.subst(ctx, by).into(),
-            Exp::DotCall(e) => e.subst(ctx, by).into(),
-            Exp::Anno(e) => e.subst(ctx, by).into(),
-            Exp::TypeUniv(e) => e.subst(ctx, by).into(),
-            Exp::LocalMatch(e) => e.subst(ctx, by).into(),
-            Exp::LocalComatch(e) => e.subst(ctx, by).into(),
-            Exp::Hole(e) => e.subst(ctx, by).into(),
+            Exp::Variable(e) => Ok(*e.subst(ctx, by)?),
+            Exp::TypCtor(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::Call(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::DotCall(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::Anno(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::TypeUniv(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::LocalMatch(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::LocalComatch(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::Hole(e) => Ok(e.subst(ctx, by)?.into()),
         }
     }
 }
@@ -244,19 +244,19 @@ impl Shift for Motive {
 }
 
 impl Substitutable for Motive {
-    type Result = Motive;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = Motive;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let Motive { span, param, ret_typ } = self;
 
-        Motive {
+        Ok(Motive {
             span: *span,
             param: param.clone(),
             ret_typ: ctx.bind_single(param, |ctx| {
                 let mut by = (*by).clone();
                 by.shift((1, 0));
                 ret_typ.subst(ctx, &by)
-            }),
-        }
+            })?,
+        })
     }
 }
 

--- a/lang/ast/src/exp/typ_ctor.rs
+++ b/lang/ast/src/exp/typ_ctor.rs
@@ -68,10 +68,10 @@ impl HasType for TypCtor {
 }
 
 impl Substitutable for TypCtor {
-    type Result = TypCtor;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self {
+    type Target = TypCtor;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let TypCtor { span, name, args } = self;
-        TypCtor { span: *span, name: name.clone(), args: args.subst(ctx, by) }
+        Ok(TypCtor { span: *span, name: name.clone(), args: args.subst(ctx, by)? })
     }
 }
 

--- a/lang/ast/src/exp/type_univ.rs
+++ b/lang/ast/src/exp/type_univ.rs
@@ -63,11 +63,11 @@ impl HasType for TypeUniv {
 }
 
 impl Substitutable for TypeUniv {
-    type Result = TypeUniv;
+    type Target = TypeUniv;
 
-    fn subst<S: Substitution>(&self, _ctx: &mut LevelCtx, _by: &S) -> Self::Result {
+    fn subst<S: Substitution>(&self, _ctx: &mut LevelCtx, _by: &S) -> Result<Self::Target, S::Err> {
         let TypeUniv { span } = self;
-        TypeUniv { span: *span }
+        Ok(TypeUniv { span: *span })
     }
 }
 

--- a/lang/ast/src/exp/variable.rs
+++ b/lang/ast/src/exp/variable.rs
@@ -65,17 +65,17 @@ impl HasType for Variable {
 }
 
 impl Substitutable for Variable {
-    type Result = Box<Exp>;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
+    type Target = Box<Exp>;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
         let Variable { span, idx, name, .. } = self;
-        match by.get_subst(ctx, ctx.idx_to_lvl(*idx)) {
-            Some(exp) => exp,
-            None => Box::new(Exp::Variable(Variable {
+        match by.get_subst(ctx, ctx.idx_to_lvl(*idx))? {
+            Some(exp) => Ok(exp),
+            None => Ok(Box::new(Exp::Variable(Variable {
                 span: *span,
                 idx: *idx,
                 name: name.clone(),
                 inferred_type: None,
-            })),
+            }))),
         }
     }
 }

--- a/lang/ast/src/traits/subst.rs
+++ b/lang/ast/src/traits/subst.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::Debug;
 
 use values::Binder;
@@ -14,24 +15,30 @@ use crate::*;
 /// In order to be used as a substitution an entity has to provide a method
 /// to query it for a result for a given deBruijn Level.
 pub trait Substitution: Shift + Clone + Debug {
-    fn get_subst(&self, ctx: &LevelCtx, lvl: Lvl) -> Option<Box<Exp>>;
+    type Err;
+
+    fn get_subst(&self, ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err>;
 }
 
 impl Substitution for Vec<Vec<Box<Exp>>> {
-    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Option<Box<Exp>> {
+    type Err = Infallible;
+
+    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err> {
         if lvl.fst >= self.len() {
-            return None;
+            return Ok(None);
         }
-        Some(self[lvl.fst][lvl.snd].clone())
+        Ok(Some(self[lvl.fst][lvl.snd].clone()))
     }
 }
 
 impl Substitution for Vec<Vec<Arg>> {
-    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Option<Box<Exp>> {
+    type Err = Infallible;
+
+    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err> {
         if lvl.fst >= self.len() {
-            return None;
+            return Ok(None);
         }
-        Some(self[lvl.fst][lvl.snd].exp().clone())
+        Ok(Some(self[lvl.fst][lvl.snd].exp().clone()))
     }
 }
 
@@ -54,11 +61,13 @@ impl Shift for Assign {
 }
 
 impl Substitution for Assign {
-    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Option<Box<Exp>> {
+    type Err = Infallible;
+
+    fn get_subst(&self, _ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err> {
         if self.lvl == lvl {
-            Some(self.exp.clone())
+            Ok(Some(self.exp.clone()))
         } else {
-            None
+            Ok(None)
         }
     }
 }
@@ -72,28 +81,28 @@ impl Substitution for Assign {
 /// The result type of applying a substitution is parameterized, because substituting for
 /// a variable does not, in general, yield another variable.
 pub trait Substitutable: Sized {
-    type Result;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result;
+    type Target;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err>;
 }
 
 impl<T: Substitutable> Substitutable for Option<T> {
-    type Result = Option<T::Result>;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
-        self.as_ref().map(|x| x.subst(ctx, by))
+    type Target = Option<T::Target>;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        self.as_ref().map(|x| x.subst(ctx, by)).transpose()
     }
 }
 
 impl<T: Substitutable> Substitutable for Vec<T> {
-    type Result = Vec<T::Result>;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
-        self.iter().map(|x| x.subst(ctx, by)).collect()
+    type Target = Vec<T::Target>;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        self.iter().map(|x| x.subst(ctx, by)).collect::<Result<Vec<_>, _>>()
     }
 }
 
 impl<T: Substitutable> Substitutable for Box<T> {
-    type Result = Box<T::Result>;
-    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Self::Result {
-        Box::new((**self).subst(ctx, by))
+    type Target = Box<T::Target>;
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        Ok(Box::new((**self).subst(ctx, by)?))
     }
 }
 
@@ -102,7 +111,7 @@ impl<T: Substitutable> Substitutable for Box<T> {
 //
 
 pub trait SwapWithCtx: Substitutable {
-    fn swap_with_ctx(&self, ctx: &mut LevelCtx, fst1: usize, fst2: usize) -> Self::Result;
+    fn swap_with_ctx(&self, ctx: &mut LevelCtx, fst1: usize, fst2: usize) -> Self::Target;
 }
 
 impl<T: Substitutable> SwapWithCtx for T {
@@ -111,8 +120,9 @@ impl<T: Substitutable> SwapWithCtx for T {
         ctx: &mut LevelCtx,
         fst1: usize,
         fst2: usize,
-    ) -> <T as Substitutable>::Result {
-        self.subst(ctx, &SwapSubst { fst1, fst2 })
+    ) -> <T as Substitutable>::Target {
+        // Unwrap is safe here because we are unwrapping an infallible result
+        self.subst(ctx, &SwapSubst { fst1, fst2 }).unwrap()
     }
 }
 
@@ -133,7 +143,9 @@ impl Shift for SwapSubst {
 }
 
 impl Substitution for SwapSubst {
-    fn get_subst(&self, ctx: &LevelCtx, lvl: Lvl) -> Option<Box<Exp>> {
+    type Err = Infallible;
+
+    fn get_subst(&self, ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err> {
         let new_lvl = if lvl.fst == self.fst1 {
             Some(Lvl { fst: self.fst2, snd: lvl.snd })
         } else if lvl.fst == self.fst2 {
@@ -144,28 +156,14 @@ impl Substitution for SwapSubst {
 
         let new_ctx = ctx.swap(self.fst1, self.fst2);
 
-        new_lvl.map(|new_lvl| {
+        Ok(new_lvl.map(|new_lvl| {
             Box::new(Exp::Variable(Variable {
                 span: None,
                 idx: new_ctx.lvl_to_idx(new_lvl),
                 name: VarBound::from_string(""),
                 inferred_type: None,
             }))
-        })
-    }
-}
-
-// SubstUnderCtx
-//
-//
-
-pub trait SubstUnderCtx: Substitutable {
-    fn subst_under_ctx<S: Substitution>(&self, ctx: LevelCtx, s: &S) -> Self::Result;
-}
-
-impl<T: Substitutable + Clone> SubstUnderCtx for T {
-    fn subst_under_ctx<S: Substitution>(&self, mut ctx: LevelCtx, s: &S) -> Self::Result {
-        self.subst(&mut ctx, s)
+        }))
     }
 }
 
@@ -173,21 +171,25 @@ impl<T: Substitutable + Clone> SubstUnderCtx for T {
 //
 //
 
-pub trait SubstInTelescope {
+pub trait SubstInTelescope: Sized {
     /// Substitute in a telescope
-    fn subst_in_telescope<S: Substitution>(&self, ctx: LevelCtx, s: &S) -> Self;
+    fn subst_in_telescope<S: Substitution>(&self, ctx: LevelCtx, s: &S) -> Result<Self, S::Err>;
 }
 
 impl SubstInTelescope for Telescope {
-    fn subst_in_telescope<S: Substitution>(&self, mut ctx: LevelCtx, s: &S) -> Self {
+    fn subst_in_telescope<S: Substitution>(
+        &self,
+        mut ctx: LevelCtx,
+        s: &S,
+    ) -> Result<Self, S::Err> {
         let Telescope { params } = self;
 
-        ctx.bind_fold(
+        ctx.bind_fold_failable(
             params.iter(),
             Vec::new(),
             |ctx, params_out, param| {
-                params_out.push(param.subst(ctx, s));
-                Binder { name: param.name.clone(), content: () }
+                params_out.push(param.subst(ctx, s)?);
+                Ok(Binder { name: param.name.clone(), content: () })
             },
             |_, params_out| Telescope { params: params_out },
         )

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -68,7 +68,7 @@ impl Ctx {
                     let metavar_state = meta_vars.get(&h.metavar).unwrap();
                     match metavar_state {
                         MetaVarState::Solved { ctx, solution } => {
-                            let lhs = solution.clone().subst(&mut ctx.clone(), &h.args);
+                            let lhs = solution.clone().subst(&mut ctx.clone(), &h.args)?;
                             self.add_constraint(Constraint::Equality {
                                 ctx: constraint_cxt.clone(),
                                 lhs,

--- a/lang/elaborator/src/result.rs
+++ b/lang/elaborator/src/result.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use miette::{Diagnostic, SourceSpan};
 use miette_util::codespan::Span;
 use miette_util::ToMiette;
@@ -243,5 +245,17 @@ impl TypeError {
             while_elaborating_span: while_elaborating_span.to_miette(),
         }
         .into()
+    }
+}
+
+impl From<Infallible> for TypeError {
+    fn from(inf: Infallible) -> Self {
+        match inf {}
+    }
+}
+
+impl From<Infallible> for Box<TypeError> {
+    fn from(inf: Infallible) -> Self {
+        Box::new(TypeError::from(inf))
     }
 }

--- a/lang/elaborator/src/typechecker/exprs/call.rs
+++ b/lang/elaborator/src/typechecker/exprs/call.rs
@@ -44,7 +44,7 @@ impl CheckInfer for Call {
                     &ctx.type_info_table.lookup_ctor_or_codef(&name.clone())?;
                 let mut args_out = check_args(args, &name.clone(), ctx, params, *span)?;
                 let typ_out = typ
-                    .subst_under_ctx(vec![params.params.clone()].into(), &vec![args.args.clone()])
+                    .subst(&mut vec![params.params.clone()].into(), &vec![args.args.clone()])?
                     .to_exp();
                 let typ_nf = typ_out.normalize(&ctx.type_info_table, &mut ctx.env())?;
 
@@ -63,8 +63,8 @@ impl CheckInfer for Call {
                 let params = params.clone();
                 let typ = typ.clone();
                 let mut args_out = check_args(args, &name.clone(), ctx, &params, *span)?;
-                let typ_out = typ
-                    .subst_under_ctx(vec![params.params.clone()].into(), &vec![args.args.clone()]);
+                let typ_out =
+                    typ.subst(&mut vec![params.params.clone()].into(), &vec![args.args.clone()])?;
                 let typ_nf = typ_out.normalize(&ctx.type_info_table, &mut ctx.env())?;
 
                 erasure::mark_erased_args(&params, &mut args_out);

--- a/lang/elaborator/src/typechecker/exprs/dot_call.rs
+++ b/lang/elaborator/src/typechecker/exprs/dot_call.rs
@@ -45,17 +45,15 @@ impl CheckInfer for DotCall {
 
         let self_param_out = self_param
             .typ
-            .subst_under_ctx(vec![params.params.clone()].into(), &vec![args.args.clone()])
+            .subst(&mut vec![params.params.clone()].into(), &vec![args.args.clone()])?
             .to_exp();
         let self_param_nf = self_param_out.normalize(&ctx.type_info_table, &mut ctx.env())?;
 
         let exp_out = exp.check(ctx, &self_param_nf)?;
 
         let subst = vec![args.to_exps(), vec![exp.clone()]];
-        let typ_out = ret_typ.subst_under_ctx(
-            vec![params.params.clone(), vec![self_param.to_param()]].into(),
-            &subst,
-        );
+        let typ_out = ret_typ
+            .subst(&mut vec![params.params.clone(), vec![self_param.to_param()]].into(), &subst)?;
         let typ_out_nf = typ_out.normalize(&ctx.type_info_table, &mut ctx.env())?;
 
         erasure::mark_erased_args(params, &mut args_out);

--- a/lang/elaborator/src/typechecker/exprs/local_comatch.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_comatch.rs
@@ -293,7 +293,7 @@ impl WithExpectedType<'_> {
                                         params.params.clone(),
                                         vec![self_param.to_param()],
                                     ]);
-                                    let mut ret_typ = ret_typ.subst(&mut subst_ctx, &subst);
+                                    let mut ret_typ = ret_typ.subst(&mut subst_ctx, &subst)?;
                                     ret_typ.shift((-1, 0));
                                     ret_typ.normalize(
                                         &ctx.type_info_table,
@@ -327,9 +327,9 @@ impl WithExpectedType<'_> {
                                 ctx.fork::<TcResult<_>, _>(|ctx| {
                                     let type_info_table = ctx.type_info_table.clone();
                                     ctx.subst(&type_info_table, &unif)?;
-                                    let body = body.subst(&mut ctx.levels(), &unif);
+                                    let body = body.subst(&mut ctx.levels(), &unif)?;
 
-                                    let t_subst = ret_typ_nf.subst(&mut ctx.levels(), &unif);
+                                    let t_subst = ret_typ_nf.subst(&mut ctx.levels(), &unif)?;
                                     let t_nf =
                                         t_subst.normalize(&ctx.type_info_table, &mut ctx.env())?;
 

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -66,7 +66,7 @@ impl CheckInfer for LocalMatch {
                 let mut subst_ctx = ctx.levels().append(&vec![vec![motive_binder]].into());
                 let on_exp = shift_and_clone(on_exp, (1, 0));
                 let subst = Assign { lvl: Lvl { fst: subst_ctx.len() - 1, snd: 0 }, exp: on_exp };
-                let mut motive_t = ret_typ.subst(&mut subst_ctx, &subst);
+                let mut motive_t = ret_typ.subst(&mut subst_ctx, &subst)?;
                 motive_t.shift((-1, 0));
                 let motive_t_nf = motive_t.normalize(&ctx.type_info_table, &mut ctx.env())?;
                 convert(ctx.vars.clone(), &mut ctx.meta_vars, motive_t_nf, t, span)?;
@@ -264,7 +264,7 @@ impl WithScrutineeType<'_> {
                     t.shift((1, 0));
                     let mut t = t
                         .swap_with_ctx(&mut subst_ctx_1, curr_lvl, curr_lvl - 1)
-                        .subst(&mut subst_ctx_2, &subst);
+                        .subst(&mut subst_ctx_2, &subst)?;
                     t.shift((-1, 0));
 
                     // We have to check whether we have an absurd case or an ordinary case.
@@ -302,9 +302,9 @@ impl WithScrutineeType<'_> {
                             ctx.fork::<TcResult<_>, _>(|ctx| {
                                 let type_info_table = ctx.type_info_table.clone();
                                 ctx.subst(&type_info_table, &unif)?;
-                                let body = body.subst(&mut ctx.levels(), &unif);
+                                let body = body.subst(&mut ctx.levels(), &unif)?;
 
-                                let t_subst = t.subst(&mut ctx.levels(), &unif);
+                                let t_subst = t.subst(&mut ctx.levels(), &unif)?;
                                 let t_nf =
                                     t_subst.normalize(&ctx.type_info_table, &mut ctx.env())?;
 

--- a/lang/elaborator/src/typechecker/exprs/mod.rs
+++ b/lang/elaborator/src/typechecker/exprs/mod.rs
@@ -148,7 +148,7 @@ fn check_args(
     }
 
     let Telescope { params } =
-        params.subst_in_telescope(LevelCtx::empty(), &vec![this.args.clone()]);
+        params.subst_in_telescope(LevelCtx::empty(), &vec![this.args.clone()])?;
 
     let args = this
         .args

--- a/lang/transformations/src/lifting/mod.rs
+++ b/lang/transformations/src/lifting/mod.rs
@@ -588,12 +588,13 @@ impl Ctx {
         let LiftedSignature { telescope, subst, args } = lifted_signature(fvs, &self.ctx);
 
         // Substitute the new parameters for the free variables
-        let cases = cases.subst(&mut self.ctx, &subst);
-        let self_typ = self_typ.subst(&mut self.ctx, &subst);
+        // Unwrap is safe here because we are unwrapping an infallible result
+        let cases = cases.subst(&mut self.ctx, &subst).unwrap();
+        let self_typ = self_typ.subst(&mut self.ctx, &subst).unwrap();
         let def_ret_typ = match &motive {
-            Some(m) => m.lift(self).subst(&mut self.ctx, &subst).ret_typ,
+            Some(m) => m.lift(self).subst(&mut self.ctx, &subst).unwrap().ret_typ,
             None => shift_and_clone(
-                &ret_typ.clone().unwrap().lift(self).subst(&mut self.ctx, &subst),
+                &ret_typ.clone().unwrap().lift(self).subst(&mut self.ctx, &subst).unwrap(),
                 (1, 0),
             ),
         };
@@ -667,8 +668,9 @@ impl Ctx {
         let LiftedSignature { telescope, subst, args } = lifted_signature(fvs, &self.ctx);
 
         // Substitute the new parameters for the free variables
-        let cases = cases.subst(&mut self.ctx, &subst);
-        let typ = typ.subst(&mut self.ctx, &subst);
+        // Unwrap is safe here because we are unwrapping an infallible result
+        let cases = cases.subst(&mut self.ctx, &subst).unwrap();
+        let typ = typ.subst(&mut self.ctx, &subst).unwrap();
 
         // Build the new top-level definition
         let name = self.unique_codef_name(name, &inferred_type.name.id);


### PR DESCRIPTION
In preparation of fixing the unification implementation that is part of conversion checking, I make substitutions fallible. Thereafter I can implement a `PartialRenaming` substitution which can fail if it encounters a variable that is not in its domain.
Alternatives include creating a separate fallible AST traversal for partial renaming or a traversal to check for free variables. However, I think that this approach is both the most efficient and future-proof, because it allows us to relax some rigidity conditions by executing them lazily as part of the fallible substitution.

Open question: I added some `unwrap`s in places where the substitution result is known to be infallible (and where currently no `Result` can be propagated. This is not ideal, because it is not statically verified that the `unwrap`s are safe. Instead, we should consider using [`unwrap-infallible`](https://github.com/mzabaluev/unwrap-infallible). The code in this library is so small that I would consider just copying it to the `ast` crate rather than adding the dependency. What do you think?