### PR TITLE
Use trailing commas when pretty printing

### DIFF
--- a/examples/encoding_fu_stump.pol
+++ b/examples/encoding_fu_stump.pol
@@ -13,17 +13,17 @@ use "../std/codata/fun.pol"
 
 /// The type of dependent functions.
 codata Π(A: Type, T: A -> Type) {
-    Π(A, T).dap(A: Type, T: A -> Type, x: A): T.ap(a := A, b := Type, x)
+    Π(A, T).dap(A: Type, T: A -> Type, x: A): T.ap(a := A, b := Type, x),
 }
 
 /// An abbreviation of the induction step, i.e. a function from "P x" to "P (S x)".
 codef StepFun(P: Nat -> Type): Fun(Nat, Type) {
-    .ap(_, _, x) => P.ap(a := Nat, b:= Type, x) -> P.ap(a := Nat, b:= Type, S(x))
+    .ap(_, _, x) => P.ap(a := Nat, b:= Type, x) -> P.ap(a := Nat, b:= Type, S(x)),
 }
 
 codata Nat {
     (n: Nat).ind(P: Nat -> Type, base: P.ap(a := Nat, b:= Type, Z), step: Π(Nat, StepFun(P)))
-        : P.ap(a := Nat, b:= Type, n)
+        : P.ap(a := Nat, b:= Type, n),
 }
 
 codef Z: Nat { .ind(P, base, step) => base }
@@ -31,5 +31,5 @@ codef Z: Nat { .ind(P, base, step) => base }
 codef S(m: Nat): Nat {
     .ind(P, base, step) =>
         step.dap(Nat, StepFun(P), m)
-            .ap(a := P.ap(a := Nat, b:= Type, m), b:= P.ap(a := Nat, b:= Type, S(m)), m.ind(P, base, step))
+            .ap(a := P.ap(a := Nat, b:= Type, m), b:= P.ap(a := Nat, b:= Type, S(m)), m.ind(P, base, step)),
 }

--- a/examples/eq.pol
+++ b/examples/eq.pol
@@ -1,19 +1,19 @@
 codata Fun(a b: Type) {
-    Fun(a, b).ap(a b: Type, x: a): b
+    Fun(a, b).ap(a b: Type, x: a): b,
 }
 
 data Eq(a: Type, x y: a) {
-    Refl(a: Type, x: a): Eq(a, x, x)
+    Refl(a: Type, x: a): Eq(a, x, x),
 }
 
 def Eq(a, x, y).sym(a: Type, x y: a): Eq(a, y, x) { Refl(a, x) => Refl(a, x) }
 
 def Eq(a, x, y).subst(a: Type, x y: a, p: a -> Type, prf: p.ap(a, Type, x)): p.ap(a, Type, y) {
-    Refl(a, x) => prf
+    Refl(a, x) => prf,
 }
 
 def Eq(a, x, y).trans(a: Type, x y z: a, h: Eq(a, y, z)): Eq(a, x, z) { Refl(a, x) => h }
 
 def Eq(a, x, y).cong(a b: Type, x y: a, f: a -> b): Eq(b, f.ap(a, b, x), f.ap(a, b, y)) {
-    Refl(a, x) => Refl(b, f.ap(a, b, x))
+    Refl(a, x) => Refl(b, f.ap(a, b, x)),
 }

--- a/examples/functor.pol
+++ b/examples/functor.pol
@@ -1,15 +1,15 @@
 codata Fun(a b: Type) {
-    Fun(a, b).ap(a b: Type, x: a): b
+    Fun(a, b).ap(a b: Type, x: a): b,
 }
 
 data Eq(a: Type, x y: a) {
-    Refl(a: Type, x: a): Eq(a, x, x)
+    Refl(a: Type, x: a): Eq(a, x, x),
 }
 
 codef Id(a: Type): Fun(a, a) { .ap(_, _, x) => x }
 
 codef Compose(a b c: Type, f: a -> b, g: b -> c): Fun(a, c) {
-    .ap(_, _, x) => g.ap(b, c, f.ap(a, b, x))
+    .ap(_, _, x) => g.ap(b, c, f.ap(a, b, x)),
 }
 
 codata Functor(f: Type -> Type) {
@@ -21,15 +21,15 @@ codata Functor(f: Type -> Type) {
                                 a b c: Type,
                                 g: a -> b,
                                 h: b -> c,
-                                x: t.ap(Type, Type, a)
+                                x: t.ap(Type, Type, a),
                                 )
         : Eq(t.ap(Type, Type, c),
              f.map(t, a, c, Compose(a, b, c, g, h), x),
-             f.map(t, b, c, h, f.map(t, a, b, g, x)))
+             f.map(t, b, c, h, f.map(t, a, b, g, x))),
 }
 
 data Box(a: Type) {
-    MkBox(a: Type, x: a): Box(a)
+    MkBox(a: Type, x: a): Box(a),
 }
 
 codef BoxFun: Fun(Type, Type) { .ap(_, _, a) => Box(a) }
@@ -40,12 +40,12 @@ codef BoxFunctor: Functor(BoxFun) {
     .map(_, a, b, g, x) => x.map_box(a, b, g),
     .law_id(_, a, x) =>
         x.match as x => Eq(Box(a), x.map_box(a, a, Id(a)), x) {
-            MkBox(_, x) => Refl(Box(a), MkBox(a, x))
+            MkBox(_, x) => Refl(Box(a), MkBox(a, x)),
         },
     .law_compose(_, a, b, c, g, h, x) =>
         x.match as x => Eq(Box(c),
                            x.map_box(a, c, Compose(a, b, c, g, h)),
                            x.map_box(a, b, g).map_box(b, c, h)) {
             MkBox(_, x) => Refl(Box(c), MkBox(c, h.ap(b, c, g.ap(a, b, x))))
-        }
+        },
 }

--- a/examples/pi.pol
+++ b/examples/pi.pol
@@ -1,26 +1,26 @@
 /// The non-dependent function type.
 codata Fun(a b: Type) {
-    Fun(a, b).ap(a b: Type, x: a): b
+    Fun(a, b).ap(a b: Type, x: a): b,
 }
 
 /// The dependent function type.
 codata Π(a: Type, p: a -> Type) {
-    Π(a, p).pi_elim(a: Type, p: a -> Type, x: a): p.ap(a, Type, x)
+    Π(a, p).pi_elim(a: Type, p: a -> Type, x: a): p.ap(a, Type, x),
 }
 
 /// The dependent sum type.
 data Σ(a: Type, p: a -> Type) {
-    Exists(a: Type, p: a -> Type, x: a, prf: p.ap(a, Type, x)): Σ(a, p)
+    Exists(a: Type, p: a -> Type, x: a, prf: p.ap(a, Type, x)): Σ(a, p),
 }
 
 data Sum(a b: Type) {
     /// The left injection into a sum.
     Inl(a b: Type, x: a): Sum(a, b),
     /// The right injection into a sum.
-    Inr(a b: Type, x: b): Sum(a, b)
+    Inr(a b: Type, x: b): Sum(a, b),
 }
 
 codata Pair(a b: Type) {
     Pair(a, b).π₁(a b: Type): a,
-    Pair(a, b).π₂(a b: Type): b
+    Pair(a, b).π₂(a b: Type): b,
 }

--- a/examples/stlc.pol
+++ b/examples/stlc.pol
@@ -9,14 +9,14 @@ data Exp {
     /// Lambda abstractions
     Lam(body: Exp),
     /// Function applications
-    App(lhs rhs: Exp)
+    App(lhs rhs: Exp),
 }
 
 /// Types of the object language
 data Typ {
     /// Function type
     FunT(t1 t2: Typ),
-    VarT(x: Nat)
+    VarT(x: Nat),
 }
 
 /// **Typing contexts**.
@@ -25,37 +25,37 @@ data Ctx {
     /// The empty context
     Nil,
     /// Adding a typed binding to the context
-    Cons(t: Typ, ts: Ctx)
+    Cons(t: Typ, ts: Ctx),
 }
 
 /// Appending two contexts
 def Ctx.append(other: Ctx): Ctx {
     Nil => other,
-    Cons(t, ts) => Cons(t, ts.append(other))
+    Cons(t, ts) => Cons(t, ts.append(other)),
 }
 
 /// Computing the length of a context
 def Ctx.len: Nat {
     Nil => Z,
-    Cons(_, ts) => S(ts.len)
+    Cons(_, ts) => S(ts.len),
 }
 
 /// Substituting an expression for a variable in an expression.
 def Exp.subst(v: Nat, by: Exp): Exp {
     Var(x) => x.cmp(v).subst_result(x, by),
     Lam(e) => Lam(e.subst(S(v), by)),
-    App(e1, e2) => App(e1.subst(v, by), e2.subst(v, by))
+    App(e1, e2) => App(e1.subst(v, by), e2.subst(v, by)),
 }
 
 def Ordering.subst_result(x: Nat, by: Exp): Exp {
     LT => Var(x),
     EQ => by,
-    GT => Var(x.pred)
+    GT => Var(x.pred),
 }
 
 data Elem(x: Nat, t: Typ, ctx: Ctx) {
     Here(t: Typ, ts: Ctx): Elem(Z, t, Cons(t, ts)),
-    There(x: Nat, t t2: Typ, ts: Ctx, prf: Elem(x, t, ts)): Elem(S(x), t, Cons(t2, ts))
+    There(x: Nat, t t2: Typ, ts: Ctx, prf: Elem(x, t, ts)): Elem(S(x), t, Cons(t2, ts)),
 }
 
 /// The typing judgement.
@@ -68,9 +68,9 @@ data HasType(ctx: Ctx, e: Exp, t: Typ) {
          t1 t2: Typ,
          e1 e2: Exp,
          e1_t: HasType(ctx, e1, FunT(t1, t2)),
-         e2_t: HasType(ctx, e2, t1)
+         e2_t: HasType(ctx, e2, t1),
          )
-        : HasType(ctx, App(e1, e2), t2)
+        : HasType(ctx, App(e1, e2), t2),
 }
 
 /// The evaluation relation
