### PR TITLE
Respect lockfile in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 install:
-	@cargo build
+	@cargo build --release
 	@cargo install --offline --locked --path app --force
 
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: install
 install:
-	@cargo install --path app --force
+	@cargo build
+	@cargo install --offline --locked --path app --force
 
 .PHONY: check
 check: lint test


### PR DESCRIPTION
`cargo install` doesn't respect the lockfile `Cargo.lock` by default. This is why `make install` always tries to connect to the internet to update dependencies. With this patch `make install` should work reliably offline if the dependencies are cached.