### PR TITLE
Add lexer for operators

### DIFF
--- a/examples/strong_existentials.pol
+++ b/examples/strong_existentials.pol
@@ -20,16 +20,16 @@
 // products `A × B` consisting of an element of type `A` and an element
 // of type `B`. As a datatype it can be written as follows:
 
-data ×₊(A B: Type) {
-  Sum(A B: Type, x: A, y: B): ×₊(A,B)
+data Tensor(A B: Type) {
+  Sum(A B: Type, x: A, y: B): Tensor(A,B)
 }
 
 // Using the negative polarization, the product is specified using the two
 // projections on the first and second element:
 
-codata ×₋(A B: Type) {
-  ×₋(A,B).π₁(A B: Type): A,
-  ×₋(A,B).π₂(A B: Type): B
+codata With(A B: Type) {
+  With(A,B).π₁(A B: Type): A,
+  With(A,B).π₂(A B: Type): B
 }
 
 //
@@ -49,21 +49,21 @@ codata Fun(A B: Type) {
 // us to use the notation `A -> B` instead of `Fun(A,B)`.
 
 // The existential type can be represented using a data type with one constructor
-// `∃Sum`. This constructor takes as arguments the function `T` of type `Type -> Type`,
+// `ExistsSum`. This constructor takes as arguments the function `T` of type `Type -> Type`,
 // a type `A` and a witness `W` of type `T.ap(Type,Type,A)` which corresponds to `T[A/X]`
 // in more standard notation.
 
-data ∃₊(T: Type -> Type) {
-  ∃Sum(T: Type -> Type, A: Type, W: T.ap(Type,Type,A)): ∃₊(T)
+data ExistsPos(T: Type -> Type) {
+  ExistsSum(T: Type -> Type, A: Type, W: T.ap(Type,Type,A)): ExistsPos(T)
 }
 
 // As a codata type, we still have two projections `eπ₁`and `eπ₂` as in the case
 // of non-dependent products. But the second projection now uses the self-parameter
 // to guarantee that an element of type `T[self.eπ₁/X]` is returned.
 
-codata ∃₋(T: Type -> Type) {
-  ∃₋(T).eπ₁(T: Type -> Type): Type,
-  (self: ∃₋(T)).eπ₂(T: Type -> Type): T.ap(Type,Type, self.eπ₁(T))
+codata ExistsNeg(T: Type -> Type) {
+  ExistsNeg(T).eπ₁(T: Type -> Type): Type,
+  (self: ExistsNeg(T)).eπ₂(T: Type -> Type): T.ap(Type,Type, self.eπ₁(T))
 }
 
 //
@@ -76,25 +76,25 @@ codata ∃₋(T: Type -> Type) {
 // existentials, except that the type constructor `Σ` is now indexed over both a
 // type `A` and a type family `T: A -> Type`.
 
-data Σ₊(A: Type, T: A -> Type) {
-  ΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A,Type,x)): Σ₊(A,T)
+data ΣPos(A: Type, T: A -> Type) {
+  ΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A,Type,x)): ΣPos(A,T)
 }
 
-def Σ₊(A,T).defπ₁(A: Type, T: A -> Type): A {
+def ΣPos(A,T).defπ₁(A: Type, T: A -> Type): A {
   ΣSum(_,_,x,_) => x
 }
 
-def (self: Σ₊(A,T)).defπ₂(A: Type, T: A -> Type): T.ap(A,Type,self.defπ₁(A,T)) {
+def (self: ΣPos(A,T)).defπ₂(A: Type, T: A -> Type): T.ap(A,Type,self.defπ₁(A,T)) {
   ΣSum(_,_,_,w) => w
 }
 
 
-codata Σ₋(A: Type, T: A -> Type) {
-  Σ₋(A,T).sπ₁(A: Type, T: A -> Type): A,
-  (self: Σ₋(A,T)).sπ₂(A: Type, T: A -> Type): T.ap(A,Type, self.sπ₁(A,T))
+codata ΣNeg(A: Type, T: A -> Type) {
+  ΣNeg(A,T).sπ₁(A: Type, T: A -> Type): A,
+  (self: ΣNeg(A,T)).sπ₂(A: Type, T: A -> Type): T.ap(A,Type, self.sπ₁(A,T))
 }
 
-codef DefΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A, Type, x)): Σ₋(A,T) {
+codef DefΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A, Type, x)): ΣNeg(A,T) {
   .sπ₁(_,_) => x,
   .sπ₂(_,_) => w
 }

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -527,10 +527,12 @@ impl Lower for cst::exp::NatLit {
 impl Lower for cst::exp::BinOp {
     type Target = ast::Exp;
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::BinOp { span, symbol, lhs, rhs } = self;
-        if symbol != "->" {
-            let err =
-                LoweringError::UnknownOperator { span: span.to_miette(), operator: symbol.clone() };
+        let cst::exp::BinOp { span, operator, lhs, rhs } = self;
+        if operator.id != "->" {
+            let err = LoweringError::UnknownOperator {
+                span: operator.span.to_miette(),
+                operator: operator.id.clone(),
+            };
             return Err(err);
         }
         let (_, uri) = ctx.symbol_table.lookup(&Ident { span: *span, id: "Fun".to_owned() })?;

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -35,7 +35,7 @@ impl Lower for cst::exp::Exp {
             cst::exp::Exp::LocalComatch(e) => e.lower(ctx),
             cst::exp::Exp::Hole(e) => e.lower(ctx),
             cst::exp::Exp::NatLit(e) => e.lower(ctx),
-            cst::exp::Exp::Fun(e) => e.lower(ctx),
+            cst::exp::Exp::BinOp(e) => e.lower(ctx),
             cst::exp::Exp::Lam(e) => e.lower(ctx),
         }
     }
@@ -524,18 +524,23 @@ impl Lower for cst::exp::NatLit {
     }
 }
 
-impl Lower for cst::exp::Fun {
+impl Lower for cst::exp::BinOp {
     type Target = ast::Exp;
     fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Fun { span, from, to } = self;
+        let cst::exp::BinOp { span, symbol, lhs, rhs } = self;
+        if symbol != "->" {
+            let err =
+                LoweringError::UnknownOperator { span: span.to_miette(), operator: symbol.clone() };
+            return Err(err);
+        }
         let (_, uri) = ctx.symbol_table.lookup(&Ident { span: *span, id: "Fun".to_owned() })?;
         Ok(ast::TypCtor {
             span: Some(*span),
             name: ast::IdBound { span: Some(*span), id: "Fun".to_owned(), uri: uri.clone() },
             args: ast::Args {
                 args: vec![
-                    ast::Arg::UnnamedArg { arg: from.lower(ctx)?, erased: false },
-                    ast::Arg::UnnamedArg { arg: to.lower(ctx)?, erased: false },
+                    ast::Arg::UnnamedArg { arg: lhs.lower(ctx)?, erased: false },
+                    ast::Arg::UnnamedArg { arg: rhs.lower(ctx)?, erased: false },
                 ],
             },
         }

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -107,6 +107,13 @@ pub enum LoweringError {
         #[label]
         span: SourceSpan,
     },
+    #[error("Unknown operator: {operator}")]
+    #[diagnostic(code("L-017"))]
+    UnknownOperator {
+        #[label]
+        span: SourceSpan,
+        operator: String,
+    },
     #[error("An unexpected internal error occurred: {message}")]
     #[diagnostic(code("L-XXX"))]
     /// This error should not occur.

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -156,7 +156,7 @@ pub struct NatLit {
 /// Binary Operator, e.g. `e -> e` or `e + e`.
 pub struct BinOp {
     pub span: Span,
-    pub symbol: String,
+    pub operator: Operator,
     pub lhs: Box<Exp>,
     pub rhs: Box<Exp>,
 }

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -67,7 +67,7 @@ pub enum Exp {
     LocalComatch(LocalComatch),
     Hole(Hole),
     NatLit(NatLit),
-    Fun(Fun),
+    BinOp(BinOp),
     Lam(Lam),
 }
 
@@ -81,7 +81,7 @@ impl Exp {
             Exp::LocalComatch(local_comatch) => local_comatch.span,
             Exp::Hole(hole) => hole.span,
             Exp::NatLit(nat_lit) => nat_lit.span,
-            Exp::Fun(fun) => fun.span,
+            Exp::BinOp(binop) => binop.span,
             Exp::Lam(lam) => lam.span,
         }
     }
@@ -153,11 +153,12 @@ pub struct NatLit {
 }
 
 #[derive(Debug, Clone)]
-/// Function arrow (syntactic sugar), e.g. a -> b
-pub struct Fun {
+/// Binary Operator, e.g. `e -> e` or `e + e`.
+pub struct BinOp {
     pub span: Span,
-    pub from: Box<Exp>,
-    pub to: Box<Exp>,
+    pub symbol: String,
+    pub lhs: Box<Exp>,
+    pub rhs: Box<Exp>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/cst/ident.rs
+++ b/lang/parser/src/cst/ident.rs
@@ -8,3 +8,11 @@ pub struct Ident {
     pub span: Span,
     pub id: String,
 }
+
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+pub struct Operator {
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    pub span: Span,
+    pub id: String,
+}

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -272,8 +272,8 @@ pub Atom: Box<Exp> = {
 Anno: Anno = <l: @L> <exp: Ops> ":" <typ: Exp> <r: @R> =>
   Anno { span: span(l, r), exp, typ };
 
-BinOp: BinOp = <l: @L> <lhs: Ops> <s: "Operator"> <rhs: Exp> <r: @R> =>
-  BinOp { span: span(l, r), symbol: s.to_owned(), lhs, rhs };
+BinOp: BinOp = <l: @L> <lhs: Ops> <operator: Operator> <rhs: Exp> <r: @R> =>
+  BinOp { span: span(l, r), operator, lhs, rhs };
 
 Lam: Lam = <l: @L> "\\" <case: Case<CopatternLam>> <r: @R> =>
   Lam { span: span(l, r), case };
@@ -318,4 +318,8 @@ BindingSite: BindingSite = {
 
 Ident: Ident = {
    <l: @L> <i: "Identifier"> <r: @R> => Ident { span: span(l,r), id: i.to_owned() }
+}
+
+Operator: Operator = {
+  <l: @L> <i: "Operator"> <r: @R> => Operator { span: span(l,r), id: i.to_owned() }
 }

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -51,7 +51,6 @@ extern {
     ":" => Token::Colon,
     "." => Token::Dot,
     "?" => Token::QuestionMark,
-    "->" => Token::RightArrow,
     "\\" => Token::Backslash,
     "#" => Token::Hash,
     "_" => Token::Underscore,
@@ -60,6 +59,7 @@ extern {
     //
     //
     "Identifier" => Token::Ident(<String>),
+    "Operator" => Token::Operator(<String>),
 
     // Literals
     //
@@ -237,7 +237,7 @@ pub TypApp: Call = {
 
 pub Exp: Box<Exp> = {
     <e: Anno> => Box::new(Exp::Anno(e)),
-    <e: Fun> => Box::new(Exp::Fun(e)),
+    <e: BinOp> => Box::new(Exp::BinOp(e)),
     <e: Lam> => Box::new(Exp::Lam(e)),
     Ops,
 }
@@ -272,8 +272,8 @@ pub Atom: Box<Exp> = {
 Anno: Anno = <l: @L> <exp: Ops> ":" <typ: Exp> <r: @R> =>
   Anno { span: span(l, r), exp, typ };
 
-Fun: Fun = <l: @L> <from: Ops> "->" <to: Exp> <r: @R> =>
-  Fun { span: span(l, r), from, to };
+BinOp: BinOp = <l: @L> <lhs: Ops> <s: "Operator"> <rhs: Exp> <r: @R> =>
+  BinOp { span: span(l, r), symbol: s.to_owned(), lhs, rhs };
 
 Lam: Lam = <l: @L> "\\" <case: Case<CopatternLam>> <r: @R> =>
   Lam { span: span(l, r), case };

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -84,8 +84,6 @@ pub enum Token {
     Dot,
     #[token("?")]
     QuestionMark,
-    #[token("->")]
-    RightArrow,
     #[token("\\")]
     Backslash,
     #[token("#")]
@@ -98,12 +96,19 @@ pub enum Token {
     // We use the following unicode categories:
     // Ll = lowercase letter
     // Lu = uppercase letter
-    // Sm = math symbol
     // No = other numbers (includes subscripts and superscript numerals)
     // ' is contained in the category Po (Punctuation other)
     // _ is contained in the category Pc (Punctuation connector)
-    #[regex(r"[\p{Ll}\p{Lu}\p{Sm}][\p{Ll}\p{Lu}\p{Sm}\p{No}0-9_']*", |lex| lex.slice().to_string())]
+    #[regex(r"[\p{Ll}\p{Lu}][\p{Ll}\p{Lu}\p{No}0-9_']*", |lex| lex.slice().to_string())]
     Ident(String),
+
+    // Operators
+    //
+    // We use the following unicode categories:
+    // Pd = Dash Punctuation
+    // Sm = math symbol
+    #[regex(r"[\p{Pd}\p{Sm}][\p{Pd}\p{Sm}]*", |lex| lex.slice().to_string())]
+    Operator(String),
 
     // Literals
     //

--- a/test/suites/fail-lower/L-017.expected
+++ b/test/suites/fail-lower/L-017.expected
@@ -1,0 +1,8 @@
+L-017
+
+  × Unknown operator: +++
+   ╭─[L-017.pol:3:25]
+ 2 │ 
+ 3 │ let f(x: Bool) : Bool { x +++ x}
+   ·                         ───────
+   ╰────

--- a/test/suites/fail-lower/L-017.expected
+++ b/test/suites/fail-lower/L-017.expected
@@ -1,8 +1,8 @@
 L-017
 
   × Unknown operator: +++
-   ╭─[L-017.pol:3:25]
+   ╭─[L-017.pol:3:27]
  2 │ 
  3 │ let f(x: Bool) : Bool { x +++ x}
-   ·                         ───────
+   ·                           ───
    ╰────

--- a/test/suites/fail-lower/L-017.pol
+++ b/test/suites/fail-lower/L-017.pol
@@ -1,0 +1,3 @@
+data Bool { T, F }
+
+let f(x: Bool) : Bool { x +++ x}

--- a/test/suites/fail-parse/P-003.expected
+++ b/test/suites/fail-parse/P-003.expected
@@ -1,6 +1,6 @@
 P-002
 
-  × Unexpected end of file. Expected "(", ")", ",", "->", ".", ":", ":=", "=>", "Identifier", "_", "absurd", "as", "{", "}"
+  × Unexpected end of file. Expected "(", ")", ",", ".", ":", ":=", "=>", "Identifier", "Operator", "_", "absurd", "as", "{", "}"
    ╭─[P-003.pol:1:9]
  1 │ data foo
    ╰────

--- a/test/suites/success/036-webserver.pol
+++ b/test/suites/success/036-webserver.pol
@@ -13,12 +13,12 @@ codata Π(A: Type, T: Fun(A, Type)) {
   Π(A,T).dap(A: Type, T: Fun(A,Type), x: A): T.ap(A,Type,x)
 }
 
-codata ×₋(a b : Type) {
-    ×₋(a,b).fst(a : Type, b: Type) : a,
-    ×₋(a,b).snd(a : Type, b: Type) : b
+codata With(a b : Type) {
+    With(a,b).fst(a : Type, b: Type) : a,
+    With(a,b).snd(a : Type, b: Type) : b
 }
 
-codef Pair(a b : Type, x : a, y : b) : ×₋(a,b) {
+codef Pair(a b : Type, x : a, y : b) : With(a,b) {
     .fst(a,b) => x,
     .snd(a,b) => y
 }
@@ -43,29 +43,29 @@ codata State(loggedIn: Bool) {
 }
 
 codata Utils {
-    .put_twice(n: Nat, route: Route, state: State(route.requiresLogin)): ×₋(State(route.requiresLogin), Response)
+    .put_twice(n: Nat, route: Route, state: State(route.requiresLogin)): With(State(route.requiresLogin), Response)
 }
 
 codef MkUtils: Utils {
     .put_twice(n, route, state) =>
-        route.put(n).ap(State(route.requiresLogin), ×₋(State(route.requiresLogin), Response), route.put(n).ap(State(route.requiresLogin), ×₋(State(route.requiresLogin), Response), state).fst(State(route.requiresLogin), Response))
+        route.put(n).ap(State(route.requiresLogin), With(State(route.requiresLogin), Response), route.put(n).ap(State(route.requiresLogin), With(State(route.requiresLogin), Response), state).fst(State(route.requiresLogin), Response))
 }
 
 data Eq(t : Type, a: t, b: t) {
     Refl(t : Type, a : t) : Eq(t, a, a)
 }
 
-def Eq(t1, a, b).cong_pair(t1 t2: Type, a b: t1, c: t2): Eq(×₋(t1, t2), Pair(t1, t2, a, c), Pair(t1, t2, b, c)) {
-    Refl(_, _) => Refl(×₋(t1, t2), Pair(t1, t2, b, c))
+def Eq(t1, a, b).cong_pair(t1 t2: Type, a b: t1, c: t2): Eq(With(t1, t2), Pair(t1, t2, a, c), Pair(t1, t2, b, c)) {
+    Refl(_, _) => Refl(With(t1, t2), Pair(t1, t2, b, c))
 }
 
 codata Route {
     .requiresLogin: Bool,
     (self: Route).get: State(self.requiresLogin) -> Response,
-    (self: Route).post: State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),
-    (self: Route).put(n : Nat): State(self.requiresLogin) -> ×₋(State(self.requiresLogin),Response),
+    (self: Route).post: State(self.requiresLogin) -> With(State(self.requiresLogin),Response),
+    (self: Route).put(n : Nat): State(self.requiresLogin) -> With(State(self.requiresLogin),Response),
     (self: Route).put_idempotent(n : Nat) : Π(State(self.requiresLogin),
-        \ap(_,_,state) => Eq(×₋(State(self.requiresLogin), Response), self.put(n).ap(State(self.requiresLogin), ×₋(State(self.requiresLogin), Response), state), MkUtils.put_twice(n, self, state)))
+        \ap(_,_,state) => Eq(With(State(self.requiresLogin), Response), self.put(n).ap(State(self.requiresLogin), With(State(self.requiresLogin), Response), state), MkUtils.put_twice(n, self, state)))
 }
 
 codef Index: Route {
@@ -74,7 +74,7 @@ codef Index: Route {
     .get => \ap(_,_,state) => Return(state.counter(F)),
     .put(n) => \ap(_,_,state) => Pair(State(F), Response, state, Forbidden),
     .put_idempotent(n) => comatch {
-        .dap(_, _, state) => Refl(×₋(State(F), Response), Pair(State(F), Response, state, Forbidden))
+        .dap(_, _, state) => Refl(With(State(F), Response), Pair(State(F), Response, state, Forbidden))
     }
 }
 

--- a/test/suites/success/Regr-250.ir.expected
+++ b/test/suites/success/Regr-250.ir.expected
@@ -1,4 +1,4 @@
-codef Unit₋ {
-    .typeAt₋(x, x0) absurd,
-    .dataAt₋(x, x0) absurd
+codef Unit {
+    .typeAt(x, x0) absurd,
+    .dataAt(x, x0) absurd
 }

--- a/test/suites/success/Regr-250.pol
+++ b/test/suites/success/Regr-250.pol
@@ -1,19 +1,19 @@
-data ℕ {
+data Nat {
     Z,
-    S(n: ℕ),
+    S(n: Nat),
 }
 
-data Fin(max: ℕ) {
-    FZ(max: ℕ): Fin(max),
-    FS(max: ℕ, val: Fin(max)): Fin(S(max)),
+data Fin(max: Nat) {
+    FZ(max: Nat): Fin(max),
+    FS(max: Nat, val: Fin(max)): Fin(S(max)),
 }
 
-codata Product₋(arity: ℕ) {
-    Product₋(S(arity)).typeAt₋(arity: ℕ, pos: Fin(arity)): Type,
-    (self: Product₋(S(arity))).dataAt₋(arity: ℕ, pos: Fin(arity)): self.typeAt₋(arity, pos),
+codata ProductN(arity: Nat) {
+    ProductN(S(arity)).typeAt(arity: Nat, pos: Fin(arity)): Type,
+    (self: ProductN(S(arity))).dataAt(arity: Nat, pos: Fin(arity)): self.typeAt(arity, pos),
 }
 
-codef Unit₋: Product₋(0) {
-    .typeAt₋(_, _) absurd,
-    .dataAt₋(_, _) absurd,
+codef Unit: ProductN(0) {
+    .typeAt(_, _) absurd,
+    .dataAt(_, _) absurd,
 }


### PR DESCRIPTION
Modify the lexer so that we have separate productions for identifiers and operators. I am not sure which other Unicode categories we might want to add for operators, but `Sm` is already quite big, and contains most of the mathy stuff. In order to make operators distinct from identifiers I removed `Sm` from the syntax of identifiers. An alternative would be to not allow identifiers to *start* with a character from the `Sm` set.