@@ -78,18 +78,18 @@ data HasType(ctx: Ctx, e: Exp, t: Typ) {
 data Eval(e1 e2: Exp) {
     EBeta(e1 e2: Exp): Eval(App(Lam(e1), e2), e1.subst(Z, e2)),
     ECongApp1(e1 e1': Exp, h: Eval(e1, e1'), e2: Exp): Eval(App(e1, e2), App(e1', e2)),
-    ECongApp2(e1 e2 e2': Exp, h: Eval(e2, e2')): Eval(App(e1, e2), App(e1, e2'))
+    ECongApp2(e1 e2 e2': Exp, h: Eval(e2, e2')): Eval(App(e1, e2), App(e1, e2')),
 }
 
 /// Characterizes the subset of Values.
 data IsValue(e: Exp) {
     /// Every lambda abstraction is a value
-    VLam(e: Exp): IsValue(Lam(e))
+    VLam(e: Exp): IsValue(Lam(e)),
 }
 
 data Progress(e: Exp) {
     PVal(e: Exp, h: IsValue(e)): Progress(e),
-    PStep(e1 e2: Exp, h: Eval(e1, e2)): Progress(e1)
+    PStep(e1 e2: Exp, h: Eval(e1, e2)): Progress(e1),
 }
 
 def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e) {
@@ -97,7 +97,7 @@ def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e) {
         \ap(_,_,h_t) => h_t.match {
             TVar(_, _, _, elem) => elem.empty_absurd(x, t).ex_falso(Progress(Var(x))),
             TLam(_, _, _, _, _) absurd,
-            TApp(_, _, _, _, _, _, _) absurd
+            TApp(_, _, _, _, _, _, _) absurd,
         },
     Lam(e) => \ap(_,_,_) => PVal(Lam(e), VLam(e)),
     App(e1, e2) =>
@@ -111,10 +111,10 @@ def (e: Exp).progress(t: Typ): HasType(Nil, e, t) -> Progress(e) {
                         PStep(App(e1, e2), App(e1', e2), ECongApp1(e1, e1', e1_eval_e1', e2)),
                     PVal(_, is_val) =>
                         is_val.match {
-                            VLam(e) => PStep(App(Lam(e), e2), e.subst(Z, e2), EBeta(e, e2))
-                        }
-                }
-        }
+                            VLam(e) => PStep(App(Lam(e), e2), e.subst(Z, e2), EBeta(e, e2)),
+                        },
+                },
+        },
 }
 
 def (e1: Exp).preservation(e2: Exp, t: Typ)
@@ -123,13 +123,13 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
         \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
             EBeta(_, _) absurd,
             ECongApp1(_, _, _, _) absurd,
-            ECongApp2(_, _, _, _) absurd
+            ECongApp2(_, _, _, _) absurd,
         },
     Lam(_) =>
         \ap(_,_,h_t) => \ap(_,_,h_eval) => h_eval.match {
             EBeta(_, _) absurd,
             ECongApp1(_, _, _, _) absurd,
-            ECongApp2(_, _, _, _) absurd
+            ECongApp2(_, _, _, _) absurd,
         },
     App(e1, e2) =>
         \ap(_,_,h_t) => h_t.match {
@@ -170,10 +170,10 @@ def (e1: Exp).preservation(e2: Exp, t: Typ)
                                   .ap(HasType(Cons(t1, Nil), e1, t2),
                                       HasType(Nil, e2, t1) -> HasType(Nil, e1.subst(Z, e2), t2),
                                       h_e1)
-                                  .ap(HasType(Nil, e2, t1), HasType(Nil, e1.subst(Z, e2), t2), h_e2)
-                        }
-                }
-        }
+                                  .ap(HasType(Nil, e2, t1), HasType(Nil, e1.subst(Z, e2), t2), h_e2),
+                        },
+                },
+        },
 }
 
 def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
@@ -196,7 +196,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                               .ap(_, _, cmp) =>
                                                   HasType(ctx1.append(ctx2),
                                                           cmp.subst_result(x, by_e),
-                                                          t2)
+                                                          t2),
                                           },
                                           ctx2.weaken_append(ctx1, Var(x), t2)
                                               .ap(HasType(ctx1, Var(x), t2),
@@ -226,7 +226,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                               .ap(_, _, cmp) =>
                                                   HasType(ctx1.append(ctx2),
                                                           cmp.subst_result(x, by_e),
-                                                          t2)
+                                                          t2),
                                           },
                                           ctx1.append(ctx2)
                                               .weaken_append(Nil, by_e, t2)
@@ -264,7 +264,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                               .ap(_, _, cmp) =>
                                                   HasType(ctx1.append(ctx2),
                                                           cmp.subst_result(x, by_e),
-                                                          t2)
+                                                          t2),
                                           },
                                           TVar(ctx1.append(ctx2),
                                                x.pred,
@@ -280,8 +280,8 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                                                        h_gt)
                                                    .ap(Elem(x, t2, ctx1.append(Cons(t1, ctx2))),
                                                        Elem(x.pred, t2, ctx1.append(ctx2)),
-                                                       h_elem)))
-                }
+                                                       h_elem))),
+                },
         },
     Lam(body) =>
         \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
@@ -300,7 +300,7 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                              h_body)
                          .ap(HasType(Nil, by_e, t1),
                              HasType(Cons(a, ctx1).append(ctx2), body.subst(S(ctx1.len), by_e), b),
-                             h_by))
+                             h_by)),
         },
     App(e1, e2) =>
         \ap(_,_,h_e) => \ap(_,_,h_by) => h_e.match {
@@ -329,8 +329,8 @@ def (e: Exp).subst_lemma(ctx1 ctx2: Ctx, t1 t2: Typ, by_e: Exp)
                            h_e2)
                        .ap(HasType(Nil, by_e, t1),
                            HasType(ctx1.append(ctx2), e2.subst(ctx1.len, by_e), a),
-                           h_by))
-        }
+                           h_by)),
+        },
 }
 
 def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ)
@@ -354,7 +354,7 @@ def (ctx2: Ctx).weaken_append(ctx1: Ctx, e: Exp, t: Typ)
                                    e.weaken_cons(ctx1, t', t)
                                     .ap(HasType(ctx1, e, t),
                                         HasType(ctx1.append(Cons(t', Nil)), e, t),
-                                        h_e)))
+                                        h_e))),
 }
 
 def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
@@ -364,7 +364,7 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
             TLam(_, _, _, _, _) absurd,
             TApp(_, _, _, _, _, _, _) absurd,
             TVar(_, _, _, h_elem) =>
-                TVar(ctx.append(Cons(t1, Nil)), x, t2, h_elem.elem_append(x, t1, t2, ctx))
+                TVar(ctx.append(Cons(t1, Nil)), x, t2, h_elem.elem_append(x, t1, t2, ctx)),
         },
     Lam(e) =>
         \ap(_,_,h_e) => h_e.match {
@@ -378,7 +378,7 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
                      e.weaken_cons(Cons(a, ctx), t1, b)
                       .ap(HasType(Cons(a, ctx), e, b),
                           HasType(Cons(a, ctx).append(Cons(t1, Nil)), e, b),
-                          h_e))
+                          h_e)),
         },
     App(e1, e2) =>
         \ap(_,_,h_e) => h_e.match {
@@ -395,15 +395,15 @@ def (e: Exp).weaken_cons(ctx: Ctx, t1 t2: Typ)
                            HasType(ctx.append(Cons(t1, Nil)), e1, FunT(a, b)),
                            h_e1),
                      e2.weaken_cons(ctx, t1, a)
-                       .ap(HasType(ctx, e2, a), HasType(ctx.append(Cons(t1, Nil)), e2, a), h_e2))
-        }
+                       .ap(HasType(ctx, e2, a), HasType(ctx.append(Cons(t1, Nil)), e2, a), h_e2)),
+        },
 }
 
 def Elem(n, t2, ctx).elem_append(n: Nat, t1 t2: Typ, ctx: Ctx)
     : Elem(n, t2, ctx.append(Cons(t1, Nil))) {
     Here(t, ts) => Here(t, ts.append(Cons(t1, Nil))),
     There(n, _, t', ts, h) =>
-        There(n, t2, t', ts.append(Cons(t1, Nil)), h.elem_append(n, t1, t2, ts))
+        There(n, t2, t', ts.append(Cons(t1, Nil)), h.elem_append(n, t1, t2, ts)),
 }
 
 def (ctx1: Ctx).append_assoc(ctx2 ctx3: Ctx)
@@ -415,22 +415,22 @@ def (ctx1: Ctx).append_assoc(ctx2 ctx3: Ctx)
                 Ctx,
                 xs.append(ctx2).append(ctx3),
                 xs.append(ctx2.append(ctx3)),
-                comatch { .ap(_, _, xs) => Cons(x, xs) })
+                comatch { .ap(_, _, xs) => Cons(x, xs) }),
 }
 
 def (ctx: Ctx).append_nil: Eq(Ctx, ctx, ctx.append(Nil)) {
     Nil => Refl(Ctx, Nil),
-    Cons(t, ts) => ts.append_nil.eq_cons(ts, ts.append(Nil), t)
+    Cons(t, ts) => ts.append_nil.eq_cons(ts, ts.append(Nil), t),
 }
 
 def Elem(x, t, Nil).empty_absurd(x: Nat, t: Typ): Void {
     Here(_, _) absurd,
-    There(_, _, _, _, _) absurd
+    There(_, _, _, _, _) absurd,
 }
 
 def Elem(Z, t1, Cons(t2, ctx)).elem_unique(ctx: Ctx, t1 t2: Typ): Eq(Typ, t2, t1) {
     Here(_, _) => Refl(Typ, t1),
-    There(_, _, _, _, _) absurd
+    There(_, _, _, _, _) absurd,
 }
 
 def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ)
@@ -441,8 +441,8 @@ def (ctx1: Ctx).ctx_lookup(ctx2: Ctx, t1 t2: Typ)
             Here(_, _) absurd,
             There(_, _, _, _, h) =>
                 ts.ctx_lookup(ctx2, t1, t2)
-                  .ap(Elem(ts.len, t1, ts.append(Cons(t2, ctx2))), Eq(Typ, t2, t1), h)
-        }
+                  .ap(Elem(ts.len, t1, ts.append(Cons(t2, ctx2))), Eq(Typ, t2, t1), h),
+        },
 }
 
 def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
