### PR TITLE
Fix unification for conversion checking

### DIFF
--- a/lang/ast/src/ctx/values.rs
+++ b/lang/ast/src/ctx/values.rs
@@ -2,6 +2,9 @@
 //!
 //! Tracks locally bound variables
 
+use pretty::DocAllocator;
+use printer::Print;
+
 use crate::traits::Shift;
 use crate::*;
 
@@ -72,5 +75,21 @@ impl<T: Substitutable> Substitutable for Binder<T> {
 impl<T: ContainsMetaVars> ContainsMetaVars for Binder<T> {
     fn contains_metavars(&self) -> bool {
         self.content.contains_metavars()
+    }
+}
+
+impl<T: Print> Print for Binder<T> {
+    fn print_prec<'a>(
+        &'a self,
+        cfg: &printer::PrintCfg,
+        alloc: &'a printer::Alloc<'a>,
+        prec: printer::Precedence,
+    ) -> printer::Builder<'a> {
+        let Binder { name, content } = self;
+
+        alloc
+            .text(name.to_string())
+            .append(alloc.text(":="))
+            .append(content.print_prec(cfg, alloc, prec))
     }
 }

--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -126,9 +126,18 @@ impl Attributes {
 #[derive(Debug, Clone)]
 pub enum MetaVarState {
     /// We know what the metavariable stands for.
-    Solved { ctx: LevelCtx, solution: Box<Exp> },
+    /// The solution lives in the same context as the metavariable.
+    Solved {
+        /// The context in which the metavariable and therefore also its solution lives.
+        ctx: LevelCtx,
+        /// The solution to the metavariable.
+        solution: Box<Exp>,
+    },
     /// We don't know yet what the metavariable stands for.
-    Unsolved { ctx: LevelCtx },
+    Unsolved {
+        /// The context in which the metavariable lives.
+        ctx: LevelCtx,
+    },
 }
 
 impl MetaVarState {

--- a/lang/ast/src/exp/hole.rs
+++ b/lang/ast/src/exp/hole.rs
@@ -13,7 +13,7 @@ use crate::{
         LevelCtx,
     },
     ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    VarBind, Zonk, ZonkError,
+    Zonk, ZonkError,
 };
 
 use super::{Exp, MetaVar, MetaVarKind};
@@ -57,8 +57,7 @@ impl Hole {
             .iter()
             .map(|args| {
                 args.iter()
-                    // FIXME: Track the variable names of hole arguments
-                    .map(|_| Binder { name: VarBind::from_string("x"), content: () })
+                    .map(|binder| Binder { name: binder.name.clone(), content: () })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();

--- a/lang/ast/src/traits/occurs.rs
+++ b/lang/ast/src/traits/occurs.rs
@@ -1,6 +1,6 @@
 use crate::ctx::LevelCtx;
 use crate::exp::Exp;
-use crate::{Idx, Lvl, Variable};
+use crate::{Hole, Idx, Lvl, Variable};
 
 pub trait Occurs {
     /// Whether a subexpression that fulfills a predicate occurs
@@ -29,6 +29,22 @@ pub trait Occurs {
     fn occurs_var(&self, ctx: &mut LevelCtx, lvl: Lvl) -> bool {
         self.occurs(ctx, &|ctx, exp| match exp {
             Exp::Variable(Variable { idx, .. }) => ctx.idx_to_lvl(*idx) == lvl,
+            _ => false,
+        })
+    }
+    /// Whether a metavariable with the given `meta_var_id` occurs as a subexpression
+    ///
+    /// # Parameters
+    ///
+    /// - `ctx`: current context under which `self` is closed
+    /// - `meta_var_id`: the metavariable id we are looking for
+    ///
+    /// # Returns
+    ///
+    /// Whether a hole with `meta_var_id` occurs as a subexpression
+    fn occurs_metavar(&self, ctx: &mut LevelCtx, meta_var_id: u64) -> bool {
+        self.occurs(ctx, &|_ctx, exp| match exp {
+            Exp::Hole(Hole { metavar, .. }) => metavar.id == meta_var_id,
             _ => false,
         })
     }

--- a/lang/ast/src/traits/occurs.rs
+++ b/lang/ast/src/traits/occurs.rs
@@ -1,6 +1,6 @@
 use crate::ctx::LevelCtx;
 use crate::exp::Exp;
-use crate::{Hole, Idx, Lvl, Variable};
+use crate::{Hole, Idx, Lvl, MetaVar, Variable};
 
 pub trait Occurs {
     /// Whether a subexpression that fulfills a predicate occurs
@@ -37,13 +37,14 @@ pub trait Occurs {
     /// # Parameters
     ///
     /// - `ctx`: current context under which `self` is closed
-    /// - `meta_var_id`: the metavariable id we are looking for
+    /// - `metavar`: the metavariable we are looking for
     ///
     /// # Returns
     ///
     /// Whether a hole with `meta_var_id` occurs as a subexpression
-    fn occurs_metavar(&self, ctx: &mut LevelCtx, meta_var_id: u64) -> bool {
-        self.occurs(ctx, &|_ctx, exp| match exp {
+    fn occurs_metavar(&self, ctx: &mut LevelCtx, metavar: &MetaVar) -> bool {
+        let meta_var_id = metavar.id;
+        self.occurs(ctx, &move |_ctx, exp| match exp {
             Exp::Hole(Hole { metavar, .. }) => metavar.id == meta_var_id,
             _ => false,
         })

--- a/lang/driver/src/database.rs
+++ b/lang/driver/src/database.rs
@@ -505,7 +505,6 @@ impl Database {
         self.ust.invalidate(uri);
         self.ast.invalidate(uri);
         self.type_info_table.invalidate(uri);
-        self.type_info_table.invalidate(uri);
         self.hover_by_id.invalidate(uri);
         self.goto_by_id.invalidate(uri);
         self.item_by_id.invalidate(uri);

--- a/lang/elaborator/src/conversion_checking/mod.rs
+++ b/lang/elaborator/src/conversion_checking/mod.rs
@@ -52,17 +52,19 @@
 //! ```
 //! When hovering over the holes in an editor connected to our language server, you will see that both holes are solved with `Nat`.
 
-use ast::{ctx::values::TypeCtx, Exp, HasSpan, HashMap, MetaVar, MetaVarState};
-use constraints::Constraint;
 use log::trace;
+
+use ast::{ctx::values::TypeCtx, Exp, HasSpan, HashMap, MetaVar, MetaVarState};
 use miette_util::{codespan::Span, ToMiette};
 use printer::Print;
-use unify::Ctx;
 
 use crate::result::{TcResult, TypeError};
 
 mod constraints;
 mod unify;
+
+use constraints::Constraint;
+use unify::Ctx;
 
 pub fn convert(
     ctx: TypeCtx,

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -354,7 +354,7 @@ impl Ctx {
         log::trace!("candidate = {}", candidate.print_trace());
 
         // Condition 3: `metavar` does not occur in `candidate`
-        if candidate.occurs_metavar(&mut constraint_ctx.clone(), metavar.id) {
+        if candidate.occurs_metavar(&mut constraint_ctx.clone(), &metavar) {
             return Err(TypeError::MetaOccursCheckFailed {
                 span: metavar.span.to_miette(),
                 meta_var: metavar.print_to_string(None),

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -454,7 +454,7 @@ impl PartialRenaming {
 
 /// Extract the variable from an expression.
 ///
-/// This function helps ensure condition 1 of Millner's pattern fragment,
+/// This function helps ensure condition 1 of Miller's pattern fragment,
 /// in particular that the arguments of a metavariable consist of bound variables rather than arbitrary expressions.
 /// However, in Polarity, variables can also occur underneath type annotations or as the solution of a hole.
 /// Therefore, this function strips away these layers to get to the variable, if any.

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -1,12 +1,21 @@
+//! This file implements the core logic for unification for conversion checking
+//!
+//! It is based on the following references:
+//!
+//! * Andreas Abel, and Brigitte Pientka. "Higher-order dynamic pattern unification for dependent types and records." (2011)
+//! * Adam Gundry and Conor McBride. "A tutorial implementation of dynamic pattern unification." (2013).
+//! * András Kovács's elaboration-zoo (https://github.com/AndrasKovacs/elaboration-zoo)
+
 use std::collections::HashSet;
 
-use ast::Variable;
+use ast::{ctx::values::Binder, Variable};
 use ctx::LevelCtx;
-use miette_util::codespan::Span;
+use miette_util::{codespan::Span, ToMiette};
 
-use crate::result::{TcResult, TypeError};
 use ast::*;
 use printer::Print;
+
+use crate::result::{TcResult, TypeError};
 
 use super::constraints::Constraint;
 
@@ -16,27 +25,6 @@ pub struct Ctx {
     /// A cache of solved constraints. We can skip solving a constraint
     /// if we have seen it before
     pub done: HashSet<Constraint>,
-}
-
-/// Tests whether the hole is in Miller's pattern fragment, i.e. whether it is applied
-/// to distinct bound variables.
-fn is_solvable(h: &Hole) -> bool {
-    let Hole { args, .. } = h;
-    let mut seen: HashSet<Idx> = HashSet::new();
-    for subst in args {
-        for exp in subst {
-            let Exp::Variable(v) = &*exp.content else {
-                return false;
-            };
-            if seen.contains(&v.idx) {
-                return false;
-            } else {
-                seen.insert(v.idx);
-                continue;
-            }
-        }
-    }
-    true
 }
 
 impl Ctx {
@@ -64,32 +52,34 @@ impl Ctx {
     ) -> TcResult {
         match eqn {
             Constraint::Equality { ctx: constraint_cxt, lhs, rhs } => match (&**lhs, &**rhs) {
-                (Exp::Hole(h), e) | (e, Exp::Hole(h)) => {
+                // This is the most interesting case, where we equate a hole with an expression.
+                (Exp::Hole(h), candidate) | (candidate, Exp::Hole(h)) => {
+                    // Every hole is associated with a metavariable and a list of arguments.
+                    // The unification problem is:
+                    //
+                    // ```text
+                    // constraint_cxt ⊢ h.metavar args =? candidate
+                    // ```
                     let metavar_state = meta_vars.get(&h.metavar).unwrap();
                     match metavar_state {
+                        // When we encounter an unsolved metavariable, we attempt to solve it
+                        MetaVarState::Unsolved { ctx: metavar_ctx } => self.solve_meta_var(
+                            meta_vars,
+                            metavar_ctx.clone(),
+                            h.metavar,
+                            &h.args,
+                            constraint_cxt.levels(),
+                            Box::new(candidate.clone()),
+                            while_elaborating_span,
+                        )?,
+                        // When we encounter a solved metavariable, we substitute the arguments in the solution.
                         MetaVarState::Solved { ctx, solution } => {
                             let lhs = solution.clone().subst(&mut ctx.clone(), &h.args)?;
                             self.add_constraint(Constraint::Equality {
                                 ctx: constraint_cxt.clone(),
                                 lhs,
-                                rhs: Box::new(e.clone()),
+                                rhs: Box::new(candidate.clone()),
                             })?;
-                        }
-                        MetaVarState::Unsolved { ctx } => {
-                            if is_solvable(h) {
-                                self.solve_meta_var(
-                                    meta_vars,
-                                    h.metavar,
-                                    ctx.clone(),
-                                    Box::new(e.clone()),
-                                )?;
-                            } else {
-                                return Err(TypeError::cannot_decide(
-                                    &Box::new(Exp::Hole(h.clone())),
-                                    &Box::new(e.clone()),
-                                    while_elaborating_span,
-                                ));
-                            }
                         }
                     }
 
@@ -225,22 +215,153 @@ impl Ctx {
         Ok(())
     }
 
+    /// Attempt to solve a metavariable with a given candidate solution.
+    /// In particular, this function attempts to solve the following equation:
+    ///
+    /// ```text
+    /// constraint_ctx ⊢ metavar args =? candidate
+    /// ```
+    ///
+    /// Let us start with a quick note on the contexts involved here.
+    /// First of all, at its definition site, `metavar` is a well-typed hole under a context which
+    /// we will call `metavar_ctx`.
+    /// However, when this function is called we also know that, by assumption,
+    /// `constraint_ctx  ⊢ candidate` as well as `constraint_ctx ⊢ metavar args`.
+    /// Our goal is to transform `candidate` in such a way that it can be inserted for `metavar`.
+    /// Let's call the transformed `candidate` expression `solution`.
+    /// After the transformation we will have `metavar_ctx ⊢ solution`.
+    ///
+    /// In general, this problem is undecidable and there is not always a unique solution.
+    /// Therefore, we only accept a decidable subset of unification problems, namely those that fall
+    /// under Millner's pattern fragment:
+    ///
+    /// 1. `args` consists of distinct bound variables
+    /// 2. every free variable of `candidate` occurs in `args`
+    /// 3. `metavar` does not occur in `candidate`
+    ///
+    /// If these conditions are met, there exists the following unique solution:
+    ///
+    /// ```text
+    /// metavar = candidate[args⁻¹]
+    /// ```
+    ///
+    /// where `args⁻¹` is the "inverse" substitution to `args`.
+    /// The inverse substitution maps each argument in `args` to the corresponding bound variable in `metavar_ctx`.
+    /// For instance, if `constraint_ctx = [[x, y], [z]]`, `metavar_ctx = [[a, b]]`, and `args = (x, y)`,
+    /// then `args⁻¹ = { x ↦ a, y ↦ b }`. If `candidate = SomeCtor(x)`, then `meta_var` is solved to `SomeCtor(a)`.
+    ///
+    /// # Examples
+    ///
+    /// First, consider the following simple example:
+    ///
+    /// ```text
+    /// 1: let n1 : Nat = 5;
+    /// 2: let n2 : Nat = _;
+    /// 3: let n3 : Nat = 2;
+    /// 4: Refl(n2) : n1 = n1
+    /// ```
+    ///
+    /// Here, we have that:
+    ///
+    /// - `meta_var_cxt = [n1 : Nat]` (at 2:)
+    /// - `constraint_ctx = [n1: Nat, n2: Nat, n3: Nat]` (at 4:)
+    ///
+    /// We have to solve `n2 =? n1`. The arguments of the metavariable (at 2:) are `args = (n1)`.
+    /// The candidate solution is `candidate = n1`, `args⁻¹ = { n1 ↦ n1 }` and hence we solve the problem with
+    /// `solution = n1[args⁻¹] = n1`.
+    ///
+    /// Now let us look at a little less straightforward example.
+    ///
+    /// ```text
+    /// let bar(a: Type, x: ?0 (a) ): a { ... }
+    /// let force(b: Type, x: b): b { bar(b, x) }
+    /// ```
+    ///
+    /// Here, the type of `x` in `bar` left out. We call the metavariable `?0`.
+    /// Solving this metavariable is forced in the call to `bar` in `force`.
+    /// In particular, we check that `(b, x): [a: Type, x: ?0 (a)]`, which equates `?0 =? b`.
+    /// Hence, we have that:
+    ///
+    /// - `metavar_ctx = [a: Type] ⊢ ?0(a) : Type`
+    /// - `constraint_ctx = [b: Type, x: b] ⊢ ?0 = b : Type`
+    /// - `args = (b)`
+    /// - `args⁻¹ = { b ↦ a }``
+    /// - `solution = b[args⁻¹] = a`
+    ///
+    /// # Parameters
+    ///
+    /// - `meta_vars`: The global metavariables state
+    /// - `metavar_ctx`: The context of the metavariable
+    /// - `metavar`: The metavariable to solve
+    /// - `args`: The arguments of the metavariable
+    /// - `constraint_ctx`: The context of the solution
+    /// - `candidate`: The candidate solution
+    /// - `while_elaborating_span`: The origin of the unification call,
+    ///                             tracked here for better error messages
+    ///
+    /// # Requires
+    ///
+    /// - `metavar_ctx ⊢ metavar`
+    /// - `constraint_ctx ⊢ metavar args`
+    /// - `constraint_ctx ⊢ candidate`
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if the metavariable was successfully solved
+    /// - `Err(TypeError)` if the metavariable could not be solved
+    /// - `meta_vars[meta_var]`
+    ///
+    /// # Ensures
+    ///
+    /// If solving is successful:
+    ///
+    /// - `meta_vars[meta_var] = Solved { ctx: metavar_ctx, solution }`
+    ///    where `solution` is the solution to the metavariable
+    /// - `metavar_ctx ⊢ solution[args]` is well-typed
+    /// - `solution` does not contain any other solved metavariables
+    /// - All other `meta_vars` do not contain `meta_var` (i.e. `meta_var` is replaced by `solution` via zonking)
+    #[allow(clippy::vec_box)]
+    #[allow(clippy::too_many_arguments)]
     fn solve_meta_var(
         &mut self,
         meta_vars: &mut HashMap<MetaVar, MetaVarState>,
+        metavar_ctx: LevelCtx,
         metavar: MetaVar,
-        ctx: LevelCtx,
-        mut solution: Box<Exp>,
+        args: &[Vec<Binder<Box<Exp>>>],
+        constraint_ctx: LevelCtx,
+        candidate: Box<Exp>,
+        while_elaborating_span: &Option<Span>,
     ) -> TcResult {
-        log::trace!(
-            "Solved metavariable: {} with solution: {}",
-            metavar.id,
-            solution.print_trace()
-        );
+        log::trace!("Attempting to solve metavariable {}", metavar.print_trace());
+        log::trace!("metavar_ctx = {}", metavar_ctx.print_trace());
+        log::trace!("metavar = {}", metavar.print_trace());
+        log::trace!("args = {}", args.to_vec().print_trace());
+        log::trace!("constraint_ctx = {}", constraint_ctx.print_trace());
+        log::trace!("candidate = {}", candidate.print_trace());
+
+        // Condition 3: `metavar` does not occur in `candidate`
+        if candidate.occurs_metavar(&mut constraint_ctx.clone(), metavar.id) {
+            return Err(TypeError::MetaOccursCheckFailed {
+                span: metavar.span.to_miette(),
+                meta_var: metavar.print_to_string(None),
+                while_elaborating_span: while_elaborating_span.to_miette(),
+            }
+            .into());
+        }
+
+        let subst = PartialRenaming::from_args(
+            &constraint_ctx,
+            &metavar_ctx,
+            &metavar,
+            args,
+            while_elaborating_span,
+        )?;
+        let mut solution = candidate.subst(&mut constraint_ctx.clone(), &subst)?;
         solution
             .zonk(meta_vars)
             .map_err(|err| TypeError::Impossible { message: err.to_string(), span: None })?;
-        meta_vars.insert(metavar, MetaVarState::Solved { ctx: ctx.clone(), solution });
+        log::trace!("solution = {}", solution.print_trace());
+        meta_vars.insert(metavar, MetaVarState::Solved { ctx: metavar_ctx.clone(), solution });
         let meta_vars_snapshot = meta_vars.clone();
         for (_, state) in meta_vars.iter_mut() {
             match state {
@@ -259,6 +380,107 @@ impl Ctx {
     }
 }
 
+#[derive(Debug, Clone)]
+struct PartialRenaming {
+    map: HashMap<Lvl, Lvl>,
+    /// The context of the metavariable (and its solution)
+    metavar_ctx: LevelCtx,
+    /// The metavariable, tracked here for better error messages
+    meta_var: MetaVar,
+    /// The origin of the unification call, tracked here for better error messages
+    while_elaborating_span: Option<Span>,
+}
+
+impl PartialRenaming {
+    #[allow(clippy::vec_box)]
+    fn from_args(
+        constraint_ctx: &LevelCtx,
+        metavar_ctx: &LevelCtx,
+        meta_var: &MetaVar,
+        args: &[Vec<Binder<Box<Exp>>>],
+        while_elaborating_span: &Option<Span>,
+    ) -> TcResult<Self> {
+        let mut map = HashMap::default();
+
+        for (fst, telescope) in args.iter().enumerate() {
+            for (snd, arg) in telescope.iter().enumerate() {
+                let to_lvl = Lvl { fst, snd };
+                match &*arg.content {
+                    Exp::Variable(Variable { idx, name, .. }) => {
+                        let from_lvl = constraint_ctx.idx_to_lvl(*idx);
+                        if map.insert(from_lvl, to_lvl).is_some() {
+                            // Condition 1: `args` consists of *distinct* bound variables
+                            return Err(TypeError::MetaArgNotDistinct {
+                                span: meta_var.span.to_miette(),
+                                meta_var: meta_var.print_to_string(None),
+                                arg: name.print_to_string(None),
+                                while_elaborating_span: while_elaborating_span.to_miette(),
+                            }
+                            .into());
+                        }
+                    }
+                    other => {
+                        // Condition 1: `args` consists of distinct bound *variables*
+                        return Err(TypeError::MetaArgNotVariable {
+                            span: meta_var.span.to_miette(),
+                            meta_var: meta_var.print_to_string(None),
+                            arg: other.print_to_string(None),
+                            while_elaborating_span: while_elaborating_span.to_miette(),
+                        }
+                        .into());
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            map,
+            metavar_ctx: metavar_ctx.clone(),
+            meta_var: *meta_var,
+            while_elaborating_span: *while_elaborating_span,
+        })
+    }
+}
+
+impl Shift for PartialRenaming {
+    fn shift_in_range<R: ShiftRange>(&mut self, _range: &R, _by: (isize, isize)) {
+        // PartialRenaming is shift-invariant, so nothing to do here
+    }
+}
+
+impl Substitution for PartialRenaming {
+    type Err = TypeError;
+
+    fn get_subst(&self, ctx: &LevelCtx, lvl: Lvl) -> Result<Option<Box<Exp>>, Self::Err> {
+        let from_binder = ctx.lookup(lvl);
+        self.map
+            .get(&lvl)
+            .map(|target_lvl| {
+                let idx = self.metavar_ctx.lvl_to_idx(*target_lvl);
+                let to_binder = self.metavar_ctx.lookup(*target_lvl);
+                Some(Box::new(Exp::Variable(Variable {
+                    span: None,
+                    idx,
+                    name: match to_binder.name {
+                        VarBind::Var { id, .. } => VarBound { span: None, id },
+                        // When we encouter a wildcard, we use `x` as a placeholder name for the variable referencing this binder.
+                        // Of course, `x` is not guaranteed to be unique; in general we do not guarantee that the string representation of variables remains intact during elaboration.
+                        // When reliable variable names are needed (e.g. for printing source code or code generation), the `renaming` transformation needs to be applied to the AST first.
+                        ast::VarBind::Wildcard { .. } => VarBound::from_string("x"),
+                    },
+                    inferred_type: None,
+                })))
+            })
+            // Condition 2: every free variable of `candidate` occurs in `args`
+            .ok_or(TypeError::MetaEquatedToOutOfScope {
+                span: self.meta_var.span.to_miette(),
+                meta_var: self.meta_var.print_to_string(None),
+                out_of_scope: from_binder.name.to_string(),
+                while_elaborating_span: self.while_elaborating_span.to_miette(),
+            })
+    }
+}
+
 fn zip_cases_by_xtors(
     cases_lhs: &[Case],
     cases_rhs: &[Case],
@@ -274,4 +496,196 @@ fn zip_cases_by_xtors(
         }
     }
     cases.into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use ctx::LevelCtx;
+    use url::Url;
+
+    use super::*;
+
+    fn var(name: &str, idx: (usize, usize)) -> Box<Exp> {
+        Box::new(Exp::Variable(Variable {
+            span: None,
+            idx: Idx { fst: idx.0, snd: idx.1 },
+            name: VarBound::from_string(name),
+            inferred_type: None,
+        }))
+    }
+
+    fn level_ctx(rows: Vec<Vec<&str>>) -> LevelCtx {
+        let ctx: Vec<Vec<VarBind>> = rows
+            .into_iter()
+            .map(|row| row.into_iter().map(VarBind::from_string).collect())
+            .collect();
+        ctx.into()
+    }
+
+    fn meta_var(id: u64) -> MetaVar {
+        MetaVar { span: None, kind: MetaVarKind::MustSolve, id }
+    }
+
+    fn dummy_uri() -> Url {
+        Url::parse("inmemory://scratch.pol").unwrap()
+    }
+
+    fn true_exp() -> Box<Exp> {
+        let uri = dummy_uri();
+        let name = IdBound { span: None, id: "T".to_owned(), uri };
+        Box::new(Exp::TypCtor(TypCtor { span: None, name, args: Args { args: vec![] } }))
+    }
+
+    fn fun_type(a: Box<Exp>, b: Box<Exp>) -> Box<Exp> {
+        let uri = dummy_uri();
+        let name = IdBound { span: None, id: "Fun".to_owned(), uri };
+        Box::new(Exp::TypCtor(TypCtor {
+            span: None,
+            name,
+            args: Args {
+                args: vec![
+                    Arg::UnnamedArg { arg: a, erased: false },
+                    Arg::UnnamedArg { arg: b, erased: false },
+                ],
+            },
+        }))
+    }
+
+    /// Violation of condition 1: The args contain a non-variable argument.
+    ///
+    /// Example problem: `?0(T) =? T`
+    /// ```
+    #[test]
+    fn test_fail_meta_arg_not_variable() {
+        use crate::result::TypeError::MetaArgNotVariable;
+
+        let mut ctx = Ctx { constraints: vec![], done: HashSet::default() };
+        let mut meta_vars = HashMap::default();
+
+        let metavar_ctx = level_ctx(vec![vec!["x"]]);
+        let metavar = meta_var(0);
+
+        let args = &[vec![Binder { name: VarBind::from_string("x"), content: true_exp() }]];
+
+        let constraint_ctx = level_ctx(vec![vec!["x"]]);
+        let candidate = var("x", (0, 0));
+
+        let err = ctx
+            .solve_meta_var(
+                &mut meta_vars,
+                metavar_ctx,
+                metavar,
+                args,
+                constraint_ctx,
+                candidate,
+                &None,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            *err,
+            MetaArgNotVariable {
+                span: None,
+                meta_var: "_0".to_owned(),
+                arg: "T".to_owned(),
+                while_elaborating_span: None,
+            }
+        );
+    }
+
+    /// Violation of condition 2: The candidate refers to a binder not in the metavariable’s arguments.
+    ///
+    /// Example problem: `?0(x,y) =? Fun(z, z)`
+    #[test]
+    fn test_fail_condition_2() {
+        use crate::result::TypeError::MetaEquatedToOutOfScope;
+
+        let mut ctx = Ctx { constraints: vec![], done: HashSet::default() };
+        let mut meta_vars = HashMap::default();
+
+        let metavar_ctx = level_ctx(vec![vec!["x", "y"]]);
+        let metavar = meta_var(0);
+
+        let args = &[vec![
+            Binder { name: VarBind::from_string("x"), content: var("x", (0, 2)) },
+            Binder { name: VarBind::from_string("y"), content: var("y", (0, 1)) },
+        ]];
+
+        let constraint_ctx = level_ctx(vec![vec!["x", "y", "z"]]);
+        let candidate = var("z", (0, 0));
+
+        let err = ctx
+            .solve_meta_var(
+                &mut meta_vars,
+                metavar_ctx,
+                metavar,
+                args,
+                constraint_ctx,
+                candidate,
+                &None,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            *err,
+            MetaEquatedToOutOfScope {
+                span: None,
+                meta_var: "_0".to_owned(),
+                out_of_scope: "z".to_owned(),
+                while_elaborating_span: None,
+            }
+        );
+    }
+
+    /// Violation of condition 3: The candidate contains the metavariable itself.
+    ///
+    /// Example problem: `?0 =? Fun(?0, ?0)`
+    #[test]
+    fn test_fail_condition_3() {
+        use crate::result::TypeError::MetaOccursCheckFailed;
+
+        let mut ctx = Ctx { constraints: vec![], done: HashSet::default() };
+        let mut meta_vars = HashMap::default();
+
+        let metavar_ctx = level_ctx(vec![]);
+        let metavar = meta_var(0);
+
+        let args: &[Vec<Binder<Box<Exp>>>] = &[];
+
+        let hole: Box<Exp> = Box::new(
+            Hole {
+                span: None,
+                kind: MetaVarKind::MustSolve,
+                metavar,
+                inferred_type: None,
+                inferred_ctx: None,
+                args: vec![],
+                solution: None,
+            }
+            .into(),
+        );
+
+        let candidate = fun_type(hole.clone(), hole);
+
+        let err = ctx
+            .solve_meta_var(
+                &mut meta_vars,
+                metavar_ctx,
+                metavar,
+                args,
+                level_ctx(vec![vec![]]),
+                candidate,
+                &None,
+            )
+            .unwrap_err();
+
+        assert_eq!(
+            *err,
+            MetaOccursCheckFailed {
+                span: None,
+                meta_var: "_0".to_owned(),
+                while_elaborating_span: None
+            }
+        );
+    }
 }

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -237,7 +237,7 @@ impl Ctx {
     /// ```
     ///
     /// Let us start with a quick note on the contexts involved here.
-    /// First of all, at its definition site, `metavar` is a well-typed hole under a context which
+    /// First of all, at the site where it is introduced, `metavar` is a well-typed hole under a context which
     /// we will call `metavar_ctx`.
     /// However, when this function is called we also know that, by assumption,
     /// `constraint_ctx  ⊢ candidate` as well as `constraint_ctx ⊢ metavar args`.
@@ -291,7 +291,7 @@ impl Ctx {
     /// let force(b: Type, x: b): b { bar(b, x) }
     /// ```
     ///
-    /// Here, the type of `x` in `bar` left out. We call the metavariable `?0`.
+    /// Here, the type of `x` in `bar` is left out and a metavariable `?0` generated for the hole.
     /// Solving this metavariable is forced in the call to `bar` in `force`.
     /// In particular, we check that `(b, x): [a: Type, x: ?0 (a)]`, which equates `?0 =? b`.
     /// Hence, we have that:

--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -230,7 +230,7 @@ impl Ctx {
     }
 
     /// Attempt to solve a metavariable with a given candidate solution.
-    /// In particular, this function attempts to solve the following equation:
+    /// In particular, this method attempts to solve the following equation:
     ///
     /// ```text
     /// constraint_ctx ⊢ metavar args =? candidate
@@ -239,7 +239,7 @@ impl Ctx {
     /// Let us start with a quick note on the contexts involved here.
     /// First of all, at the site where it is introduced, `metavar` is a well-typed hole under a context which
     /// we will call `metavar_ctx`.
-    /// However, when this function is called we also know that, by assumption,
+    /// However, when this method is called we also know that, by assumption,
     /// `constraint_ctx  ⊢ candidate` as well as `constraint_ctx ⊢ metavar args`.
     /// Our goal is to transform `candidate` in such a way that it can be inserted for `metavar`.
     /// Let's call the transformed `candidate` expression `solution`.

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -453,10 +453,11 @@ impl Eval for Hole {
     type Val = Box<Val>;
 
     fn eval(&self, info_table: &Rc<TypeInfoTable>, env: &mut Env) -> TcResult<Self::Val> {
-        let Hole { span, kind, metavar, args, .. } = self;
+        let Hole { span, kind, metavar, args, solution, .. } = self;
         let args = args.eval(info_table, env)?;
+        let solution = solution.eval(info_table, env)?;
         Ok(Box::new(Val::Neu(
-            val::Hole { span: *span, kind: *kind, metavar: *metavar, args }.into(),
+            val::Hole { span: *span, kind: *kind, metavar: *metavar, args, solution }.into(),
         )))
     }
 }
@@ -540,5 +541,13 @@ impl Eval for Box<Exp> {
 
     fn eval(&self, info_table: &Rc<TypeInfoTable>, env: &mut Env) -> TcResult<Self::Val> {
         (**self).eval(info_table, env)
+    }
+}
+
+impl<T: Eval> Eval for Option<T> {
+    type Val = Option<T::Val>;
+
+    fn eval(&self, info_table: &Rc<TypeInfoTable>, env: &mut Env) -> TcResult<Self::Val> {
+        self.as_ref().map(|x| x.eval(info_table, env)).transpose()
     }
 }

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -575,6 +575,8 @@ pub struct Hole {
     pub metavar: MetaVar,
     /// Explicit substitution of the context, compare documentation of ast::Hole
     pub args: Vec<Vec<Binder<Box<Val>>>>,
+    /// The solution of this hole, if any
+    pub solution: Option<Box<Val>>,
 }
 
 impl Shift for Hole {
@@ -603,7 +605,7 @@ impl ReadBack for Hole {
     type Nf = ast::Hole;
 
     fn read_back(&self, info_table: &Rc<TypeInfoTable>) -> TcResult<Self::Nf> {
-        let Hole { span, kind, metavar, args } = self;
+        let Hole { span, kind, metavar, args, solution } = self;
         let args = args.read_back(info_table)?;
         Ok(ast::Hole {
             span: *span,
@@ -612,7 +614,7 @@ impl ReadBack for Hole {
             inferred_type: None,
             inferred_ctx: None,
             args,
-            solution: None,
+            solution: solution.read_back(info_table)?,
         })
     }
 }

--- a/lang/elaborator/src/result.rs
+++ b/lang/elaborator/src/result.rs
@@ -22,7 +22,7 @@ pub type TcResult<T = ()> = Result<T, Box<TypeError>>;
 
 /// This enum contains all errors that can be emitted during elaboration, i.e. either
 /// during bidirectional type inference, normalization, index unification or conversion checking.
-#[derive(Error, Diagnostic, Debug, Clone)]
+#[derive(Error, Diagnostic, Debug, Clone, PartialEq, Eq)]
 pub enum TypeError {
     #[error("Wrong number of arguments to {name} provided: got {actual}, expected {expected}")]
     #[diagnostic(code("T-001"))]
@@ -177,12 +177,12 @@ pub enum TypeError {
         #[label("While elaborating")]
         while_elaborating_span: Option<SourceSpan>,
     },
-    #[error("The metavariable {message} could not be solved")]
+    #[error("The metavariable {meta_var} could not be solved")]
     #[diagnostic(code("T-017"))]
     UnresolvedMeta {
         #[label]
         span: Option<SourceSpan>,
-        message: String,
+        meta_var: String,
     },
     #[error("A case for constructor {name} was missing during evaluation.")]
     #[diagnostic(code("T-018"))]
@@ -190,6 +190,57 @@ pub enum TypeError {
     #[error("A case for destructor {name} was missing during evaluation.")]
     #[diagnostic(code("T-019"))]
     MissingCocase { name: String },
+    #[error("The metavariable {meta_var} received {arg} as an argument more than once")]
+    #[diagnostic(
+        code("T-020"),
+        help("This means that the metavariable cannot be solved automatically.")
+    )]
+    MetaArgNotDistinct {
+        #[label]
+        span: Option<SourceSpan>,
+        meta_var: String,
+        arg: String,
+        #[label("While elaborating")]
+        while_elaborating_span: Option<SourceSpan>,
+    },
+    #[error("The metavariable {meta_var} received argument {arg} which is not a variable")]
+    #[diagnostic(
+        code("T-021"),
+        help("This means that the metavariable cannot be solved automatically.")
+    )]
+    MetaArgNotVariable {
+        #[label]
+        span: Option<SourceSpan>,
+        meta_var: String,
+        arg: String,
+        #[label("While elaborating")]
+        while_elaborating_span: Option<SourceSpan>,
+    },
+    #[error("The metavariable {meta_var} was equated with an expression that contains {out_of_scope} which is not in scope for {meta_var}")]
+    #[diagnostic(
+        code("T-022"),
+        help("This means that the metavariable cannot be solved automatically.")
+    )]
+    MetaEquatedToOutOfScope {
+        #[label]
+        span: Option<SourceSpan>,
+        meta_var: String,
+        out_of_scope: String,
+        #[label("While elaborating")]
+        while_elaborating_span: Option<SourceSpan>,
+    },
+    #[error("The metavariable {meta_var} was equated with an expression that itself contains {meta_var}")]
+    #[diagnostic(
+        code("T-023"),
+        help("This means that the metavariable cannot be solved automatically.")
+    )]
+    MetaOccursCheckFailed {
+        #[label]
+        span: Option<SourceSpan>,
+        meta_var: String,
+        #[label("While elaborating")]
+        while_elaborating_span: Option<SourceSpan>,
+    },
     #[error("An unexpected internal error occurred: {message}")]
     #[diagnostic(code("T-XXX"))]
     /// This error should not occur.

--- a/lang/elaborator/src/typechecker/decls/mod.rs
+++ b/lang/elaborator/src/typechecker/decls/mod.rs
@@ -59,7 +59,7 @@ pub fn check_metavars_solved(meta_vars: &HashMap<MetaVar, MetaVarState>) -> TcRe
     if let Some(mv) = unsolved.iter().next() {
         let err = TypeError::UnresolvedMeta {
             span: mv.span.to_miette(),
-            message: mv.print_to_string(None),
+            meta_var: mv.print_to_string(None),
         };
         return Err(err.into());
     }

--- a/std/data/eq.pol
+++ b/std/data/eq.pol
@@ -1,11 +1,11 @@
 -- | The Martin-Löf equality type.
-data Eq(a: Type, x y: a) {
+data Eq(implicit a: Type, x y: a) {
     -- | The reflexivity constructor.
-    Refl(a: Type, x: a): Eq(a, x, x)
+    Refl(implicit a: Type, x: a): Eq(x, x)
 }
 
 -- | Proof of symmetry of equality.
-def Eq(a, x, y).sym(a: Type, x y: a): Eq(a, y, x) { Refl(a, x) => Refl(a, x) }
+def Eq(a:=a, x, y).sym(a: Type, x y: a): Eq(a:=a, y, x) { Refl(a, x) => Refl(a:=a, x) }
 
 -- | Proof of transitivity of equality.
-def Eq(a, x, y).trans(a: Type, x y z: a, h: Eq(a, y, z)): Eq(a, x, z) { Refl(a, x) => h }
+def Eq(a:=a, x, y).trans(a: Type, x y z: a, h: Eq(a:=a, y, z)): Eq(a:=a, x, z) { Refl(a, x) => h }

--- a/test/suites/fail-check/011-escaping-hole.expected
+++ b/test/suites/fail-check/011-escaping-hole.expected
@@ -1,0 +1,15 @@
+T-022
+
+  × The metavariable _0 was equated with an expression that contains b which is not in scope for _0
+    ╭─[011-escaping-hole.pol:8:19]
+  7 │ #[transparent]
+  8 │ let foo(): Bool { _ }
+    ·                   ─
+  9 │ 
+ 10 │ let bar(b: Bool): Eq(Bool, foo(), b) {
+ 11 │     Refl(Bool, b)
+    ·     ──────┬──────
+    ·           ╰── While elaborating
+ 12 │ }
+    ╰────
+  help: This means that the metavariable cannot be solved automatically.

--- a/test/suites/fail-check/011-escaping-hole.pol
+++ b/test/suites/fail-check/011-escaping-hole.pol
@@ -1,0 +1,12 @@
+data Bool { T, F }
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x)
+}
+
+#[transparent]
+let foo(): Bool { _ }
+
+let bar(b: Bool): Eq(Bool, foo(), b) {
+    Refl(Bool, b)
+}

--- a/test/suites/fail-check/Regr-348.expected
+++ b/test/suites/fail-check/Regr-348.expected
@@ -1,0 +1,11 @@
+T-022
+
+  × The metavariable ?1 was equated with an expression that contains f which is not in scope for ?1
+   ╭─[Regr-348.pol:5:19]
+ 4 │ 
+ 5 │ let bar(f: Fun(?, ?)): f.ap(?, ?, ?) {
+   ·                   ─    ┬
+   ·                   │    ╰── While elaborating
+ 6 │     ?
+   ╰────
+  help: This means that the metavariable cannot be solved automatically.

--- a/test/suites/fail-check/Regr-348.pol
+++ b/test/suites/fail-check/Regr-348.pol
@@ -1,0 +1,7 @@
+codata Fun(a b: Type) {
+    Fun(a,b).ap(a b: Type, x: a) : b
+}
+
+let bar(f: Fun(?, ?)): f.ap(?, ?, ?) {
+    ?
+}

--- a/test/suites/fail-check/Regr-403.expected
+++ b/test/suites/fail-check/Regr-403.expected
@@ -1,23 +1,23 @@
 T-002
 
   × The following terms are not equal:
-  │   1: Eq(Bool -> Bool, \x. T, \x. T)
-  │   2: Eq(Bool -> Bool, \x. T, \x. F)
+  │   1: Eq(<Bool -> Bool>, \x. T, \x. T)
+  │   2: Eq(a:=Bool -> Bool, \x. T, \x. F)
   │ 
-    ╭─[Regr-403.pol:6:13]
+    ╭─[Regr-403.pol:6:31]
   5 │ #[transparent]
   6 │ let foo(y: Bool) : Fun(Bool, Bool)  {
-    ·             ─────┬─────
-    ·                  ╰── Source of (1)
+    ·                               ────┬───
+    ·                                   ╰── Source of (1)
   7 │     \x. y
   8 │ }
   9 │ 
- 10 │ let proof: Eq(Fun(Bool, Bool), foo(T), foo(F)) {
-    ·            ─────────────────┬─────────────────
-    ·                             ╰── Source of (2)
- 11 │     Refl(Fun(Bool,Bool), foo(T))
-    ·     ──────────────┬─────────────
-    ·                   ╰── While elaborating
+ 10 │ let proof: Eq(a := Fun(Bool, Bool), foo(T), foo(F)) {
+    ·            ────────────────────┬───────────────────
+    ·                                ╰── Source of (2)
+ 11 │     Refl(a := Fun(Bool,Bool), foo(T))
+    ·     ────────────────┬────────────────
+    ·                     ╰── While elaborating
  12 │ }
     ╰────
   help: The two subterms T and F are not equal.

--- a/test/suites/fail-check/Regr-403.pol
+++ b/test/suites/fail-check/Regr-403.pol
@@ -7,6 +7,6 @@ let foo(y: Bool) : Fun(Bool, Bool)  {
     \x. y
 }
 
-let proof: Eq(Fun(Bool, Bool), foo(T), foo(F)) {
-    Refl(Fun(Bool,Bool), foo(T))
+let proof: Eq(a := Fun(Bool, Bool), foo(T), foo(F)) {
+    Refl(a := Fun(Bool,Bool), foo(T))
 }

--- a/test/suites/success/039-metavars-accross-decls.ir.expected
+++ b/test/suites/success/039-metavars-accross-decls.ir.expected
@@ -1,0 +1,3 @@
+let foo { T }
+
+let bar { Refl(T) }

--- a/test/suites/success/039-metavars-accross-decls.pol
+++ b/test/suites/success/039-metavars-accross-decls.pol
@@ -1,0 +1,12 @@
+data Bool { T, F }
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x)
+}
+
+#[transparent]
+let foo: Bool { _ }
+
+let bar: Eq(Bool, foo(), T) {
+    Refl(Bool, T)
+}

--- a/test/suites/success/Regr-348.ir.expected
+++ b/test/suites/success/Regr-348.ir.expected
@@ -1,0 +1,1 @@
+codef Id { .ap(x) => x }

--- a/test/suites/success/Regr-348.pol
+++ b/test/suites/success/Regr-348.pol
@@ -1,0 +1,7 @@
+codata Fun(a: Type, b: Type) {
+    Fun(a, b).ap(a: Type, b: Type, x: a) : b
+}
+
+codef Id(a: Type): Fun(a, ?) {
+    .ap(a, b, x) => x
+}

--- a/test/suites/success/Regr-403.pol
+++ b/test/suites/success/Regr-403.pol
@@ -7,6 +7,6 @@ let foo : Fun(Bool, Bool)  {
     \x. x
 }
 
-let proof: Eq(Fun(Bool, Bool), foo, foo) {
-    Refl(Fun(Bool,Bool), foo)
+let proof: Eq(a := Fun(Bool, Bool), foo, foo) {
+    Refl(a:= Fun(Bool,Bool), foo)
 }

--- a/test/suites/success/Regr-442.ir.expected
+++ b/test/suites/success/Regr-442.ir.expected
@@ -1,0 +1,1 @@
+let force(f, x) { f.foo(x) }

--- a/test/suites/success/Regr-442.pol
+++ b/test/suites/success/Regr-442.pol
@@ -1,0 +1,7 @@
+codata Foo {
+    (f: Foo).foo(a: Type, x: ?): a
+}
+
+let force(f: Foo, b: Type, x: b): b {
+    f.foo(b, x)
+}


### PR DESCRIPTION
Previous to this PR, our implementation of unification for conversion checking was incorrect because we did not properly build an inverse substitution for the hole arguments.
This led to bugs such as #442 and #348.

Depends on #479 and #480.

Fixes #442, fixes #348.