### PR TITLE
Add CLI option to test lexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,6 +2509,7 @@ dependencies = [
  "log",
  "lsp-server",
  "miette",
+ "parser",
  "printer",
  "termsize",
  "thiserror",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -36,6 +36,7 @@ driver = { path = "../lang/driver" }
 elaborator = { path = "../lang/elaborator" }
 ast = { path = "../lang/ast" }
 printer = { path = "../lang/printer" }
+parser = { path = "../lang/parser" }
 lsp-server = { path = "../lang/lsp" }
 docs = { path = "../lang/docs" }
 

--- a/app/src/cli/lex.rs
+++ b/app/src/cli/lex.rs
@@ -1,0 +1,21 @@
+use std::{fs, path::PathBuf};
+
+use parser::lexer::Lexer;
+
+pub async fn exec(args: Args) -> miette::Result<()> {
+    let src = fs::read_to_string(&args.filepath).expect("Failed to read file");
+    let lexer = Lexer::new(&src);
+    for tok in lexer {
+        match tok {
+            Ok((p1, tok, p2)) => println!("{tok} at ({p1},{p2})"),
+            Err(err) => println!("{err}"),
+        }
+    }
+    Ok(())
+}
+
+#[derive(clap::Args)]
+pub struct Args {
+    #[clap(value_parser, value_name = "FILE")]
+    filepath: PathBuf,
+}

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod compile;
 mod doc;
 mod format;
 mod gen_completions;
+mod lex;
 mod lift;
 mod lsp;
 mod run;
@@ -36,6 +37,7 @@ pub fn exec() -> miette::Result<()> {
             Fmt(args) => format::exec(args).await,
             Texify(args) => texify::exec(args).await,
             Xfunc(args) => xfunc::exec(args).await,
+            Lex(args) => lex::exec(args).await,
             Lsp(args) => lsp::exec(args).await,
             Lift(args) => lift::exec(args).await,
             Doc(args) => doc::exec(args).await,
@@ -76,6 +78,9 @@ enum Command {
     /// Start an LSP server
     #[clap(hide(true))]
     Lsp(lsp::Args),
+    /// Lex a file and print the resulting token stream for debugging
+    #[clap(hide(true))]
+    Lex(lex::Args),
     /// Lift local (co)matches of a type to the top-level
     Lift(lift::Args),
     /// Generate documentation for a file

--- a/lang/parser/src/lib.rs
+++ b/lang/parser/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod cst;
 mod grammar;
-mod lexer;
+pub mod lexer;
 mod result;
 
 use lexer::Lexer;


### PR DESCRIPTION
Small CLI option to get the token stream for a file. Useful for working on the lexer or debugging lexing issues.
```console
david@edueeb6 polarity % pol lex std/codata/fun.pol
DocComment("-- | The type of non-dependent functions.\n") at (0,42)
Codata at (42,48)
Ident("Fun") at (49,52)
LParen at (52,53)
Ident("a") at (53,54)
Ident("b") at (55,56)
Colon at (56,57)
Ident("Type") at (58,62)
RParen at (62,63)
LBrace at (64,65)
DocComment("-- | Application of a function to its argument.\n") at (70,118)
Ident("Fun") at (122,125)
LParen at (125,126)
Ident("a") at (126,127)
Comma at (127,128)
Ident("b") at (129,130)
RParen at (130,131)
Dot at (131,132)
Ident("ap") at (132,134)
LParen at (134,135)
Implicit at (135,143)
Ident("a") at (144,145)
Ident("b") at (146,147)
Colon at (147,148)
Ident("Type") at (149,153)
Comma at (153,154)
Ident("x") at (155,156)
Colon at (156,157)
Ident("a") at (158,159)
RParen at (159,160)
Colon at (160,161)
Ident("b") at (162,163)
RBrace at (164,165)
DocComment("-- | The polymorphic identity function.\n") at (167,207)
Codef at (207,212)
Ident("Id") at (213,215)
LParen at (215,216)
Ident("a") at (216,217)
Colon at (217,218)
Ident("Type") at (219,223)
RParen at (223,224)
Colon at (224,225)
Ident("Fun") at (226,229)
LParen at (229,230)
Ident("a") at (230,231)
Comma at (231,232)
Ident("a") at (233,234)
RParen at (234,235)
LBrace at (236,237)
Dot at (238,239)
Ident("ap") at (239,241)
LParen at (241,242)
Underscore at (242,243)
Comma at (243,244)
Underscore at (245,246)
Comma at (246,247)
Ident("x") at (248,249)
RParen at (249,250)
DoubleRightArrow at (251,253)
Ident("x") at (254,255)
RBrace at (256,257)
```