@@ -450,7 +450,7 @@ def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
     Nil =>
         \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_lt.match {
             LERefl(_) absurd,
-            LESucc(_, _, _) absurd
+            LESucc(_, _, _) absurd,
         },
     Cons(t', ts) =>
         \ap(_,_,h_lt) => \ap(_,_,h_elem) => h_elem.match {
@@ -464,8 +464,8 @@ def (ctx1: Ctx).elem_append_first(ctx2: Ctx, t: Typ, x: Nat)
                         .ap(LE(S(x'), ts.len),
                             Elem(x', t, ts.append(ctx2)) -> Elem(x', t, ts),
                             h_lt.le_unsucc(x, ts.len))
-                        .ap(Elem(x', t, ts.append(ctx2)), Elem(x', t, ts), h))
-        }
+                        .ap(Elem(x', t, ts.append(ctx2)), Elem(x', t, ts), h)),
+        },
 }
 
 def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
@@ -477,16 +477,16 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
             Here(_, _) =>
                 h_gt.match {
                     LERefl(_) absurd,
-                    LESucc(_, _, _) absurd
+                    LESucc(_, _, _) absurd,
                 },
-            There(_, _, _, _, h) => h
+            There(_, _, _, _, h) => h,
         },
     Cons(t, ts) =>
         \ap(_,_,h_gt) => \ap(_,_,h_elem) => h_elem.match {
             Here(_, _) =>
                 h_gt.match {
                     LERefl(_) absurd,
-                    LESucc(_, _, _) absurd
+                    LESucc(_, _, _) absurd,
                 },
             There(x', _, _, _, h) =>
                 h_gt.le_unsucc(S(ts.len), x')
@@ -507,59 +507,59 @@ def (ctx1: Ctx).elem_append_pred(ctx2: Ctx, t1 t2: Typ, x: Nat)
                                            h_gt.le_unsucc(S(ts.len), x'))
                                        .ap(Elem(x', t1, ts.append(Cons(t2, ctx2))),
                                            Elem(x'.pred, t1, ts.append(ctx2)),
-                                           h)))
-        }
+                                           h))),
+        },
 }
 
 
 codata Fun(a b: Type) {
-    Fun(a, b).ap(a b: Type, x: a): b
+    Fun(a, b).ap(a b: Type, x: a): b,
 }
 
 data Eq(a: Type, x y: a) {
-    Refl(a: Type, x: a): Eq(a, x, x)
+    Refl(a: Type, x: a): Eq(a, x, x),
 }
 
 def Eq(a, x, y).sym(a: Type, x y: a): Eq(a, y, x) { Refl(a, x) => Refl(a, x) }
 
 def Eq(a, x, y).transport(a: Type, x y: a, p: a -> Type, prf: p.ap(a, Type, x)): p.ap(a, Type, y) {
-    Refl(a, x) => prf
+    Refl(a, x) => prf,
 }
 
 def Eq(a, x, y).cong(a b: Type, x y: a, f: a -> b): Eq(b, f.ap(a, b, x), f.ap(a, b, y)) {
-    Refl(a, x) => Refl(b, f.ap(a, b, x))
+    Refl(a, x) => Refl(b, f.ap(a, b, x)),
 }
 
 def Eq(Nat, x, y).eq_s(x y: Nat): Eq(Nat, S(x), S(y)) { Refl(_, _) => Refl(Nat, S(x)) }
 
 def Eq(Ctx, xs, ys).eq_cons(xs ys: Ctx, t: Typ): Eq(Ctx, Cons(t, xs), Cons(t, ys)) {
-    Refl(_, _) => Refl(Ctx, Cons(t, xs))
+    Refl(_, _) => Refl(Ctx, Cons(t, xs)),
 }
 
 def Nat.cmp(y: Nat): Ordering {
     Z =>
         y.match {
             Z => EQ,
-            S(_) => LT
+            S(_) => LT,
         },
     S(x) =>
         y.match {
             Z => GT,
-            S(y) => x.cmp(y)
-        }
+            S(y) => x.cmp(y),
+        },
 }
 
 data CmpReflect(x y: Nat) {
     IsLT(x y: Nat, h1: Eq(Ordering, LT, x.cmp(y)), h2: LE(S(x), y)): CmpReflect(x, y),
     IsEQ(x y: Nat, h1: Eq(Ordering, EQ, x.cmp(y)), h2: Eq(Nat, x, y)): CmpReflect(x, y),
-    IsGT(x y: Nat, h1: Eq(Ordering, GT, x.cmp(y)), h2: LE(S(y), x)): CmpReflect(x, y)
+    IsGT(x y: Nat, h1: Eq(Ordering, GT, x.cmp(y)), h2: LE(S(y), x)): CmpReflect(x, y),
 }
 
 def (x: Nat).cmp_reflect(y: Nat): CmpReflect(x, y) {
     Z =>
         y.match as y => CmpReflect(Z, y) {
             Z => IsEQ(Z, Z, Refl(Ordering, EQ), Refl(Nat, Z)),
-            S(y) => IsLT(Z, S(y), Refl(Ordering, LT), y.z_le.le_succ(Z, y))
+            S(y) => IsLT(Z, S(y), Refl(Ordering, LT), y.z_le.le_succ(Z, y)),
         },
     S(x) =>
         y.match as y => CmpReflect(S(x), y) {
@@ -568,12 +568,12 @@ def (x: Nat).cmp_reflect(y: Nat): CmpReflect(x, y) {
                 x.cmp_reflect(y).match {
                     IsLT(_, _, h1, h2) => IsLT(S(x), S(y), h1, h2.le_succ(S(x), y)),
                     IsEQ(_, _, h1, h2) => IsEQ(S(x), S(y), h1, h2.eq_s(x, y)),
-                    IsGT(_, _, h1, h2) => IsGT(S(x), S(y), h1, h2.le_succ(S(y), x))
-                }
-        }
+                    IsGT(_, _, h1, h2) => IsGT(S(x), S(y), h1, h2.le_succ(S(y), x)),
+                },
+        },
 }
 
 def LE(S(x), y).s_pred(x y: Nat): Eq(Nat, S(y.pred), y) {
     LERefl(_) => Refl(Nat, y),
-    LESucc(_, y', _) => Refl(Nat, y)
+    LESucc(_, y', _) => Refl(Nat, y),
 }

--- a/examples/strong_existentials.pol
+++ b/examples/strong_existentials.pol
@@ -21,7 +21,7 @@
 // of type `B`. As a datatype it can be written as follows:
 
 data Tensor(A B: Type) {
-  Sum(A B: Type, x: A, y: B): Tensor(A,B)
+  Sum(A B: Type, x: A, y: B): Tensor(A,B),
 }
 
 // Using the negative polarization, the product is specified using the two
@@ -29,7 +29,7 @@ data Tensor(A B: Type) {
 
 codata With(A B: Type) {
   With(A,B).π₁(A B: Type): A,
-  With(A,B).π₂(A B: Type): B
+  With(A,B).π₂(A B: Type): B,
 }
 
 //
@@ -42,7 +42,7 @@ codata With(A B: Type) {
 // to introduce the type of functions first:
 
 codata Fun(A B: Type) {
-  Fun(A,B).ap(A B: Type, x: A): B
+  Fun(A,B).ap(A B: Type, x: A): B,
 }
 
 // The system has builtin syntactic sugar for the function type, which allows
@@ -54,7 +54,7 @@ codata Fun(A B: Type) {
 // in more standard notation.
 
 data ExistsPos(T: Type -> Type) {
-  ExistsSum(T: Type -> Type, A: Type, W: T.ap(Type,Type,A)): ExistsPos(T)
+  ExistsSum(T: Type -> Type, A: Type, W: T.ap(Type,Type,A)): ExistsPos(T),
 }
 
 // As a codata type, we still have two projections `eπ₁`and `eπ₂` as in the case
@@ -63,7 +63,7 @@ data ExistsPos(T: Type -> Type) {
 
 codata ExistsNeg(T: Type -> Type) {
   ExistsNeg(T).eπ₁(T: Type -> Type): Type,
-  (self: ExistsNeg(T)).eπ₂(T: Type -> Type): T.ap(Type,Type, self.eπ₁(T))
+  (self: ExistsNeg(T)).eπ₂(T: Type -> Type): T.ap(Type,Type, self.eπ₁(T)),
 }
 
 //
@@ -77,24 +77,24 @@ codata ExistsNeg(T: Type -> Type) {
 // type `A` and a type family `T: A -> Type`.
 
 data ΣPos(A: Type, T: A -> Type) {
-  ΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A,Type,x)): ΣPos(A,T)
+  ΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A,Type,x)): ΣPos(A,T),
 }
 
 def ΣPos(A,T).defπ₁(A: Type, T: A -> Type): A {
-  ΣSum(_,_,x,_) => x
+  ΣSum(_,_,x,_) => x,
 }
 
 def (self: ΣPos(A,T)).defπ₂(A: Type, T: A -> Type): T.ap(A,Type,self.defπ₁(A,T)) {
-  ΣSum(_,_,_,w) => w
+  ΣSum(_,_,_,w) => w,
 }
 
 
 codata ΣNeg(A: Type, T: A -> Type) {
   ΣNeg(A,T).sπ₁(A: Type, T: A -> Type): A,
-  (self: ΣNeg(A,T)).sπ₂(A: Type, T: A -> Type): T.ap(A,Type, self.sπ₁(A,T))
+  (self: ΣNeg(A,T)).sπ₂(A: Type, T: A -> Type): T.ap(A,Type, self.sπ₁(A,T)),
 }
 
 codef DefΣSum(A: Type, T: A -> Type, x: A, w: T.ap(A, Type, x)): ΣNeg(A,T) {
   .sπ₁(_,_) => x,
-  .sπ₂(_,_) => w
+  .sπ₂(_,_) => w,
 }

--- a/examples/tutorial.pol
+++ b/examples/tutorial.pol
@@ -4,20 +4,20 @@ data Bool { T, F }
 /// We can define `not`, which negates a boolean value, by case distinction.
 def Bool.not: Bool {
     T => F,
-    F => T
+    F => T,
 }
 
-/// We can define the if_then_else observation. This example also illustrates how to use the `Type` universe to introduce the type variable `a`. 
+/// We can define the if_then_else observation. This example also illustrates how to use the `Type` universe to introduce the type variable `a`.
 def Bool.if_then_else(a: Type, then else: a): a {
     T => then,
-    F => else
+    F => else,
 }
 
 /// Since polarity is dependently typed, we can return different types,
 /// depending on the value of the Bool that is scrutinized.
 def (b : Bool).dep_if_then_else(t1 t2: Type, then: t1, else: t2): b.if_then_else(Type, t1, t2){
   T => then,
-  F => else
+  F => else,
 }
 
 /// We can define simple recursive data types.
@@ -25,13 +25,13 @@ data Nat { Z, S(n: Nat) }
 
 def Nat.add(y: Nat): Nat {
     Z => y,
-    S(x') => S(x'.add(y))
+    S(x') => S(x'.add(y)),
 }
 
 /// And more complex, parametrised ones, like this classic.
 data Vec(n: Nat) {
     VNil: Vec(Z),
-    VCons(n x: Nat, xs: Vec(n)): Vec(S(n))
+    VCons(n x: Nat, xs: Vec(n)): Vec(S(n)),
 }
 
 /// So far so good. We have covered a bunch of examples in a simple, dependently typed
@@ -54,12 +54,12 @@ codef Pred: NatToNat {
   // if we observe the application of a function of Nat to Nat
   .ap(n) => n.match { // we case split on the Nat
     Z => Z,           // in case we obtain Zero, we return Zero
-    S(m) => m         // and otherwise, we return the predecessor
+    S(m) => m,        // and otherwise, we return the predecessor
   }
 }
 
-/// This definition (main) is the main entry point for running programs 
-/// in polarity. When invoking pol run tutorial.pol, this will print S(S(S(S(Z)))) 
+/// This definition (main) is the main entry point for running programs
+/// in polarity. When invoking pol run tutorial.pol, this will print S(S(S(S(Z))))
 /// (also known as 4) as expected
 let main: Nat { Pred.ap(2.add(3)) }
 
@@ -68,19 +68,19 @@ let main: Nat { Pred.ap(2.add(3)) }
 /// We can build an option type that may (Some) or may not (None) contain a value.
 data Option(a: Type) {
     None(a: Type): Option(a),
-    Some(a: Type, x: a): Option(a)
+    Some(a: Type, x: a): Option(a),
 }
 
 /// We can also build simple, non-dependent Lists, as a data type.
 data List(a: Type) {
     Nil(a: Type): List(a),
-    Cons(a: Type, x: a, xs: List(a)): List(a)
+    Cons(a: Type, x: a, xs: List(a)): List(a),
 }
 
 /// And of course write a (safe) head implementation for it.
 def List(a).hd(a: Type): Option(a) {
     Nil(a) => None(a),
-    Cons(a, x, xs) => Some(a, x)
+    Cons(a, x, xs) => Some(a, x),
 }
 
 // We can build different kinds of (infinite) streams.
@@ -88,17 +88,17 @@ def List(a).hd(a: Type): Option(a) {
 /// One that contains only Zeroes:
 codef Zeroes: Stream {
     .head => Z,
-    .tail => Zeroes
+    .tail => Zeroes,
 }
 
 /// One that contains only Ones:
 codef Ones: Stream {
     .head => S(Z),
-    .tail => Ones
+    .tail => Ones,
 }
 
 /// And one that alternates between Ones and Zeroes:
 codef Alternate(choose: Bool): Stream {
     .head => choose.if_then_else(Nat, S(Z), Z),
-    .tail => Alternate(choose.not)
+    .tail => Alternate(choose.not),
 }

--- a/lang/ast/src/ctx/def.rs
+++ b/lang/ast/src/ctx/def.rs
@@ -124,6 +124,7 @@ impl<T: Print> Print for GenericCtx<T> {
                     }),
                     sep.clone(),
                 )
+                .append(alloc.text(COMMA).flat_alt(alloc.nil()))
                 .brackets()
         });
         alloc.intersperse(iter, sep.clone()).brackets()

