### PR TITLE
Allow non-linear arguments that don't occur in solution

### DIFF
--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -123,7 +123,7 @@ impl Attributes {
 ///
 /// A metavariable is always annotated with a local context which specifies
 /// which free variables may occur in the solution.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetaVarState {
     /// We know what the metavariable stands for.
     /// The solution lives in the same context as the metavariable.

--- a/test/suites/fail-check/012-nonlinear-args.expected
+++ b/test/suites/fail-check/012-nonlinear-args.expected
@@ -1,0 +1,13 @@
+T-020
+
+  × The metavariable ?0 received b2 as an argument more than once
+    ╭─[012-nonlinear-args.pol:9:46]
+  8 │ 
+  9 │ def Eq(Bool, b1, b2).bar(b1 b2: Bool, x: Foo(?, b2)): Foo(b1, b2) {
+    ·                                              ─
+ 10 │     Refl(_, _) => x
+    ·                   ┬
+    ·                   ╰── While elaborating
+ 11 │ }
+    ╰────
+  help: This means that the metavariable cannot be solved automatically.

--- a/test/suites/fail-check/012-nonlinear-args.pol
+++ b/test/suites/fail-check/012-nonlinear-args.pol
@@ -1,0 +1,11 @@
+data Bool { T, F }
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x)
+}
+
+data Foo(a b: Bool) {}
+
+def Eq(Bool, b1, b2).bar(b1 b2: Bool, x: Foo(?, b2)): Foo(b1, b2) {
+    Refl(_, _) => x
+}


### PR DESCRIPTION
The first baby step to relax the conditions on metavariable arguments: we allow non-linear arguments if they don't occur in the solution.

We still need to improve the error messages here. 