### PR TITLE
Add example of set objects

### DIFF
--- a/examples/index.json
+++ b/examples/index.json
@@ -8,6 +8,10 @@
         "path": "eq.pol"
     },
     {
+        "name": "Set Interface",
+        "path": "set.pol"
+    },
+    {
         "name": "STLC Type Soundness",
         "path": "stlc.pol"
     },

--- a/examples/set.pol
+++ b/examples/set.pol
@@ -20,32 +20,21 @@ codef Empty: Set {
 
 #[transparent]
 let Insert(s: Set, n: Nat): Set {
-    s.contains(n).match {
-        T => s,
-        // NOTE (2025-03-25): Polarity does not currently allow local comatches
-        // to use self parameters. Instead we lift this to the top-level.
-        F => Insert'(s, n),
-    }
+    // NOTE (2025-03-25): Polarity does not currently allow local comatches
+    // to use self parameters. Instead we lift this to the top-level.
+    s.contains(n).ite(s, Insert'(s, n))
 }
 
 codef Insert'(s: Set, n: Nat): Set {
     .is_empty => F,
-    .contains(i) =>
-        i.eq(n).match {
-            T => T,
-            F => s.contains(i),
-        },
+    .contains(i) => i.eq(n).or(s.contains(i)),
     .insert(i) => Insert(Insert'(s, n), i),
     .union(r) => Union(Insert'(s, n), r),
 }
 
 codef Union(s1 s2: Set): Set {
-    .is_empty => F,
-    .contains(i) =>
-        s1.contains(i).match {
-            T => T,
-            F => s2.contains(i),
-        },
+    .is_empty => s1.is_empty.and(s2.is_empty),
+    .contains(i) => s1.contains(i).or(s2.contains(i)),
     .insert(i) => Insert(Union(s1, s2), i),
     .union(r) => Union(Union(s1, s2), r),
 }

--- a/examples/set.pol
+++ b/examples/set.pol
@@ -1,0 +1,63 @@
+use "../std/data/bool.pol"
+use "../std/data/eq.pol"
+use "../std/data/nat.pol"
+// Set objects from Section 3 of “On Understanding Data Abstraction, Revisited”
+// by William R. Cook https://www.cs.utexas.edu/~wcook/Drafts/2009/essay.pdf
+
+codata Set {
+    .is_empty: Bool,
+    .contains(i: Nat): Bool,
+    .insert(i: Nat): Set,
+    .union(r: Set): Set,
+}
+
+codef Empty: Set {
+    .is_empty => T,
+    .contains(_) => F,
+    .insert(i) => Insert(Empty, i),
+    .union(s) => s,
+}
+
+#[transparent]
+let Insert(s: Set, n: Nat): Set {
+    s.contains(n).match {
+        T => s,
+        // NOTE (2025-03-25): Polarity does not currently allow local comatches
+        // to use self parameters. Instead we lift this to the top-level.
+        F => Insert'(s, n),
+    }
+}
+
+codef Insert'(s: Set, n: Nat): Set {
+    .is_empty => F,
+    .contains(i) =>
+        i.eq(n).match {
+            T => T,
+            F => s.contains(i),
+        },
+    .insert(i) => Insert(Insert'(s, n), i),
+    .union(r) => Union(Insert'(s, n), r),
+}
+
+codef Union(s1 s2: Set): Set {
+    .is_empty => F,
+    .contains(i) =>
+        s1.contains(i).match {
+            T => T,
+            F => s2.contains(i),
+        },
+    .insert(i) => Insert(Union(s1, s2), i),
+    .union(r) => Union(Union(s1, s2), r),
+}
+
+codef Full : Set {
+    .is_empty => F,
+    .contains(_) => T,
+    .insert(_) => Full,
+    .union(_) => Full,
+}
+
+// Expression from Section 3.2 of the paper
+let paper_example : Eq(a:=Bool, Empty.insert(3).union(Empty.insert(1)).insert(5).contains(4), F) {
+    Refl(a:=Bool, F)
+}

--- a/examples/set.pol
+++ b/examples/set.pol
@@ -2,16 +2,25 @@ use "../std/data/bool.pol"
 use "../std/data/eq.pol"
 use "../std/data/nat.pol"
 use "../std/data/ordering.pol"
-// Set objects from Section 3 of “On Understanding Data Abstraction, Revisited”
-// by William R. Cook https://www.cs.utexas.edu/~wcook/Drafts/2009/essay.pdf
+// An example of various implementations of the set interface from Section 3
+// of William R. Cook’s essay, “On Understanding Data Abstraction, Revisited”
+// https://www.cs.utexas.edu/~wcook/Drafts/2009/essay.pdf
 
+/// An interface for sets of natural numbers
 codata Set {
+    /// Returns `T` if the set is empty
     .is_empty: Bool,
+    /// Returns `T` if `i` is in the set
     .contains(i: Nat): Bool,
+    /// Inserts an element `i` into the set
     .insert(i: Nat): Set,
+    /// Returns a set containing all of the elements in two sets
     .union(r: Set): Set,
 }
 
+// Core set implementations from Figure 8 for the paper
+
+/// A set that contains no elements
 codef Empty: Set {
     .is_empty => T,
     .contains(_) => F,
@@ -19,6 +28,7 @@ codef Empty: Set {
     .union(s) => s,
 }
 
+/// A set that contains the elements in `s` along with `n`
 #[transparent]
 let Insert(s: Set, n: Nat): Set {
     // NOTE (2025-03-25): Polarity does not currently allow local comatches
@@ -33,6 +43,7 @@ codef Insert'(s: Set, n: Nat): Set {
     .union(r) => Union(Insert'(s, n), r),
 }
 
+/// A set that contains all of the elements from `s1` and `s2`
 codef Union(s1 s2: Set): Set {
     .is_empty => s1.is_empty.and(s2.is_empty),
     .contains(i) => s1.contains(i).or(s2.contains(i)),
@@ -40,13 +51,19 @@ codef Union(s1 s2: Set): Set {
     .union(r) => Union(Union(s1, s2), r),
 }
 
-// Expression from Section 3.2 of the paper
-let paper_example : Eq(a:=Bool, Empty.insert(3).union(Empty.insert(1)).insert(5).contains(4), F) {
+/// The expression from Section 3.2 of the paper
+#[transparent]
+let paper_example: Bool {
+    Empty.insert(3).union(Empty.insert(1)).insert(5).contains(4)
+}
+
+let test_paper_example : Eq(a:=Bool, paper_example, F) {
     Refl(a:=Bool, F)
 }
 
 // Additional implementations from Section 3.4 of the paper:
 
+/// A set that contains all of the natural numbers
 codef Full : Set {
     .is_empty => F,
     .contains(_) => T,
@@ -54,6 +71,7 @@ codef Full : Set {
     .union(_) => Full,
 }
 
+/// A set containing the natural numbers from `n` to `m` (inclusive).
 codef Interval(n m: Nat): Set {
     .is_empty => n.cmp(m).isGt,
     .contains(i) => n.cmp(i).isLe.and(i.cmp(m).isLe),

--- a/examples/set.pol
+++ b/examples/set.pol
@@ -1,6 +1,7 @@
 use "../std/data/bool.pol"
 use "../std/data/eq.pol"
 use "../std/data/nat.pol"
+use "../std/data/ordering.pol"
 // Set objects from Section 3 of “On Understanding Data Abstraction, Revisited”
 // by William R. Cook https://www.cs.utexas.edu/~wcook/Drafts/2009/essay.pdf
 
@@ -27,7 +28,7 @@ let Insert(s: Set, n: Nat): Set {
 
 codef Insert'(s: Set, n: Nat): Set {
     .is_empty => F,
-    .contains(i) => i.eq(n).or(s.contains(i)),
+    .contains(i) => i.cmp(n).isEq.or(s.contains(i)),
     .insert(i) => Insert(Insert'(s, n), i),
     .union(r) => Union(Insert'(s, n), r),
 }
@@ -39,6 +40,13 @@ codef Union(s1 s2: Set): Set {
     .union(r) => Union(Union(s1, s2), r),
 }
 
+// Expression from Section 3.2 of the paper
+let paper_example : Eq(a:=Bool, Empty.insert(3).union(Empty.insert(1)).insert(5).contains(4), F) {
+    Refl(a:=Bool, F)
+}
+
+// Additional implementations from Section 3.4 of the paper:
+
 codef Full : Set {
     .is_empty => F,
     .contains(_) => T,
@@ -46,7 +54,9 @@ codef Full : Set {
     .union(_) => Full,
 }
 
-// Expression from Section 3.2 of the paper
-let paper_example : Eq(a:=Bool, Empty.insert(3).union(Empty.insert(1)).insert(5).contains(4), F) {
-    Refl(a:=Bool, F)
+codef Interval(n m: Nat): Set {
+    .is_empty => n.cmp(m).isGt,
+    .contains(i) => n.cmp(i).isLe.and(i.cmp(m).isLe),
+    .insert(i) => Insert(Interval(n, m), i),
+    .union(r) => Union(Interval(n, m), r),
 }

--- a/examples/set.pol
+++ b/examples/set.pol
@@ -31,8 +31,8 @@ codef Empty: Set {
 /// A set that contains the elements in `s` along with `n`
 #[transparent]
 let Insert(s: Set, n: Nat): Set {
-    // NOTE (2025-03-25): Polarity does not currently allow local comatches
-    // to use self parameters. Instead we lift this to the top-level.
+    // NOTE (2025-03-25): Polarity does not currently support local recursive
+    // definitions, so we use a top-level helper `codef Insert'` here.
     s.contains(n).ite(s, Insert'(s, n))
 }
 

--- a/std/data/nat.pol
+++ b/std/data/nat.pol
@@ -1,4 +1,5 @@
 use "./bool.pol"
+use "./ordering.pol"
 
 /// The type of Peano natural numbers.
 data Nat {
@@ -43,15 +44,15 @@ def Nat.pred: Nat {
     S(x) => x
 }
 
-/// Compare two natural numbers for equality.
-def Nat.eq(other: Nat): Bool {
+/// Compare two natural numbers.
+def Nat.cmp(other: Nat): Ordering {
     Z => other.match {
-        Z => T,
-        S(_) => F,
+        Z => EQ,
+        S(_) => LT,
     },
     S(x) => other.match {
-        Z => F,
-        S(other) => x.eq(other),
+        Z => GT,
+        S(other) => x.cmp(other),
     },
 }
 

--- a/std/data/nat.pol
+++ b/std/data/nat.pol
@@ -1,3 +1,5 @@
+use "./bool.pol"
+
 /// The type of Peano natural numbers.
 data Nat {
     /// The constant zero.
@@ -39,6 +41,18 @@ def Nat.fact: Nat {
 def Nat.pred: Nat {
     Z => Z,
     S(x) => x
+}
+
+/// Compare two natural numbers for equality.
+def Nat.eq(other: Nat): Bool {
+    Z => other.match {
+        Z => T,
+        S(_) => F,
+    },
+    S(x) => other.match {
+        Z => F,
+        S(other) => x.eq(other),
+    },
 }
 
 /// The lesser-or-equal relation on natural numbers.

--- a/std/data/ordering.pol
+++ b/std/data/ordering.pol
@@ -1,3 +1,5 @@
+use "./bool.pol"
+
 /// The result of comparing two totally-ordered values.
 data Ordering {
     /// Lesser than
@@ -6,4 +8,46 @@ data Ordering {
     EQ,
     /// Greater than
     GT,
+}
+
+/// Returns `T` if the ordering is `EQ`
+def Ordering.isEq: Bool {
+    LT => F,
+    EQ => T,
+    GT => F,
+}
+
+/// Returns `T` if the ordering is not `EQ`
+def Ordering.isNe: Bool {
+    LT => T,
+    EQ => F,
+    GT => T,
+}
+
+/// Returns `T` if the ordering is `LT`
+def Ordering.isLt: Bool {
+    LT => T,
+    EQ => F,
+    GT => F,
+}
+
+/// Returns `T` if the ordering is `GT`
+def Ordering.isGt: Bool {
+    LT => F,
+    EQ => F,
+    GT => T,
+}
+
+/// Returns `T` if the ordering is `LT` or `EQ`
+def Ordering.isLe: Bool {
+    LT => T,
+    EQ => T,
+    GT => F,
+}
+
+/// Returns `T` if the ordering is `EQ` or `GT`
+def Ordering.isGe: Bool {
+    LT => F,
+    EQ => T,
+    GT => T,
 }


### PR DESCRIPTION
I originally implemented this as a [gist](https://gist.github.com/brendanzab/285c31f1c5dc9da954cd48c8fbee47b7), and was asked on discord if I could add this as an example to the repository because “it is a non-(strictly positive) codata type (in the `.union` destructor `Set` occurs both positively and negatively in recursive positions)”.

I wasn’t sure if I should keep it self-contained, or if I should use the prelude. I ultimately ended up using the prelude and adding `Nat.eq`, but this could be changed. I could also bring the definitions more into the line by using the relational operations on `Bool`, but I was unsure if they were lazily evaluated or not, so left the example using `match` for now.

Edit: I decided to switch to using the boolean operations, as it makes the example much more readable, but I’m very curious about the evaluation semantics of Polarity!