--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -451,7 +451,11 @@ impl Print for Data {
         } else {
             alloc
                 .line()
-                .append(alloc.intersperse(ctors.iter().map(|ctor| ctor.print(cfg, alloc)), sep))
+                .append(
+                    alloc
+                        .intersperse(ctors.iter().map(|ctor| ctor.print(cfg, alloc)), sep)
+                        .append(alloc.text(COMMA).flat_alt(alloc.nil())),
+                )
                 .nest(cfg.indent)
                 .append(alloc.line())
                 .braces_anno()
@@ -519,7 +523,11 @@ impl Print for Codata {
         } else {
             alloc
                 .line()
-                .append(alloc.intersperse(dtors.iter().map(|dtor| dtor.print(cfg, alloc)), sep))
+                .append(
+                    alloc
+                        .intersperse(dtors.iter().map(|dtor| dtor.print(cfg, alloc)), sep.clone())
+                        .append(alloc.text(COMMA).flat_alt(alloc.nil())),
+                )
                 .nest(cfg.indent)
                 .append(alloc.line())
                 .braces_anno()

--- a/lang/ast/src/exp/case.rs
+++ b/lang/ast/src/exp/case.rs
@@ -152,7 +152,8 @@ pub fn print_cases<'a>(cases: &'a [Case], cfg: &PrintCfg, alloc: &'a Alloc<'a>) 
             let sep = alloc.text(COMMA).append(alloc.hardline());
             alloc
                 .hardline()
-                .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep.clone()))
+                .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+                .append(alloc.text(COMMA).flat_alt(alloc.nil()))
                 .nest(cfg.indent)
                 .append(alloc.hardline())
                 .braces_anno()

--- a/lang/ast/src/exp/hole.rs
+++ b/lang/ast/src/exp/hole.rs
@@ -200,7 +200,7 @@ fn print_hole_args<'a>(
 ) -> Builder<'a> {
     let groups = args.iter().map(|group| group.print(cfg, alloc).parens());
     let sep = alloc.text(COMMA).append(alloc.space());
-    alloc.intersperse(groups, sep).brackets()
+    alloc.intersperse(groups, sep).append(alloc.text(COMMA).flat_alt(alloc.nil())).brackets()
 }
 
 impl Zonk for Hole {

--- a/lang/backend/src/ir/exprs.rs
+++ b/lang/backend/src/ir/exprs.rs
@@ -255,7 +255,11 @@ pub fn print_cases<'a>(cases: &'a [Case], cfg: &PrintCfg, alloc: &'a Alloc<'a>) 
             let sep = alloc.text(COMMA).append(alloc.hardline());
             alloc
                 .hardline()
-                .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep.clone()))
+                .append(
+                    alloc
+                        .intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep)
+                        .append(alloc.text(COMMA).flat_alt(alloc.nil())),
+                )
                 .nest(cfg.indent)
                 .append(alloc.hardline())
                 .braces_anno()

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -29,7 +29,11 @@ fn print_cases<'a>(cases: &'a [Case], cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> B
     let sep = alloc.text(COMMA).append(alloc.hardline());
     alloc
         .hardline()
-        .append(alloc.intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep))
+        .append(
+            alloc
+                .intersperse(cases.iter().map(|x| x.print(cfg, alloc)), sep)
+                .append(alloc.text(COMMA).flat_alt(alloc.nil())),
+        )
         .nest(cfg.indent)
         .append(alloc.hardline())
         .braces_anno()

--- a/std/codata/fun.pol
+++ b/std/codata/fun.pol
@@ -1,7 +1,7 @@
 /// The type of non-dependent functions.
 codata Fun(a b: Type) {
     /// Application of a function to its argument.
-    Fun(a, b).ap(implicit a b: Type, x: a): b
+    Fun(a, b).ap(implicit a b: Type, x: a): b,
 }
 
 /// The polymorphic identity function.

--- a/std/codata/pair.pol
+++ b/std/codata/pair.pol
@@ -3,11 +3,11 @@ codata Pair(a b: Type) {
     /// First projection on a pair.
     Pair(a, b).fst(implicit a b: Type): a,
     /// Second projection on a pair.
-    Pair(a, b).snd(implicit a b: Type): b
+    Pair(a, b).snd(implicit a b: Type): b,
 }
 
 /// Constructing an element of the pair type.
 codef MkPair(a b: Type, x: a, y: b): Pair(a, b) {
     .fst(_, _) => x,
-    .snd(_, _) => y
+    .snd(_, _) => y,
 }

--- a/std/codata/pi.pol
+++ b/std/codata/pi.pol
@@ -2,5 +2,5 @@ use "./fun.pol"
 
 /// The dependent function type.
 codata Pi(a: Type, p: a -> Type) {
-    Pi(a, p).dap(a: Type, p: a -> Type, x: a): p.ap(x)
+    Pi(a, p).dap(a: Type, p: a -> Type, x: a): p.ap(x),
 }

--- a/std/codata/sigma.pol
+++ b/std/codata/sigma.pol
@@ -3,5 +3,5 @@ use "./fun.pol"
 /// The (strong) Sigma type defined by first and second projections.
 codata Sigma(A: Type, T: A -> Type) {
   Sigma(A,T).proj1(A: Type, T: A -> Type): A,
-  (self: Sigma(A,T)).proj2(A: Type, T: A -> Type): T.ap(self.proj1(A,T))
+  (self: Sigma(A,T)).proj2(A: Type, T: A -> Type): T.ap(self.proj1(A,T)),
 }

--- a/std/codata/stream.pol
+++ b/std/codata/stream.pol
@@ -3,11 +3,11 @@ codata Stream(a: Type) {
     /// The head observation which yields the first element.
     Stream(a).hd(implicit a: Type): a,
     /// The tail observation which yields the remainder of the stream.
-    Stream(a).tl(implicit a: Type): Stream(a)
+    Stream(a).tl(implicit a: Type): Stream(a),
 }
 
 /// An infinite stream which repeats the argument.
 codef Repeat(a: Type, elem: a): Stream(a) {
     .hd(_) => elem,
-    .tl(_) => Repeat(a, elem)
+    .tl(_) => Repeat(a, elem),
 }

--- a/std/data/bool.pol
+++ b/std/data/bool.pol
@@ -3,25 +3,25 @@ data Bool {
     /// The boolean constant True.
     T,
     /// The boolean constant False.
-    F
+    F,
 }
 
 /// Negation of a boolean value.
 def Bool.neg: Bool {
     T => F,
-    F => T
+    F => T,
 }
 
 /// Conjunction of two boolean values.
 def Bool.and(other: Bool): Bool {
     T => other,
-    F => F
+    F => F,
 }
 
 /// Inclusive disjunction of two boolean values.
 def Bool.or(other: Bool): Bool {
     T => T,
-    F => other
+    F => other,
 }
 
 /// Exclusive disjunction of two boolean values.
@@ -29,9 +29,9 @@ def Bool.xor(other: Bool): Bool {
     T =>
         other.match {
             T => F,
-            F => T
+            F => T,
         },
-    F => other
+    F => other,
 }
 
 /// Boolean nor function, also called joint denial or Peirce's function.
