### PR TITLE
Revisit lambda sugar for arbitrary SAM

### DIFF
--- a/examples/stlc.pol
+++ b/examples/stlc.pol
@@ -94,14 +94,14 @@ data Progress(e: Exp) {
 
 def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e) {
     Var(x) =>
-        \h_t. h_t.match {
+        \ap(_,_,h_t) => h_t.match {
             TVar(_, _, _, elem) => elem.empty_absurd(x, t).ex_falso(Progress(Var(x))),
             TLam(_, _, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd
         },
-    Lam(e) => \_. PVal(Lam(e), VLam(e)),
+    Lam(e) => \ap(_,_,_) => PVal(Lam(e), VLam(e)),
     App(e1, e2) =>
-        \h_t. h_t.match {
+        \ap(_,_,h_t) => h_t.match {
             TVar(_, _, _, _) absurd,
             TLam(_, _, _, _, _) absurd,
             TApp(_, t1, t2, _, _, e1_t, e2_t) =>
@@ -120,23 +120,23 @@ def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e) {
 def (e1: Exp).preservation(e2: Exp, t: Typ)
     : HasType(Nil, e1, t) -> Eval(e1, e2) -> HasType(Nil, e2, t) {
     Var(_) =>
-        \h_t. \h_eval. h_eval.match {
+        \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
             EBeta(_, _) absurd,
             ECongApp1(_, _, _, _) absurd,
             ECongApp2(_, _, _, _) absurd
         },
     Lam(_) =>
-        \h_t. \h_eval. h_eval.match {
+        \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
             EBeta(_, _) absurd,
             ECongApp1(_, _, _, _) absurd,
             ECongApp2(_, _, _, _) absurd
         },
     App(e1, e2) =>
-        \h_t. h_t.match {
+        \ap(_,_,h_t) => h_t.match {
             TVar(_, _, _, _) absurd,
             TLam(_, _, _, _, _) absurd,
             TApp(_, t1, t2, _, _, h_lam, h_e2) =>
-                \h_eval. h_eval.match {
+                \ap(_,_,h_eval) => h_eval.match {
                     ECongApp1(_, e1', h, _) =>
                         TApp(Nil,
                              t1,
@@ -183,7 +183,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                                                             e.subst(ctx1.len, by_e),
                                                                             t2) {
     Var(x) =>
-        \h_e. \h_by. h_e.match {
+        \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
             TLam(_, _, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TVar(_, _, _, h_elem) =>
@@ -284,7 +284,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                 }
         },
     Lam(body) =>
-        \h_e. \h_by. h_e.match {
+        \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
             TVar(_, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TLam(_, a, b, _, h_body) =>
@@ -303,7 +303,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                              h_by))
         },
     App(e1, e2) =>
-        \h_e. \h_by. h_e.match {
+        \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
             TVar(_, _, _, _) absurd,
             TLam(_, _, _, _, _) absurd,
             TApp(_, a, b, _, _, h_e1, h_e2) =>
@@ -336,14 +336,14 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
 def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ)
     : HasType(ctx1, e, t) -> HasType(ctx1.append(ctx2), e, t) {
     Nil =>
-        \h_e. ctx1.append_nil
+        \ap(_,_,h_e) => ctx1.append_nil
                   .transport(Ctx,
                              ctx1,
                              ctx1.append(Nil),
                              comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
                              h_e),
     Cons(t', ts) =>
-        \h_e. ctx1.append_assoc(Cons(t', Nil), ts)
+        \ap(_,_,h_e) => ctx1.append_assoc(Cons(t', Nil), ts)
                   .transport(Ctx,
                              ctx1.append(Cons(t', Nil)).append(ts),
                              ctx1.append(Cons(t', ts)),
@@ -360,14 +360,14 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ)
 def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
     : HasType(ctx, e, t2) -> HasType(ctx.append(Cons(t1, Nil)), e, t2) {
     Var(x) =>
-        \h_e. h_e.match {
+        \ap(_,_,h_e) => h_e.match {
             TLam(_, _, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TVar(_, _, _, h_elem) =>
                 TVar(ctx.append(Cons(t1, Nil)), x, t2, h_elem.elem_append(x, t1, t2, ctx))
         },
     Lam(e) =>
-        \h_e. h_e.match {
+        \ap(_,_,h_e) => h_e.match {
             TVar(_, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TLam(_, a, b, _, h_e) =>
@@ -381,7 +381,7 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
                           h_e))
         },
     App(e1, e2) =>
-        \h_e. h_e.match {
+        \ap(_,_,h_e) => h_e.match {
             TVar(_, _, _, _) absurd,
             TLam(_, _, _, _, _) absurd,
             TApp(_, a, b, _, _, h_e1, h_e2) =>
@@ -435,9 +435,9 @@ def Elem(Z, t1, Cons(t2, ctx)).elem_unique(ctx: Ctx, t1 t2: Typ): Eq(Typ, t2, t1
 
 def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ)
     : Elem(ctx1.len, t1, ctx1.append(Cons(t2, ctx2))) -> Eq(Typ, t2, t1) {
-    Nil => \h. h.elem_unique(ctx2, t1, t2),
+    Nil => \ap(_,_,h) => h.elem_unique(ctx2, t1, t2),
     Cons(t, ts) =>
-        \h. h.match {
+        \ap(_,_,h) => h.match {
             Here(_, _) absurd,
             There(_, _, _, _, h) =>
                 ts.ctx_lookup(ctx2, t1, t2)
@@ -448,12 +448,12 @@ def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ)
 def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
     : LE(S(x), ctx1.len) -> Elem(x, t, ctx1.append(ctx2)) -> Elem(x, t, ctx1) {
     Nil =>
-        \h_lt. \h_elem. h_lt.match {
+        \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_lt.match {
             LERefl(_) absurd,
             LESucc(_, _, _) absurd
         },
     Cons(t', ts) =>
-        \h_lt. \h_elem. h_elem.match {
+        \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_elem.match {
             Here(_, _) => Here(t, ts),
             There(x', _, _, _, h) =>
                 There(x',
@@ -473,7 +473,7 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
                                                                              t1,
                                                                              ctx1.append(ctx2)) {
     Nil =>
-        \h_gt. \h_elem. h_elem.match {
+        \ap(_,_,h_gt) => \ap(_,_,h_elem) => h_elem.match {
             Here(_, _) =>
                 h_gt.match {
                     LERefl(_) absurd,
@@ -482,7 +482,7 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
             There(_, _, _, _, h) => h
         },
     Cons(t, ts) =>
-        \h_gt. \h_elem. h_elem.match {
+        \ap(_,_,h_gt) => \ap(_,_,h_elem) => h_elem.match {
             Here(_, _) =>
                 h_gt.match {
                     LERefl(_) absurd,

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -547,26 +547,12 @@ impl Lower for cst::exp::Lam {
     type Target = ast::Exp;
 
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Lam { span, var, body } = self;
-
-        let case = cst::exp::Case {
-            span: *span,
-            pattern: cst::exp::Copattern {
-                span: *span,
-                name: Ident { span: *span, id: "ap".to_owned() },
-                params: vec![
-                    cst::exp::BindingSite::Wildcard { span: Default::default() },
-                    cst::exp::BindingSite::Wildcard { span: Default::default() },
-                    var.clone(),
-                ],
-            },
-            body: Some(body.clone()),
-        };
+        let cst::exp::Lam { span, case } = self;
         let comatch = cst::exp::Exp::LocalComatch(cst::exp::LocalComatch {
             span: *span,
             name: None,
             is_lambda_sugar: true,
-            cases: vec![case],
+            cases: vec![case.clone()],
         });
         comatch.lower(ctx)
     }

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -161,11 +161,12 @@ pub struct Fun {
 }
 
 #[derive(Debug, Clone)]
-/// Lambda abstractions (syntactic sugar), e.g. \x. e
+/// Syntactic sugar for codata types with only one observation.
+/// Java, for example, calls these "SAM-types", i.e. types with a "single abstract method".
+/// The standard example of this is the function type, which has the destructor "ap".
 pub struct Lam {
     pub span: Span,
-    pub var: BindingSite,
-    pub body: Box<Exp>,
+    pub case: Case<Copattern>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -207,6 +207,11 @@ Copattern: Copattern = {
   <l: @L> "." <name: Ident><params: OptTelescopeInst> <r: @R> => Copattern { span: span(l,r), name, params },
 }
 
+// In the syntactic sugar `\ap(x) => e` we do not need to parse the `.` in front of the identifier.
+CopatternLam: Copattern = {
+  <l: @L> <name: Ident><params: OptTelescopeInst> <r: @R> => Copattern { span: span(l,r), name, params },
+}
+
 Case<P> : Case<P> = {
     <l: @L> <pattern: P> <body: AbsurdOrBody> <r: @R> => Case { span: span(l, r), pattern, body },
 }
@@ -270,8 +275,8 @@ Anno: Anno = <l: @L> <exp: Ops> ":" <typ: Exp> <r: @R> =>
 Fun: Fun = <l: @L> <from: Ops> "->" <to: Exp> <r: @R> =>
   Fun { span: span(l, r), from, to };
 
-Lam: Lam = <l: @L> "\\" <var: BindingSite> "." <body: Exp> <r: @R> =>
-  Lam { span: span(l, r), var, body };
+Lam: Lam = <l: @L> "\\" <case: Case<CopatternLam>> <r: @R> =>
+  Lam { span: span(l, r), case };
 
 DotCall: DotCall = <l: @L> <exp: Ops> "." <name: Ident> <args: OptArgs> <r: @R> =>
   DotCall { span: span(l, r), exp, name, args };

--- a/test/suites/fail-check/Regr-403.expected
+++ b/test/suites/fail-check/Regr-403.expected
@@ -1,15 +1,15 @@
 T-002
 
   × The following terms are not equal:
-  │   1: Eq(<Bool -> Bool>, \x. T, \x. T)
-  │   2: Eq(a:=Bool -> Bool, \x. T, \x. F)
+  │   1: Eq(<Bool -> Bool>, \ap(_, _, x) => T, \ap(_, _, x) => T)
+  │   2: Eq(a:=Bool -> Bool, \ap(_, _, x) => T, \ap(_, _, x) => F)
   │ 
     ╭─[Regr-403.pol:6:29]
   5 │ #[transparent]
   6 │ let foo(y: Bool) : Fun(Bool, Bool)  {
     ·                             ────┬───
     ·                                 ╰── Source of (1)
-  7 │     \x. y
+  7 │     \ap(_,_,x) => y
   8 │ }
   9 │ 
  10 │ let proof: Eq(a := Fun(Bool, Bool), foo(T), foo(F)) {

--- a/test/suites/fail-check/Regr-403.pol
+++ b/test/suites/fail-check/Regr-403.pol
@@ -4,7 +4,7 @@ use "../../../std/codata/fun.pol"
 
 #[transparent]
 let foo(y: Bool) : Fun(Bool, Bool)  {
-    \x. y
+    \ap(_,_,x) => y
 }
 
 let proof: Eq(a := Fun(Bool, Bool), foo(T), foo(F)) {

--- a/test/suites/success/008.pol
+++ b/test/suites/success/008.pol
@@ -5,5 +5,5 @@ codata Fun(a: Type, b: Type) {
 data Top { Unit }
 
 def Top.id(a: Type): a -> a {
-    Unit => \x.x
+    Unit => \ap(_,_,x) => x
 }

--- a/test/suites/success/009.pol
+++ b/test/suites/success/009.pol
@@ -22,7 +22,7 @@ data Top { Unit }
 
 def (self: Exp).preservation(e2: Exp): Fun(Eval(self, e2), HasType(e2))
 {
-    App(e) => \h_eval.
+    App(e) => \ap(_,_,h_eval) =>
         h_eval.match {
             EBeta(f) => ? : HasType(e)
         }

--- a/test/suites/success/010.pol
+++ b/test/suites/success/010.pol
@@ -22,7 +22,7 @@ data Top { Unit }
 
 def (self: Exp).preservation(e2: Exp): Fun(Eval(self, e2), HasType(e2))
 {
-    App(e) => \h_eval.
+    App(e) => \ap(_,_,h_eval) =>
         h_eval.match {
             EBeta(f) => ? : HasType(e.id)
         }

--- a/test/suites/success/035-stlc-bool.pol
+++ b/test/suites/success/035-stlc-bool.pol
@@ -89,15 +89,15 @@ data Progress(e: Exp) {
 
 def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e)
 {
-    Var(x) => \h_t. h_t.match {
+    Var(x) => \ap(_,_,h_t) => h_t.match {
         TVar(_, _, _, elem) => elem.empty_absurd(x, t).elim_bot(Progress(Var(x))),
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TLit(_, _) absurd,
         TIf(_, _, _, _, _, _, _, _) absurd,
     },
-    Lam(e) => \_. PVal(Lam(e), VLam(e)),
-    App(e1, e2) => \h_t.
+    Lam(e) => \ap(_,_,_) => PVal(Lam(e), VLam(e)),
+    App(e1, e2) => \ap(_,_,h_t) =>
         h_t.match {
             TVar(_, _, _, _) absurd,
             TLam(_, _, _, _, _) absurd,
@@ -118,8 +118,8 @@ def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e)
                     }
                 }
         },
-    Lit(b) => \_. PVal(Lit(b), VLit(b)),
-    If(cond, then, else) => \h_e. h_e.match {
+    Lit(b) => \ap(_,_,_) => PVal(Lit(b), VLit(b)),
+    If(cond, then, else) => \ap(_,_,h_e) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
@@ -152,7 +152,7 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
     -> Eval(e1, e2)
     -> HasType(Nil, e2, t)
 {
-    Var(_) => \h_t. \h_eval. h_eval.match {
+    Var(_) => \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
         EBeta(_, _) absurd,
         ECongApp1(_, _, _, _) absurd,
         ECongApp2(_, _, _, _) absurd,
@@ -160,7 +160,7 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
         EIfTrue(_, _) absurd,
         EIfFalse(_, _) absurd,
     },
-    Lam(_) => \h_t. \h_eval. h_eval.match {
+    Lam(_) => \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
         EBeta(_, _) absurd,
         ECongApp1(_, _, _, _) absurd,
         ECongApp2(_, _, _, _) absurd,
@@ -168,12 +168,12 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
         EIfTrue(_, _) absurd,
         EIfFalse(_, _) absurd,
     },
-    App(e1, e2) => \h_t. h_t.match {
+    App(e1, e2) => \ap(_,_,h_t) => h_t.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TLit(_, _) absurd,
         TIf(_, _, _, _, _, _, _, _) absurd,
-        TApp(_, t1, t2, _, _, h_lam, h_e2) => \h_eval. h_eval.match {
+        TApp(_, t1, t2, _, _, h_lam, h_e2) => \ap(_,_,h_eval) => h_eval.match {
             ECongIf(_, _, _, _, _) absurd,
             EIfTrue(_, _) absurd,
             EIfFalse(_, _) absurd,
@@ -226,7 +226,7 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
             },
         }
     },
-    Lit(b) => \h_t. \h_eval. h_eval.match {
+    Lit(b) => \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
         EBeta(_, _) absurd,
         ECongApp1(_, _, _, _) absurd,
         ECongApp2(_, _, _, _) absurd,
@@ -234,7 +234,7 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
         EIfTrue(_, _) absurd,
         EIfFalse(_, _) absurd,
     },
-    If(cond, then, else) => \h_t. \h_eval. h_t.match {
+    If(cond, then, else) => \ap(_,_,h_t) => \ap(_,_,h_eval) => h_t.match {
         TVar(_, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -271,7 +271,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
     -> HasType(Nil, by_e, t1)
     -> HasType(ctx1.append(ctx2), e.subst(ctx1.len, by_e), t2)
 {
-    Var(x) => \h_e. \h_by. h_e.match {
+    Var(x) => \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
             TLam(_, _, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TLit(_, _) absurd,
@@ -334,7 +334,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                 )
         }
     },
-    Lam(body) => \h_e. \h_by. h_e.match {
+    Lam(body) => \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
         TVar(_, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -353,7 +353,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                 )
         ),
     },
-    App(e1, e2) => \h_e. \h_by. h_e.match {
+    App(e1, e2) => \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -386,14 +386,14 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                 ),
         ),
     },
-    Lit(b) => \h_e. \h_by. h_e.match {
+    Lit(b) => \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TIf(_, _, _, _, _, _, _, _) absurd,
         TLit(_, _) => TLit(ctx1.append(ctx2), b),
     },
-    If(cond, then, else) => \h_e. \h_by. h_e.match {
+    If(cond, then, else) => \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
@@ -442,13 +442,13 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
 }
 
 def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) -> HasType(ctx1.append(ctx2), e, t) {
-    Nil => \h_e. ctx1.append_nil
+    Nil => \ap(_,_,h_e) => ctx1.append_nil
         .transport(
             Ctx, ctx1, ctx1.append(Nil),
             comatch { .ap(_, _, ctx) => HasType(ctx, e, t) },
             h_e
         ),
-    Cons(t', ts) => \h_e.
+    Cons(t', ts) => \ap(_,_,h_e) =>
         ctx1.append_assoc(Cons(t', Nil), ts)
             .transport(
                 Ctx,
@@ -469,7 +469,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ): HasType(ctx1, e, t) ->
 }
 
 def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ): HasType(ctx, e, t2) -> HasType(ctx.append(Cons(t1, Nil)), e, t2) {
-    Var(x) => \h_e. h_e.match {
+    Var(x) => \ap(_,_,h_e) => h_e.match {
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -479,7 +479,7 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ): HasType(ctx, e, t2) -> HasType(c
             h_elem.elem_append(x, t1, t2, ctx)
         ),
     },
-    Lam(e) => \h_e. h_e.match {
+    Lam(e) => \ap(_,_,h_e) => h_e.match {
         TVar(_, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -494,7 +494,7 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ): HasType(ctx, e, t2) -> HasType(c
                 )
         ),
     },
-    App(e1, e2) => \h_e. h_e.match {
+    App(e1, e2) => \ap(_,_,h_e) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TLit(_, _) absurd,
@@ -515,14 +515,14 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ): HasType(ctx, e, t2) -> HasType(c
                 ),
         ),
     },
-    Lit(b) => \h_e. h_e.match {
+    Lit(b) => \ap(_,_,h_e) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
         TIf(_, _, _, _, _, _, _, _) absurd,
         TLit(_, _) => TLit(ctx.append(Cons(t1, Nil)), b),
     },
-    If(cond, then, else) => \h_e. h_e.match {
+    If(cond, then, else) => \ap(_,_,h_e) => h_e.match {
         TVar(_, _, _, _) absurd,
         TLam(_, _, _, _, _) absurd,
         TApp(_, _, _, _, _, _, _) absurd,
@@ -582,8 +582,8 @@ def Elem(0, t1, Cons(t2, ctx)).elem_unique(ctx: Ctx, t1 t2: Typ): Eq(Typ, t2, t1
 }
 
 def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ): Elem(ctx1.len, t1, ctx1.append(Cons(t2, ctx2))) -> Eq(Typ, t2, t1) {
-    Nil => \h. h.elem_unique(ctx2, t1, t2),
-    Cons(t, ts) => \h. h.match {
+    Nil => \ap(_,_,h) => h.elem_unique(ctx2, t1, t2),
+    Cons(t, ts) => \ap(_,_,h) => h.match {
         Here(_, _) absurd,
         There(_, _, _, _, h) => ts.ctx_lookup(ctx2, t1, t2)
             .ap(
@@ -597,11 +597,11 @@ def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ): Elem(ctx1.len, t1, ctx1.appen
 def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
     : LE(S(x), ctx1.len) -> Elem(x, t, ctx1.append(ctx2)) -> Elem(x, t, ctx1)
 {
-    Nil => \h_lt. \h_elem. h_lt.match {
+    Nil => \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_lt.match {
         LERefl(_) absurd,
         LESucc(_, _, _) absurd,
     },
-    Cons(t', ts) => \h_lt. \h_elem. h_elem.match {
+    Cons(t', ts) => \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_elem.match {
         Here(_, _) => Here(t, ts),
         There(x', _, _, _, h) => There(
             x', t, t', ts,
@@ -623,14 +623,14 @@ def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
 def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
     : LE(S(ctx1.len), x) -> Elem(x, t1, ctx1.append(Cons(t2, ctx2))) -> Elem(x.pred, t1, ctx1.append(ctx2))
 {
-    Nil => \h_gt. \h_elem. h_elem.match {
+    Nil => \ap(_,_,h_gt) => \ap(_,_,h_elem) => h_elem.match {
         Here(_, _) => h_gt.match {
             LERefl(_) absurd,
             LESucc(_, _, _) absurd,
         },
         There(_, _, _, _, h) => h,
     },
-    Cons(t, ts) => \h_gt. \h_elem. h_elem.match {
+    Cons(t, ts) => \ap(_,_,h_gt) => \ap(_,_,h_elem) => h_elem.match {
         Here(_, _) => h_gt.match {
             LERefl(_) absurd,
             LESucc(_, _, _) absurd,

--- a/test/suites/success/036-webserver.pol
+++ b/test/suites/success/036-webserver.pol
@@ -65,14 +65,14 @@ codata Route {
     (self: Route).post: State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),
     (self: Route).put(n : Nat): State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),
     (self: Route).put_idempotent(n : Nat) : Π(State(self.requiresLogin),
-        \state. Eq(×₋(State(self.requiresLogin), Response), self.put(n).ap(State(self.requiresLogin), ×₋(State(self.requiresLogin), Response), state), MkUtils.put_twice(n, self, state)))
+        \ap(_,_,state) => Eq(×₋(State(self.requiresLogin), Response), self.put(n).ap(State(self.requiresLogin), ×₋(State(self.requiresLogin), Response), state), MkUtils.put_twice(n, self, state)))
 }
 
 codef Index: Route {
     .requiresLogin => F,
-    .post => \state. comatch { .fst(a,b) => state, .snd(a,b) => Forbidden },
-    .get => \state. Return(state.counter(F)),
-    .put(n) => \state. Pair(State(F), Response, state, Forbidden),
+    .post => \ap(_,_,state) => comatch { .fst(a,b) => state, .snd(a,b) => Forbidden },
+    .get => \ap(_,_,state) => Return(state.counter(F)),
+    .put(n) => \ap(_,_,state) => Pair(State(F), Response, state, Forbidden),
     .put_idempotent(n) => comatch {
         .dap(_, _, state) => Refl(×₋(State(F), Response), Pair(State(F), Response, state, Forbidden))
     }
@@ -80,9 +80,9 @@ codef Index: Route {
 
 codef Admin: Route {
     .requiresLogin => T,
-    .post => \state. comatch { .fst(a,b) => state.increment, .snd(a,b) => Return(state.increment.counter(T)) },
-    .get => \state. Return(state.counter(T)),
-    .put(n) => \state. Pair(State(T), Response, state.set(n), Return(n)),
+    .post => \ap(_,_,state) => comatch { .fst(a,b) => state.increment, .snd(a,b) => Return(state.increment.counter(T)) },
+    .get => \ap(_,_,state) => Return(state.counter(T)),
+    .put(n) => \ap(_,_,state) => Pair(State(T), Response, state.set(n), Return(n)),
     .put_idempotent(n) => comatch {
         .dap(_, _, state) => state.set_idempotent(T, n).cong_pair(State(T), Response, state.set(n), state.set(n).set(n), Return(n))
     }

--- a/test/suites/success/040-absurd-lam.pol
+++ b/test/suites/success/040-absurd-lam.pol
@@ -1,0 +1,7 @@
+data Bool { T, F }
+
+codata Foo(b: Bool) {
+    Foo(T).d(x: Bool): Bool
+}
+
+let example: Foo(F) {\d(_) absurd}

--- a/test/suites/success/Regr-341a.pol
+++ b/test/suites/success/Regr-341a.pol
@@ -13,5 +13,5 @@ let foo(t: Type, x: Fun(t, Type)): Type {
 }
 
 let T : Type {
-    foo(F.ap(Type, Type, (? : Type)), \x. F.ap(Type, Type, x))
+    foo(F.ap(Type, Type, (? : Type)), \ap(_,_,x) => F.ap(Type, Type, x))
 }

--- a/test/suites/success/Regr-403.pol
+++ b/test/suites/success/Regr-403.pol
@@ -4,7 +4,7 @@ use "../../../std/codata/fun.pol"
 
 #[transparent]
 let foo : Fun(Bool, Bool)  {
-    \x. x
+    \ap(_,_,x) => x
 }
 
 let proof: Eq(a := Fun(Bool, Bool), foo, foo) {


### PR DESCRIPTION
Before this PR we have syntactic sugar for lambda abstractions which looks like `\x. e` and is desugared to `cocase { ap(_,_,x) => e }`. The downside of this approach is that we bake in the dependency on one specific codata type `Fun` with one specific destructor `ap`. But this kind of sugar would also be useful for other codata types with exactly one destructor, for example `Pi` with its destructor `dap`.

This PR changes the syntax sugar to allow `\d(args) => e` which is desugared to `cocase { d(args) => e }`. For the function type this results in `\ap(_,_,x) => e`, but as soon as we allow to omit implicit arguments in patterns we can write this as `\ap(x) => e` which is reasonably short.

As soon as we have nested patterns, we can also allow, for example `\ap(Tup(x,y)) => e`...

(SAM stands for "single abstract method", which is what Java calls the kind of classes and interfaces for which you can use lambda abstraction sugar)