### PR TITLE
Follow renaming of tower-lsp-community fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,7 @@ dependencies = [
  "log",
  "lsp-server",
  "reqwest",
- "tower-lsp",
+ "tower-lsp-server",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
@@ -2014,7 +2014,7 @@ dependencies = [
  "miette",
  "miette_util",
  "printer",
- "tower-lsp",
+ "tower-lsp-server",
  "url",
 ]
 
@@ -2513,7 +2513,7 @@ dependencies = [
  "termsize",
  "thiserror",
  "tokio",
- "tower-lsp",
+ "tower-lsp-server",
 ]
 
 [[package]]
@@ -3595,9 +3595,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
-source = "git+https://github.com/tower-lsp/tower-lsp?rev=19f5a87810ff4b643d2bc394e438450bd9c74365#19f5a87810ff4b643d2bc394e438450bd9c74365"
+name = "tower-lsp-server"
+version = "0.21.0"
+source = "git+https://github.com/tower-lsp-community/tower-lsp-server?rev=ae955f1d1c2a86bf675cc9bd0638e4c684864a6d#ae955f1d1c2a86bf675cc9bd0638e4c684864a6d"
 dependencies = [
  "async-codec-lite",
  "async-trait",
@@ -3611,14 +3611,14 @@ dependencies = [
  "serde",
  "serde_json",
  "tower",
- "tower-lsp-macros",
+ "tower-lsp-server-macros",
  "tracing",
 ]
 
 [[package]]
-name = "tower-lsp-macros"
+name = "tower-lsp-server-macros"
 version = "0.9.0"
-source = "git+https://github.com/tower-lsp/tower-lsp?rev=19f5a87810ff4b643d2bc394e438450bd9c74365#19f5a87810ff4b643d2bc394e438450bd9c74365"
+source = "git+https://github.com/tower-lsp-community/tower-lsp-server?rev=ae955f1d1c2a86bf675cc9bd0638e4c684864a6d#ae955f1d1c2a86bf675cc9bd0638e4c684864a6d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ miette = { version = "7" }
 thiserror = { version = "1" }
 # lsp server
 lsp-types = { version = "0.97" }
-tower-lsp = { git = "https://github.com/tower-lsp/tower-lsp", rev = "19f5a87810ff4b643d2bc394e438450bd9c74365", default-features = false, features = [
+tower-lsp-server = { git = "https://github.com/tower-lsp-community/tower-lsp-server", rev = "ae955f1d1c2a86bf675cc9bd0638e4c684864a6d", default-features = false, features = [
     "runtime-agnostic",
 ] }
 # ignoring fields when deriving traits (e.g. Eq, Hash)

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -30,7 +30,7 @@ log = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3"
 async-std = "1"
-tower-lsp = { workspace = true }
+tower-lsp-server = { workspace = true }
 # workspace members
 driver = { path = "../lang/driver" }
 elaborator = { path = "../lang/elaborator" }

--- a/app/src/cli/lsp.rs
+++ b/app/src/cli/lsp.rs
@@ -1,4 +1,4 @@
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 
 #[derive(clap::Args)]
 pub struct Args {}

--- a/contrib/nix/package.nix
+++ b/contrib/nix/package.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage rec {
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
-      "tower-lsp-0.20.0" = "sha256-f3S2CyFFX6yylaxMoXhB1/bfizVsLfNldLM+dXl5Y8k=";
+      "tower-lsp-server-0.21.0" = "sha256-aeCc8m7zf3Kww1EBmMJFhQTYJ9lP6+R+9WzQ8yaj3Jo=";
     };
   };
 

--- a/lang/lsp/Cargo.toml
+++ b/lang/lsp/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 
 [dependencies]
 # lsp
-tower-lsp = { workspace = true }
+tower-lsp-server = { workspace = true }
 # asynchronous locks
 async-lock = "2"
 # fancy error messages

--- a/lang/lsp/src/capabilities.rs
+++ b/lang/lsp/src/capabilities.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::lsp_types::*;
 
 pub fn capabilities() -> ServerCapabilities {
     let text_document_sync = {

--- a/lang/lsp/src/codeactions.rs
+++ b/lang/lsp/src/codeactions.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use tower_lsp::{jsonrpc, lsp_types::*};
+use tower_lsp_server::{jsonrpc, lsp_types::*};
 
 use driver::{Database, Item, Xfunc};
 

--- a/lang/lsp/src/conversion/mod.rs
+++ b/lang/lsp/src/conversion/mod.rs
@@ -1,5 +1,5 @@
 use miette::Severity;
-use tower_lsp::lsp_types::DiagnosticSeverity;
+use tower_lsp_server::lsp_types::DiagnosticSeverity;
 
 mod uri_to_url;
 

--- a/lang/lsp/src/conversion/uri_to_url.rs
+++ b/lang/lsp/src/conversion/uri_to_url.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use tower_lsp::lsp_types::Uri;
+use tower_lsp_server::lsp_types::Uri;
 
 use super::{FromLsp, ToLsp};
 

--- a/lang/lsp/src/diagnostics.rs
+++ b/lang/lsp/src/diagnostics.rs
@@ -1,7 +1,7 @@
 use lsp_types::NumberOrString;
 use miette::Diagnostic;
 use miette::SourceSpan;
-use tower_lsp::lsp_types;
+use tower_lsp_server::lsp_types;
 use url::Url;
 
 use driver::Database;

--- a/lang/lsp/src/format.rs
+++ b/lang/lsp/src/format.rs
@@ -1,6 +1,6 @@
 //! Implementation of the formatting functionality of the LSP server
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::*;
 
 use printer::Print;
 

--- a/lang/lsp/src/gotodefinition.rs
+++ b/lang/lsp/src/gotodefinition.rs
@@ -1,6 +1,6 @@
 //! Implementation of the goto-definition functionality of the LSP server
 
-use tower_lsp::{jsonrpc, lsp_types::*};
+use tower_lsp_server::{jsonrpc, lsp_types::*};
 
 use super::conversion::*;
 use super::server::*;

--- a/lang/lsp/src/hover.rs
+++ b/lang/lsp/src/hover.rs
@@ -1,7 +1,7 @@
 //! Implementation of the type-on-hover functionality of the LSP server
 use driver::*;
 use miette_util::codespan::Span;
-use tower_lsp::{jsonrpc, lsp_types::*};
+use tower_lsp_server::{jsonrpc, lsp_types::*};
 
 use super::conversion::*;
 use super::server::*;

--- a/lang/lsp/src/server.rs
+++ b/lang/lsp/src/server.rs
@@ -1,6 +1,6 @@
 use async_lock::RwLock;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::{jsonrpc, lsp_types::*, LanguageServer};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::{jsonrpc, lsp_types::*, LanguageServer};
 
 use driver::Database;
 #[cfg(not(target_arch = "wasm32"))]
@@ -12,22 +12,22 @@ use super::capabilities::*;
 use super::diagnostics::*;
 
 pub struct Server {
-    pub client: tower_lsp::Client,
+    pub client: tower_lsp_server::Client,
     pub database: RwLock<Database>,
 }
 
 impl Server {
-    pub fn new(client: tower_lsp::Client) -> Self {
+    pub fn new(client: tower_lsp_server::Client) -> Self {
         let database = Database::in_memory();
         Self::with_database(client, database)
     }
 
-    pub fn with_database(client: tower_lsp::Client, database: Database) -> Self {
+    pub fn with_database(client: tower_lsp_server::Client, database: Database) -> Self {
         Server { client, database: RwLock::new(database) }
     }
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Server {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         let capabilities = capabilities();

--- a/web/crates/browser/Cargo.toml
+++ b/web/crates/browser/Cargo.toml
@@ -5,7 +5,7 @@ name = "lsp-browser"
 version = "0.0.0"
 
 [features]
-default = ["tower-lsp/runtime-agnostic"]
+default = ["tower-lsp-server/runtime-agnostic"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 # async
 async-trait = "0.1"
 futures = "0.3"
-tower-lsp = { workspace = true }
+tower-lsp-server = { workspace = true }
 # web platform
 console_error_panic_hook = "0.1"
 js-sys = "0.3"

--- a/web/crates/browser/src/lib.rs
+++ b/web/crates/browser/src/lib.rs
@@ -3,7 +3,7 @@
 
 use driver::{FileSource, InMemorySource};
 use futures::stream::TryStreamExt;
-use tower_lsp::{LspService, Server};
+use tower_lsp_server::{LspService, Server};
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::stream::JsStream;
 


### PR DESCRIPTION
The fork has renamed the library from `tower-lsp` to `tower-lsp-server`.