@@ -40,8 +40,8 @@ def Bool.nor(other: Bool): Bool {
     F =>
         other.match {
             T => F,
-            F => T
-        }
+            F => T,
+        },
 }
 
 /// Boolean nand function, also called alternative denial or Sheffer stroke.
@@ -49,14 +49,14 @@ def Bool.nand(other: Bool): Bool {
     T =>
         other.match {
             T => F,
-            F => T
+            F => T,
         },
-    F => T
+    F => T,
 }
 
 /// If-then-else combinator which returns the `then` argument if the boolean is true
 /// and the `else` argument otherwise.
 def Bool.ite(implicit a: Type, then else: a): a {
     T => then,
-    F => else
+    F => else,
 }

--- a/std/data/eq.pol
+++ b/std/data/eq.pol
@@ -1,7 +1,7 @@
 /// The Martin-Löf equality type.
 data Eq(implicit a: Type, x y: a) {
     /// The reflexivity constructor.
-    Refl(implicit a: Type, x: a): Eq(x, x)
+    Refl(implicit a: Type, x: a): Eq(x, x),
 }
 
 /// Proof of symmetry of equality.

--- a/std/data/list.pol
+++ b/std/data/list.pol
@@ -3,23 +3,23 @@ data List(a: Type) {
     /// The canonical empty list.
     Nil(a: Type): List(a),
     /// Appending one element to the front of a list.
-    Cons(a: Type, x: a, xs: List(a)): List(a)
+    Cons(a: Type, x: a, xs: List(a)): List(a),
 }
 
 /// Concatenating two lists together.
 def List(a).concat(a: Type, other: List(a)): List(a) {
     Nil(_) => other,
-    Cons(_, x, xs) => Cons(a, x, xs.concat(a, other))
+    Cons(_, x, xs) => Cons(a, x, xs.concat(a, other)),
 }
 
 /// Appending an element to the end of a list.
 def List(a).snoc(a: Type, elem: a): List(a) {
     Nil(_) => Cons(a, elem, Nil(a)),
-    Cons(_, x, xs) => Cons(a, x, xs.snoc(a, elem))
+    Cons(_, x, xs) => Cons(a, x, xs.snoc(a, elem)),
 }
 
 /// Reversing the elements of a list.
 def List(a).reverse(a: Type): List(a) {
     Nil(_) => Nil(a),
-    Cons(_, x, xs) => xs.reverse(a).snoc(a, x)
+    Cons(_, x, xs) => xs.reverse(a).snoc(a, x),
 }

--- a/std/data/nat.pol
+++ b/std/data/nat.pol
@@ -6,19 +6,19 @@ data Nat {
     /// The constant zero.
     Z,
     /// The successor of a Peano natural number.
-    S(pred: Nat)
+    S(pred: Nat),
 }
 
 /// Addition of two natural numbers.
 def Nat.add(other: Nat): Nat {
     Z => other,
-    S(x) => S(x.add(other))
+    S(x) => S(x.add(other)),
 }
 
 /// Multiplication of two natural numbers.
 def Nat.mul(other: Nat): Nat {
     Z => Z,
-    S(x) => other.add(x.mul(other))
+    S(x) => other.add(x.mul(other)),
 }
 
 /// A saturating version of subtraction.
@@ -27,21 +27,21 @@ def Nat.monus(other: Nat): Nat {
     S(pred) =>
         other.match {
             Z => S(pred),
-            S(pred') => pred.monus(pred')
-        }
+            S(pred') => pred.monus(pred'),
+        },
 }
 
 /// The factorial of a natural number.
 def Nat.fact: Nat {
     Z => 1,
-    S(pred) => S(pred).mul(pred.fact)
+    S(pred) => S(pred).mul(pred.fact),
 }
 
 /// The predecessor of a natural number.
 /// The predecessor of `Z` is `Z`.
 def Nat.pred: Nat {
     Z => Z,
-    S(x) => x
+    S(x) => x,
 }
 
 /// Compare two natural numbers.
@@ -59,29 +59,29 @@ def Nat.cmp(other: Nat): Ordering {
 /// The lesser-or-equal relation on natural numbers.
 data LE(x y: Nat) {
     LERefl(x: Nat): LE(x, x),
-    LESucc(x y: Nat, h: LE(x, y)): LE(x, S(y))
+    LESucc(x y: Nat, h: LE(x, y)): LE(x, S(y)),
 }
 
 /// Z is smaller than any natural number.
 def (x: Nat).z_le: LE(Z, x) {
     Z => LERefl(Z),
-    S(x) => LESucc(Z, x, x.z_le)
+    S(x) => LESucc(Z, x, x.z_le),
 }
 
 /// If x <= y, then S(x) <= S(y)
 def LE(x, y).le_succ(x y: Nat): LE(S(x), S(y)) {
     LERefl(_) => LERefl(S(x)),
-    LESucc(x, y, h) => LESucc(S(x), S(y), h.le_succ(x, y))
+    LESucc(x, y, h) => LESucc(S(x), S(y), h.le_succ(x, y)),
 }
 
 /// If S(x) <= S(y), then x <= y.
 def LE(S(x), S(y)).le_unsucc(x y: Nat): LE(x, y) {
     LERefl(_) => LERefl(x),
-    LESucc(_, _, h) => h.s_le(x, y)
+    LESucc(_, _, h) => h.s_le(x, y),
 }
 
 /// If S(x) <= y, then x <= y
 def LE(S(x), y).s_le(x y: Nat): LE(x, y) {
     LERefl(_) => LESucc(x, x, LERefl(x)),
-    LESucc(_, y', h) => LESucc(x, y', h.s_le(x, y'))
+    LESucc(_, y', h) => LESucc(x, y', h.s_le(x, y')),
 }

--- a/std/data/option.pol
+++ b/std/data/option.pol
@@ -3,5 +3,5 @@ data Option(a: Type) {
     /// No value
     None(a: Type): Option(a),
     /// Some value of type `a`
-    Some(a: Type, x: a): Option(a)
+    Some(a: Type, x: a): Option(a),
 }

--- a/std/data/pair.pol
+++ b/std/data/pair.pol
@@ -1,7 +1,7 @@
 /// The data type of pairs defined by a constructor.
 data Pair(a b: Type) {
     /// Constructing an element of the pair type.
-    MkPair(a b: Type, x: a, y: b): Pair(a, b)
+    MkPair(a b: Type, x: a, y: b): Pair(a, b),
 }
 
 /// Projection on the first element of a pair.

--- a/std/data/result.pol
+++ b/std/data/result.pol
@@ -3,5 +3,5 @@ data Result(a b: Type) {
     /// A successful result.
     Ok(a b: Type, res: a): Result(a, b),
     /// An error containing an error value.
-    Err(a b: Type, err: b): Result(a, b)
+    Err(a b: Type, err: b): Result(a, b),
 }

--- a/std/data/sigma.pol
+++ b/std/data/sigma.pol
@@ -2,5 +2,5 @@ use "../codata/fun.pol"
 
 /// The Sigma type defined by a tupling constructor.
 data Sigma(A: Type, T: A -> Type) {
-  MkSigma(A: Type, T: A -> Type, x: A, w: T.ap(x)): Sigma(A,T)
+  MkSigma(A: Type, T: A -> Type, x: A, w: T.ap(x)): Sigma(A,T),
 }

--- a/std/data/vec.pol
+++ b/std/data/vec.pol
@@ -5,11 +5,11 @@ data Vec(n : Nat, a: Type) {
     /// The empty vector.
     VNil(a : Type) : Vec(Z, a),
     /// Appending one element to a vector.
-    VCons(n : Nat, a: Type, x: a, xs: Vec(n,a)) : Vec(S(n), a)
+    VCons(n : Nat, a: Type, x: a, xs: Vec(n,a)) : Vec(S(n), a),
 }
 
 /// The first element of a non-empty vector.
 def Vec(S(n), a).head(n: Nat, a: Type) : a {
     VNil(_) absurd,
-    VCons(_,_,x,_) => x
+    VCons(_,_,x,_) => x,
 }

--- a/test/suites/success/005.ir.expected
+++ b/test/suites/success/005.ir.expected
@@ -1,6 +1,6 @@
 def .not {
     True => False,
-    False => True
+    False => True,
 }
 
 def .false { Unit => True.not }

--- a/test/suites/success/007.ir.expected
+++ b/test/suites/success/007.ir.expected
@@ -1,4 +1,4 @@
 def .foo {
     CTrue => Z,
-    CFalse absurd
+    CFalse absurd,
 }

--- a/test/suites/success/011.ir.expected
+++ b/test/suites/success/011.ir.expected
@@ -2,5 +2,5 @@ def .foo {
     Foo1 => True,
     Foo2 absurd,
     Foo3 absurd,
-    Foo4 absurd
+    Foo4 absurd,
 }

--- a/test/suites/success/012.ir.expected
+++ b/test/suites/success/012.ir.expected
@@ -2,5 +2,5 @@ codef MyFoo {
     .foo1 => True,
     .foo2 absurd,
     .foo3 absurd,
-    .foo4 absurd
+    .foo4 absurd,
 }

--- a/test/suites/success/013.ir.expected
+++ b/test/suites/success/013.ir.expected
@@ -1,6 +1,6 @@
 let add(x, y) {
     x.match {
         Z => y,
-        S(x') => panic!("not yet implemented")
+        S(x') => panic!("not yet implemented"),
     }
 }

--- a/test/suites/success/014.ir.expected
+++ b/test/suites/success/014.ir.expected
@@ -1,11 +1,11 @@
 def .add(y) {
     Z => y,
-    S(x') => S(x'.add(y))
+    S(x') => S(x'.add(y)),
 }
 
 def .append'(n, m, ys) {
     Cons(n', x, xs) => Cons(n'.add(m), x, xs.append'(n', m, ys)),
-    Nil => ys
+    Nil => ys,
 }
 
 let append(n, m, xs, ys) { xs.append'(n, m, ys) }

--- a/test/suites/success/016-named-args.ir.expected
+++ b/test/suites/success/016-named-args.ir.expected
@@ -1,6 +1,6 @@
 def .and(other) {
     True => other,
-    False => False
+    False => False,
 }
 
 let example1 { Cons(True, Nil) }

--- a/test/suites/success/019-absurd.ir.expected
+++ b/test/suites/success/019-absurd.ir.expected
@@ -2,5 +2,5 @@ def .elim_zero { SNotZero(n) absurd }
 
 def .elim {
     Ok(x) => x,
-    Absurd(x) => x.elim_zero
+    Absurd(x) => x.elim_zero,
 }

--- a/test/suites/success/020-motive.ir.expected
+++ b/test/suites/success/020-motive.ir.expected
@@ -1,12 +1,12 @@
 def .rep {
     T => TrueRep,
-    F => FalseRep
+    F => FalseRep,
 }
 
 def .example(b) {
     Unit =>
         b.match {
             T => TrueRep,
-            F => FalseRep
+            F => FalseRep,
         }
 }

--- a/test/suites/success/024-gadt.ir.expected
+++ b/test/suites/success/024-gadt.ir.expected
@@ -1,4 +1,4 @@
 def .unwrap {
     WrapFoo(x) => x,
-    WrapBar(x) => x
+    WrapBar(x) => x,
 }

--- a/test/suites/success/025-imports.ir.expected
+++ b/test/suites/success/025-imports.ir.expected
@@ -3,7 +3,7 @@ use "../../../std/data/bool.pol"
 
 def .iNeg {
     T => F,
-    F => T
+    F => T,
 }
 
 let one { S(Z) }

--- a/test/suites/success/026-refinement.ir.expected
+++ b/test/suites/success/026-refinement.ir.expected
@@ -8,10 +8,10 @@ def .cong(x, y, f) { Refl(x0) => Refl(f.ap(y)) }
 
 def .not {
     True => False,
-    False => True
+    False => True,
 }
 
 def .not_inverse {
     True => Refl(True),
-    False => Refl(False)
+    False => Refl(False),
 }

--- a/test/suites/success/026-typedhole.ir.expected
+++ b/test/suites/success/026-typedhole.ir.expected
@@ -1,21 +1,21 @@
 def .add(y) {
     Z => y,
-    S(x') => S(x'.add(y))
+    S(x') => S(x'.add(y)),
 }
 
 def .head(n) {
     Cons(n', x, xs) => panic!("not yet implemented"),
-    Nil absurd
+    Nil absurd,
 }
 
 def .tail(n) {
     Cons(n', x, xs) => panic!("not yet implemented"),
-    Nil absurd
+    Nil absurd,
 }
 
 def .append(n, m, ys) {
     Nil => ys,
-    Cons(n', x, xs) => Cons(n'.add(m), x, xs.append(n', m, ys))
+    Cons(n', x, xs) => Cons(n'.add(m), x, xs.append(n', m, ys)),
 }
 
 def .example1 { Unit => Cons(S(Z), Z, Cons(Z, Z, Nil)) }
@@ -24,25 +24,25 @@ def .example2 { Unit => Unit.example1.append(S(S(Z)), S(S(Z)), Unit.example1) }
 
 def .not {
     T => F,
-    F => T
+    F => T,
 }
 
 def .if_then_else(then, else) {
     T => then,
-    F => else
+    F => else,
 }
 
 codef Zeroes {
     .sHead => Z,
-    .sTail => Zeroes
+    .sTail => Zeroes,
 }
 
 codef Ones {
     .sHead => S(Z),
-    .sTail => panic!("not yet implemented")
+    .sTail => panic!("not yet implemented"),
 }
 
 codef Alternate(choose) {
     .sHead => choose.if_then_else(S(panic!("not yet implemented")), Z),
-    .sTail => Alternate(choose.not)
+    .sTail => Alternate(choose.not),
 }

--- a/test/suites/success/027-colist.ir.expected
+++ b/test/suites/success/027-colist.ir.expected
@@ -1,15 +1,15 @@
 def .pred {
     Z => Z,
     S(n) => n,
-    Omega => Omega
+    Omega => Omega,
 }
 
 codef CountUp(from) {
     .head(n, p) => from,
-    .tail(n) => CountUp(S(from))
+    .tail(n) => CountUp(S(from)),
 }
 
 codef TakeN(n, s) {
     .head(n', p) => s.head(Omega, OmegaNotZero),
-    .tail(n') => TakeN(n.pred, s.tail(Omega))
+    .tail(n') => TakeN(n.pred, s.tail(Omega)),
 }

--- a/test/suites/success/028-boolrep.ir.expected
+++ b/test/suites/success/028-boolrep.ir.expected
@@ -2,14 +2,14 @@ use "../../../std/data/bool.pol"
 
 def .extract(x) {
     TrueRep => T,
-    FalseRep => F
+    FalseRep => F,
 }
 
 def .flipRep(x, rep) {
     Unit =>
         rep.match {
             TrueRep => FalseRep,
-            FalseRep => TrueRep
+            FalseRep => TrueRep,
         }
 }
 

--- a/test/suites/success/029-arith.ir.expected
+++ b/test/suites/success/029-arith.ir.expected
@@ -1,11 +1,11 @@
 def .add(y) {
     Z => y,
-    S(x') => S(x'.add(y))
+    S(x') => S(x'.add(y)),
 }
 
 def .and(y) {
     T => y,
-    F => F
+    F => F,
 }
 
 def .preserves(e1, e2, t, h1) {
@@ -15,7 +15,7 @@ def .preserves(e1, e2, t, h1) {
     EIsZeroCong(e, e', h_e) => panic!("not yet implemented"),
     EAndCongL(lhs, lhs', rhs, h_lhs) => panic!("not yet implemented"),
     EAndCongR(lhs, rhs, rhs', h_rhs) => panic!("not yet implemented"),
-    EAndRed(b1, b2) => panic!("not yet implemented")
+    EAndRed(b1, b2) => panic!("not yet implemented"),
 }
 
 let example { And(IsZero(Add(Num(Z), Num(Z))), Boo(T)) }

--- a/test/suites/success/030-buffer.ir.expected
+++ b/test/suites/success/030-buffer.ir.expected
@@ -1,11 +1,11 @@
 def .head(n) {
     Cons(n', x, xs) => x,
-    Nil absurd
+    Nil absurd,
 }
 
 def .tail(n) {
     Cons(n', x, xs) => xs,
-    Nil absurd
+    Nil absurd,
 }
 
 codef Empty { .read(n) absurd }
@@ -14,6 +14,6 @@ codef FromVec(n, xs) {
     .read(n') =>
         comatch {
             .proj1 => xs.head(n'),
-            .proj2 => FromVec(n', xs.tail(n'))
+            .proj2 => FromVec(n', xs.tail(n')),
         }
 }

--- a/test/suites/success/032-expressions-case-study.ir.expected
+++ b/test/suites/success/032-expressions-case-study.ir.expected
@@ -2,24 +2,24 @@ def .pres(e, ty) {
     TTrue => comatch { .preservationStep(e1, e2, ty0, s) => s.d_step1(e2) },
     TFalse => comatch { .preservationStep(e1, e2, ty0, s) => s.d_step3(e2) },
     TIte(e1, e2, e3, ty0, t1, t2, t3) =>
-        comatch { .preservationStep(e4, e5, ty1, s) => s.d_step5(e1, e2, e3, e5, ty, t1, t2, t3) }
+        comatch { .preservationStep(e4, e5, ty1, s) => s.d_step5(e1, e2, e3, e5, ty, t1, t2, t3) },
 }
 
 codef StIteT(e1, e2) {
     .d_step3(e3) absurd,
     .d_step1(e3) absurd,
-    .d_step5(e3, e4, e5, e6, ty, t1, t2, t3) => t2
+    .d_step5(e3, e4, e5, e6, ty, t1, t2, t3) => t2,
 }
 
 codef StIteF(e1, e2) {
     .d_step3(e3) absurd,
     .d_step1(e3) absurd,
-    .d_step5(e3, e4, e5, e6, ty, t1, t2, t3) => t3
+    .d_step5(e3, e4, e5, e6, ty, t1, t2, t3) => t3,
 }
 
 codef StIte(e1, e2, e3, e4, s) {
     .d_step1(e5) absurd,
     .d_step3(e5) absurd,
     .d_step5(e1', e2', e3', e5', ty, t1, t2, t3) =>
-        TIte(e2, e3, e4, ty, t1.pres(e1, TyBool).preservationStep(e1, e2, TyBool, s), t2, t3)
+        TIte(e2, e3, e4, ty, t1.pres(e1, TyBool).preservationStep(e1, e2, TyBool, s), t2, t3),
 }

--- a/test/suites/success/034-local-matches.ir.expected
+++ b/test/suites/success/034-local-matches.ir.expected
@@ -2,7 +2,7 @@ def .top_is_zero(n) {
     Unit =>
         n.match {
             Z => T,
-            S(n0) => F
+            S(n0) => F,
         }
 }
 

--- a/test/suites/success/035-stlc-bool.ir.expected
+++ b/test/suites/success/035-stlc-bool.ir.expected
@@ -1,11 +1,11 @@
 def .append(other) {
     Nil => other,
-    Cons(t, ts) => Cons(t, ts.append(other))
+    Cons(t, ts) => Cons(t, ts.append(other)),
 }
 
 def .len {
     Nil => Z,
-    Cons(x, ts) => S(ts.len)
+    Cons(x, ts) => S(ts.len),
 }
 
 def .subst(v, by) {
@@ -13,13 +13,13 @@ def .subst(v, by) {
     Lam(e) => Lam(e.subst(S(v), by)),
     App(e1, e2) => App(e1.subst(v, by), e2.subst(v, by)),
     Lit(b) => Lit(b),
-    If(cond, then, else) => If(cond.subst(v, by), then.subst(v, by), else.subst(v, by))
+    If(cond, then, else) => If(cond.subst(v, by), then.subst(v, by), else.subst(v, by)),
 }
 
 def .subst_result(x, by) {
     LT => Var(x),
     EQ => by,
-    GT => Var(x.pred)
+    GT => Var(x.pred),
 }
 
 def .progress(t) {
@@ -31,7 +31,7 @@ def .progress(t) {
                     TLam(x2, x3, x4, x5, x6) absurd,
                     TApp(x2, x3, x4, x5, x6, x7, x8) absurd,
                     TLit(x2, x3) absurd,
-                    TIf(x2, x3, x4, x5, x6, x7, x8, x9) absurd
+                    TIf(x2, x3, x4, x5, x6, x7, x8, x9) absurd,
                 }
         },
     Lam(e) => comatch { .ap(x1) => PVal(Lam(e), VLam(e)) },
@@ -57,11 +57,11 @@ def .progress(t) {
                                             TLam(x6, x7, x8, x9, x10) absurd,
                                             TApp(x6, x7, x8, x9, x10, x11, x12) absurd,
                                             TIf(x6, x7, x8, x9, x10, x11, x12, x13) absurd,
-                                            TLit(x6, x7) absurd
+                                            TLit(x6, x7) absurd,
                                         },
-                                    VLam(e) => PStep(App(Lam(e), e2), e.subst(Z, e2), EBeta(e, e2))
-                                }
-                        }
+                                    VLam(e) => PStep(App(Lam(e), e2), e.subst(Z, e2), EBeta(e, e2)),
+                                },
+                        },
                 }
         },
     Lit(b) => comatch { .ap(x1) => PVal(Lit(b), VLit(b)) },
@@ -83,7 +83,7 @@ def .progress(t) {
                                             TLam(x8, x9, x10, x11, x12) absurd,
                                             TApp(x8, x9, x10, x11, x12, x13, x14) absurd,
                                             TIf(x8, x9, x10, x11, x12, x13, x14, x15) absurd,
-                                            TLit(x8, x9) absurd
+                                            TLit(x8, x9) absurd,
                                         },
                                     VLit(b) =>
                                         b.match {
@@ -94,16 +94,16 @@ def .progress(t) {
                                             False =>
                                                 PStep(If(Lit(False), then, else),
                                                       else,
-                                                      EIfFalse(then, else))
-                                        }
+                                                      EIfFalse(then, else)),
+                                        },
                                 },
                             PStep(x6, cond', h_eval) =>
                                 PStep(If(cond, then, else),
                                       If(cond', then, else),
-                                      ECongIf(cond, cond', then, else, h_eval))
-                        }
+                                      ECongIf(cond, cond', then, else, h_eval)),
+                        },
                 }
-        }
+        },
 }
 
 def .preservation(e2, t) {
@@ -118,7 +118,7 @@ def .preservation(e2, t) {
                             ECongApp2(x4, x5, x6, x7) absurd,
                             ECongIf(x4, x5, x6, x7, x8) absurd,
                             EIfTrue(x4, x5) absurd,
-                            EIfFalse(x4, x5) absurd
+                            EIfFalse(x4, x5) absurd,
                         }
                 }
         },
@@ -133,7 +133,7 @@ def .preservation(e2, t) {
                             ECongApp2(x4, x5, x6, x7) absurd,
                             ECongIf(x4, x5, x6, x7, x8) absurd,
                             EIfTrue(x4, x5) absurd,
-                            EIfFalse(x4, x5) absurd
+                            EIfFalse(x4, x5) absurd,
                         }
                 }
         },
@@ -177,10 +177,10 @@ def .preservation(e2, t) {
                                             TLam(x7, x8, x9, x10, h_e1) =>
                                                 e4.subst_lemma(Nil, Nil, t1, t, e3)
                                                   .ap(h_e1)
-                                                  .ap(h_e2)
-                                        }
+                                                  .ap(h_e2),
+                                        },
                                 }
-                        }
+                        },
                 }
         },
     Lit(b) =>
@@ -194,7 +194,7 @@ def .preservation(e2, t) {
                             ECongApp2(x3, x4, x5, x6) absurd,
                             ECongIf(x3, x4, x5, x6, x7) absurd,
                             EIfTrue(x3, x4) absurd,
-                            EIfFalse(x3, x4) absurd
+                            EIfFalse(x3, x4) absurd,
                         }
                 }
         },
@@ -225,11 +225,11 @@ def .preservation(e2, t) {
                                             h_then,
                                             h_else),
                                     EIfTrue(x7, x8) => h_then,
-                                    EIfFalse(x7, x8) => h_else
-                                }
+                                    EIfFalse(x7, x8) => h_else,
+                                },
                         }
                 }
-        }
+        },
 }
 
 def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
@@ -291,8 +291,8 @@ def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
                                                                                      t1,
                                                                                      x)
                                                                    .ap(h_gt)
-                                                                   .ap(h_elem)))
-                                }
+                                                                   .ap(h_elem))),
+                                },
                         }
                 }
         },
@@ -313,7 +313,7 @@ def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
                                      body.subst(S(ctx1.len), by_e),
                                      body.subst_lemma(Cons(a, ctx1), ctx2, t1, b, by_e)
                                          .ap(h_body)
-                                         .ap(h_by))
+                                         .ap(h_by)),
                         }
                 }
         },
@@ -336,7 +336,7 @@ def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
                                      e1.subst_lemma(ctx1, ctx2, t1, FunT(a, t2), by_e)
                                        .ap(h_e1)
                                        .ap(h_by),
-                                     e2.subst_lemma(ctx1, ctx2, t1, a, by_e).ap(h_e2).ap(h_by))
+                                     e2.subst_lemma(ctx1, ctx2, t1, a, by_e).ap(h_e2).ap(h_by)),
                         }
                 }
         },
@@ -350,7 +350,7 @@ def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
                             TLam(x3, x4, x5, x6, x7) absurd,
                             TApp(x3, x4, x5, x6, x7, x8, x9) absurd,
                             TIf(x3, x4, x5, x6, x7, x8, x9, x10) absurd,
-                            TLit(x3, x4) => TLit(ctx1.append(ctx2), b)
+                            TLit(x3, x4) => TLit(ctx1.append(ctx2), b),
                         }
                 }
         },
@@ -374,10 +374,10 @@ def .subst_lemma(ctx1, ctx2, t1, t2, by_e) {
                                         .ap(h_cond)
                                         .ap(h_by),
                                     then.subst_lemma(ctx1, ctx2, t1, t2, by_e).ap(h_then).ap(h_by),
-                                    else.subst_lemma(ctx1, ctx2, t1, t2, by_e).ap(h_else).ap(h_by))
+                                    else.subst_lemma(ctx1, ctx2, t1, t2, by_e).ap(h_else).ap(h_by)),
                         }
                 }
-        }
+        },
 }
 
 def .weaken_append(ctx1, e, t) {
@@ -396,7 +396,7 @@ def .weaken_append(ctx1, e, t) {
                                comatch { .ap(ctx) => <ZST> },
                                ts.weaken_append(ctx1.append(Cons(t', Nil)), e, t)
                                  .ap(e.weaken_cons(ctx1, t', t).ap(h_e)))
-        }
+        },
 }
 
 def .weaken_cons(ctx, t1, t2) {
@@ -409,7 +409,7 @@ def .weaken_cons(ctx, t1, t2) {
                     TLit(x2, x3) absurd,
                     TIf(x2, x3, x4, x5, x6, x7, x8, x9) absurd,
                     TVar(x2, x3, x4, h_elem) =>
-                        TVar(ctx.append(Cons(t1, Nil)), x, t2, h_elem.elem_append(x, t1, t2, ctx))
+                        TVar(ctx.append(Cons(t1, Nil)), x, t2, h_elem.elem_append(x, t1, t2, ctx)),
                 }
         },
     Lam(e) =>
@@ -425,7 +425,7 @@ def .weaken_cons(ctx, t1, t2) {
                              a,
                              b,
                              e,
-                             e.weaken_cons(Cons(a, ctx), t1, b).ap(h_e0))
+                             e.weaken_cons(Cons(a, ctx), t1, b).ap(h_e0)),
                 }
         },
     App(e1, e2) =>
@@ -443,7 +443,7 @@ def .weaken_cons(ctx, t1, t2) {
                              e1,
                              e2,
                              e1.weaken_cons(ctx, t1, FunT(a, t2)).ap(h_e1),
-                             e2.weaken_cons(ctx, t1, a).ap(h_e2))
+                             e2.weaken_cons(ctx, t1, a).ap(h_e2)),
                 }
         },
     Lit(b) =>
@@ -454,7 +454,7 @@ def .weaken_cons(ctx, t1, t2) {
                     TLam(x1, x2, x3, x4, x5) absurd,
                     TApp(x1, x2, x3, x4, x5, x6, x7) absurd,
                     TIf(x1, x2, x3, x4, x5, x6, x7, x8) absurd,
-                    TLit(x1, x2) => TLit(ctx.append(Cons(t1, Nil)), b)
+                    TLit(x1, x2) => TLit(ctx.append(Cons(t1, Nil)), b),
                 }
         },
     If(cond, then, else) =>
@@ -473,15 +473,15 @@ def .weaken_cons(ctx, t1, t2) {
                             t2,
                             cond.weaken_cons(ctx, t1, BooT).ap(h_cond),
                             then.weaken_cons(ctx, t1, t2).ap(h_then),
-                            else.weaken_cons(ctx, t1, t2).ap(h_else))
+                            else.weaken_cons(ctx, t1, t2).ap(h_else)),
                 }
-        }
+        },
 }
 
 def .elem_append(n, t1, t2, ctx) {
     Here(t, ts) => Here(t2, ts.append(Cons(t1, Nil))),
     There(n0, x, t', ts, h) =>
-        There(n0, t2, t', ts.append(Cons(t1, Nil)), h.elem_append(n0, t1, t2, ts))
+        There(n0, t2, t', ts.append(Cons(t1, Nil)), h.elem_append(n0, t1, t2, ts)),
 }
 
 def .append_assoc(ctx2, ctx3) {
@@ -490,22 +490,22 @@ def .append_assoc(ctx2, ctx3) {
         xs.append_assoc(ctx2, ctx3)
           .cong(xs.append(ctx2).append(ctx3),
                 xs.append(ctx2.append(ctx3)),
-                comatch { .ap(xs0) => Cons(x, xs0) })
+                comatch { .ap(xs0) => Cons(x, xs0) }),
 }
 
 def .append_nil {
     Nil => Refl(Nil),
-    Cons(t, ts) => ts.append_nil.eq_cons(ts, ts.append(Nil), t)
+    Cons(t, ts) => ts.append_nil.eq_cons(ts, ts.append(Nil), t),
 }
 
 def .empty_absurd(x, t) {
     Here(x0, x1) absurd,
-    There(x0, x1, x2, x3, x4) absurd
+    There(x0, x1, x2, x3, x4) absurd,
 }
 
 def .elem_unique(ctx, t1, t2) {
     Here(x, x0) => Refl(t2),
-    There(x, x0, x1, x2, x3) absurd
+    There(x, x0, x1, x2, x3) absurd,
 }
 
 def .ctx_lookup(ctx2, t1, t2) {
@@ -515,9 +515,9 @@ def .ctx_lookup(ctx2, t1, t2) {
             .ap(h) =>
                 h.match {
                     Here(x1, x2) absurd,
-                    There(x1, x2, x3, x4, h0) => ts.ctx_lookup(ctx2, t1, t2).ap(h0)
+                    There(x1, x2, x3, x4, h0) => ts.ctx_lookup(ctx2, t1, t2).ap(h0),
                 }
-        }
+        },
 }
 
 def .elem_append_first(ctx2, t, x) {
@@ -528,7 +528,7 @@ def .elem_append_first(ctx2, t, x) {
                     .ap(h_elem) =>
                         h_lt.match {
                             LERefl(x4) absurd,
-                            LESucc(x4, x5, x6) absurd
+                            LESucc(x4, x5, x6) absurd,
                         }
                 }
         },
@@ -546,10 +546,10 @@ def .elem_append_first(ctx2, t, x) {
                                       ts,
                                       ts.elem_append_first(ctx2, t, x')
                                         .ap(h_lt.le_unsucc(S(), ts.len))
-                                        .ap(h))
+                                        .ap(h)),
                         }
                 }
-        }
+        },
 }
 
 def .elem_append_pred(ctx2, t1, t2, x) {
@@ -562,9 +562,9 @@ def .elem_append_pred(ctx2, t1, t2, x) {
                             Here(x4, x5) =>
                                 h_gt.match {
                                     LERefl(x6) absurd,
-                                    LESucc(x6, x7, x8) absurd
+                                    LESucc(x6, x7, x8) absurd,
                                 },
-                            There(x4, x5, x6, x7, h) => h
+                            There(x4, x5, x6, x7, h) => h,
                         }
                 }
         },
@@ -577,7 +577,7 @@ def .elem_append_pred(ctx2, t1, t2, x) {
                             Here(x4, x5) =>
                                 h_gt.match {
                                     LERefl(x6) absurd,
-                                    LESucc(x6, x7, x8) absurd
+                                    LESucc(x6, x7, x8) absurd,
                                 },
                             There(x', x4, x5, x6, h) =>
                                 h_gt.le_unsucc(S(ts.len), x')
@@ -591,10 +591,10 @@ def .elem_append_pred(ctx2, t1, t2, x) {
                                                      ts.append(ctx2),
                                                      ts.elem_append_pred(ctx2, t1, t2, x')
                                                        .ap(h_gt.le_unsucc(S(ts.len), x'))
-                                                       .ap(h)))
+                                                       .ap(h))),
                         }
                 }
-        }
+        },
 }
 
 def .elim_bot { }
@@ -611,27 +611,27 @@ def .eq_cons(xs, ys, t) { Refl(x0) => Refl(Cons(t, ys)) }
 
 def .pred {
     Z => Z,
-    S(x) => x
+    S(x) => x,
 }
 
 def .cmp(y) {
     Z =>
         y.match {
             Z => EQ,
-            S(x) => LT
+            S(x) => LT,
         },
     S(x) =>
         y.match {
             Z => GT,
-            S(y0) => x.cmp(y0)
-        }
+            S(y0) => x.cmp(y0),
+        },
 }
 
 def .cmp_reflect(y) {
     Z =>
         y.match {
             Z => IsEQ(Z, Z, Refl(EQ), Refl(Z)),
-            S(y0) => IsLT(Z, S(y0), Refl(LT), y0.z_le.le_succ(Z, y0))
+            S(y0) => IsLT(Z, S(y0), Refl(LT), y0.z_le.le_succ(Z, y0)),
         },
     S(x) =>
         y.match {
@@ -640,37 +640,37 @@ def .cmp_reflect(y) {
                 x.cmp_reflect(y0).match {
                     IsLT(x0, x1, h1, h2) => IsLT(S(x), S(y0), h1, h2.le_succ(S(x), y0)),
                     IsEQ(x0, x1, h1, h2) => IsEQ(S(x), S(y0), h1, h2.eq_s(x, y0)),
-                    IsGT(x0, x1, h1, h2) => IsGT(S(x), S(y0), h1, h2.le_succ(S(y0), x))
-                }
-        }
+                    IsGT(x0, x1, h1, h2) => IsGT(S(x), S(y0), h1, h2.le_succ(S(y0), x)),
+                },
+        },
 }
 
 def .z_le {
     Z => LERefl(Z),
-    S(x) => LESucc(Z, x, x.z_le)
+    S(x) => LESucc(Z, x, x.z_le),
 }
 
 def .le_succ(x, y) {
     LERefl(x0) => LERefl(S(y)),
-    LESucc(x0, y0, h) => LESucc(S(x), S(y0), h.le_succ(x, y0))
+    LESucc(x0, y0, h) => LESucc(S(x), S(y0), h.le_succ(x, y0)),
 }
 
 def .le_unsucc(x, y) {
     LERefl(x0) => LERefl(y),
-    LESucc(x0, x1, h) => h.s_le(x, y)
+    LESucc(x0, x1, h) => h.s_le(x, y),
 }
 
 def .s_le(x, y) {
     LERefl(x0) => LESucc(x, x, LERefl(x)),
-    LESucc(x0, y', h) => LESucc(x, y', h.s_le(x, y'))
+    LESucc(x0, y', h) => LESucc(x, y', h.s_le(x, y')),
 }
 
 def .s_pred(x, y) {
     LERefl(x0) => Refl(S(x)),
-    LESucc(x0, y', x1) => Refl(S())
+    LESucc(x0, y', x1) => Refl(S()),
 }
 
 def .not {
     True => False,
-    False => True
+    False => True,
 }

--- a/test/suites/success/036-webserver.ir.expected
+++ b/test/suites/success/036-webserver.ir.expected
@@ -2,7 +2,7 @@ def .cong_pair(a, b, c) { Refl(x0) => Refl(Pair(b, c)) }
 
 codef Pair(x, y) {
     .fst => x,
-    .snd => y
+    .snd => y,
 }
 
 codef MkUtils { .put_twice(n, route, state) => route.put(n).ap(route.put(n).ap(state).fst) }
@@ -14,12 +14,12 @@ codef Index {
             .ap(state) =>
                 comatch {
                     .fst => state,
-                    .snd => Forbidden
+                    .snd => Forbidden,
                 }
         },
     .get => comatch { .ap(state) => Return(state.counter(F)) },
     .put(n) => comatch { .ap(state) => Pair(state, Forbidden) },
-    .put_idempotent(n) => comatch { .dap(x0, state) => Refl(Pair(state, Forbidden)) }
+    .put_idempotent(n) => comatch { .dap(x0, state) => Refl(Pair(state, Forbidden)) },
 }
 
 codef Admin {
@@ -29,7 +29,7 @@ codef Admin {
             .ap(state) =>
                 comatch {
                     .fst => state.increment,
-                    .snd => Return(state.increment.counter(T))
+                    .snd => Return(state.increment.counter(T)),
                 }
         },
     .get => comatch { .ap(state) => Return(state.counter(T)) },
@@ -38,5 +38,5 @@ codef Admin {
         comatch {
             .dap(x0, state) =>
                 state.set_idempotent(T, n).cong_pair(state.set(n), state.set(n).set(n), Return(n))
-        }
+        },
 }

--- a/test/suites/success/037-vect.ir.expected
+++ b/test/suites/success/037-vect.ir.expected
@@ -1,21 +1,21 @@
 def .add(y) {
     Z => y,
-    S(x') => S(x'.add(y))
+    S(x') => S(x'.add(y)),
 }
 
 def .head(n) {
     Cons(n', x, xs) => x,
-    Nil absurd
+    Nil absurd,
 }
 
 def .tail(n) {
     Cons(n', x, xs) => xs,
-    Nil absurd
+    Nil absurd,
 }
 
 def .append(n, m, ys) {
     Nil => ys,
-    Cons(n', x, xs) => Cons(n'.add(m), x, xs.append(n', m, ys))
+    Cons(n', x, xs) => Cons(n'.add(m), x, xs.append(n', m, ys)),
 }
 
 def .example1 { Unit => Cons(S(Z), Z, Cons(Z, Z, Nil)) }

--- a/test/suites/success/Regr-137.ir.expected
+++ b/test/suites/success/Regr-137.ir.expected
@@ -1,4 +1,4 @@
 def .ind(P, step) {
     True => panic!("not yet implemented"),
-    False => panic!("not yet implemented")
+    False => panic!("not yet implemented"),
 }

--- a/test/suites/success/Regr-230.ir.expected
+++ b/test/suites/success/Regr-230.ir.expected
@@ -1,6 +1,6 @@
 def .add(m) {
     Z => m,
-    S(n) => S(n.add(m))
+    S(n) => S(n.add(m)),
 }
 
 let two { S(S(Z)) }

--- a/test/suites/success/Regr-230b.ir.expected
+++ b/test/suites/success/Regr-230b.ir.expected
@@ -1,6 +1,6 @@
 def .add(m) {
     Z => m,
-    S(n) => S(n.add(m))
+    S(n) => S(n.add(m)),
 }
 
 let two { S(S(Z)) }

--- a/test/suites/success/Regr-250.ir.expected
+++ b/test/suites/success/Regr-250.ir.expected
@@ -1,4 +1,4 @@
 codef Unit {
     .typeAt(x, x0) absurd,
-    .dataAt(x, x0) absurd
+    .dataAt(x, x0) absurd,
 }

--- a/test/suites/success/Regr-341b.ir.expected
+++ b/test/suites/success/Regr-341b.ir.expected
@@ -1,4 +1,4 @@
 def .foo {
     Bar => T,
-    Baz absurd
+    Baz absurd,
 }

--- a/test/suites/success/Regr-341c.ir.expected
+++ b/test/suites/success/Regr-341c.ir.expected
@@ -1,6 +1,6 @@
 def .neg {
     T => F,
-    F => T
+    F => T,
 }
 
 let foo { comatch { .ap(x) => x.neg } }


### PR DESCRIPTION
@timsueberkrueb [mentioned](https://github.com/polarity-lang/polarity/pull/506#issuecomment-2754603160) that they would prefer that the pretty printer emitted trailing commas. I also found this frustrating when using the editor actions in the web editor, and had assumed as a result that leaving off the comma was the preferred style for Polarity.

This PR implements trailing commas for all the places I could find, excluding argument lists (which seem to render with the trailing parenthesis on the last line). In the future it might be better if there was a common function that did this to share this between multiple pretty printers. 

I’ve also updated the examples and prelude to used this new style.