### PR TITLE
Store values in TypeCtx

### DIFF
--- a/lang/ast/src/ctx/def.rs
+++ b/lang/ast/src/ctx/def.rs
@@ -117,16 +117,7 @@ where
         let sep = alloc.text(COMMA).append(alloc.space());
         let iter = self.iter().map(|ctx| {
             alloc
-                .intersperse(
-                    ctx.iter().map(|b| {
-                        b.name
-                            .print(cfg, alloc)
-                            .append(COLON)
-                            .append(alloc.space())
-                            .append(b.print(cfg, alloc))
-                    }),
-                    sep.clone(),
-                )
+                .intersperse(ctx.iter().map(|b| b.print(cfg, alloc)), sep.clone())
                 .append(alloc.text(COMMA).flat_alt(alloc.nil()))
                 .brackets()
         });

--- a/lang/ast/src/ctx/def.rs
+++ b/lang/ast/src/ctx/def.rs
@@ -116,10 +116,7 @@ where
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let sep = alloc.text(COMMA).append(alloc.space());
         let iter = self.iter().map(|ctx| {
-            alloc
-                .intersperse(ctx.iter().map(|b| b.print(cfg, alloc)), sep.clone())
-                .append(alloc.text(COMMA).flat_alt(alloc.nil()))
-                .brackets()
+            alloc.intersperse(ctx.iter().map(|b| b.print(cfg, alloc)), sep.clone()).brackets()
         });
         alloc.intersperse(iter, sep.clone()).brackets()
     }

--- a/lang/ast/src/ctx/def.rs
+++ b/lang/ast/src/ctx/def.rs
@@ -109,7 +109,10 @@ impl<T> From<Vec<Vec<Binder<T>>>> for GenericCtx<T> {
     }
 }
 
-impl<T: Print> Print for GenericCtx<T> {
+impl<T> Print for GenericCtx<T>
+where
+    Binder<T>: Print,
+{
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let sep = alloc.text(COMMA).append(alloc.space());
         let iter = self.iter().map(|ctx| {
@@ -120,7 +123,7 @@ impl<T: Print> Print for GenericCtx<T> {
                             .print(cfg, alloc)
                             .append(COLON)
                             .append(alloc.space())
-                            .append(b.content.print(cfg, alloc))
+                            .append(b.print(cfg, alloc))
                     }),
                     sep.clone(),
                 )

--- a/lang/ast/src/ctx/values.rs
+++ b/lang/ast/src/ctx/values.rs
@@ -23,24 +23,6 @@ impl TypeCtx {
             .collect();
         LevelCtx::from(bound)
     }
-
-    pub fn map_failable<E, F>(&self, f: F) -> Result<Self, E>
-    where
-        F: Fn(&Binding) -> Result<Binding, E>,
-    {
-        let bound: Result<_, _> = self
-            .bound
-            .iter()
-            .map(|stack| {
-                stack
-                    .iter()
-                    .map(|b| Ok(Binder { name: b.name.clone(), content: f(&b.content)? }))
-                    .collect()
-            })
-            .collect();
-
-        Ok(Self { bound: bound? })
-    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/lang/ast/src/ctx/values.rs
+++ b/lang/ast/src/ctx/values.rs
@@ -10,7 +10,7 @@ use crate::*;
 
 use super::{GenericCtx, LevelCtx};
 
-pub type TypeCtx = GenericCtx<Box<Exp>>;
+pub type TypeCtx = GenericCtx<Binding>;
 
 impl TypeCtx {
     pub fn levels(&self) -> LevelCtx {
@@ -26,7 +26,7 @@ impl TypeCtx {
 
     pub fn map_failable<E, F>(&self, f: F) -> Result<Self, E>
     where
-        F: Fn(&Exp) -> Result<Box<Exp>, E>,
+        F: Fn(&Binding) -> Result<Binding, E>,
     {
         let bound: Result<_, _> = self
             .bound
@@ -78,7 +78,7 @@ impl<T: ContainsMetaVars> ContainsMetaVars for Binder<T> {
     }
 }
 
-impl<T: Print> Print for Binder<T> {
+impl Print for Binder<Box<Exp>> {
     fn print_prec<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -91,5 +91,144 @@ impl<T: Print> Print for Binder<T> {
             .text(name.to_string())
             .append(alloc.text(":="))
             .append(content.print_prec(cfg, alloc, prec))
+    }
+}
+
+impl Print for Binder<Binding> {
+    fn print_prec<'a>(
+        &'a self,
+        cfg: &printer::PrintCfg,
+        alloc: &'a printer::Alloc<'a>,
+        prec: printer::Precedence,
+    ) -> printer::Builder<'a> {
+        let Binder { name, content: Binding { typ, val } } = self;
+
+        let doc = alloc
+            .text(name.to_string())
+            .append(alloc.text(": "))
+            .append(typ.print_prec(cfg, alloc, prec));
+
+        match val {
+            Some(BoundValue::PatternMatching { val }) => {
+                doc.append(alloc.text(" := ")).append(val.print_prec(cfg, alloc, prec))
+            }
+            Some(BoundValue::LetBinding { val }) => {
+                doc.append(alloc.text(" := ")).append(val.print_prec(cfg, alloc, prec))
+            }
+            None => doc,
+        }
+    }
+}
+
+impl Print for Binder<()> {
+    fn print<'a>(
+        &'a self,
+        _cfg: &printer::PrintCfg,
+        alloc: &'a printer::Alloc<'a>,
+    ) -> printer::Builder<'a> {
+        let Binder { name, content: () } = self;
+
+        alloc.text(name.to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Binding {
+    /// The type of the variable
+    pub typ: Box<Exp>,
+    /// If the variable is let-bound or refined by pattern matching, this is the bound value
+    pub val: Option<BoundValue>,
+}
+
+impl Binding {
+    pub fn from_type(typ: Box<Exp>) -> Self {
+        Binding { typ, val: None }
+    }
+}
+
+impl Occurs for Binding {
+    fn occurs<F>(&self, ctx: &mut LevelCtx, f: &F) -> bool
+    where
+        F: Fn(&LevelCtx, &Exp) -> bool,
+    {
+        self.typ.occurs(ctx, f) || self.val.occurs(ctx, f)
+    }
+}
+
+impl Shift for Binding {
+    fn shift_in_range<R: ShiftRange>(&mut self, range: &R, by: (isize, isize)) {
+        let Binding { typ, val } = self;
+
+        typ.shift_in_range(range, by);
+        val.shift_in_range(range, by);
+    }
+}
+
+impl Substitutable for Binding {
+    type Target = Binding;
+
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        let Binding { typ, val } = self;
+
+        Ok(Binding { typ: typ.subst(ctx, by)?, val: val.subst(ctx, by)? })
+    }
+}
+
+impl ContainsMetaVars for Binding {
+    fn contains_metavars(&self) -> bool {
+        self.typ.contains_metavars() || self.val.contains_metavars()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum BoundValue {
+    /// The variable was substituted by `val` during pattern matching
+    PatternMatching { val: Box<Exp> },
+    /// The variable was bound to `val` in a let binding
+    LetBinding { val: Box<Exp> },
+}
+
+impl Shift for BoundValue {
+    fn shift_in_range<R: ShiftRange>(&mut self, range: &R, by: (isize, isize)) {
+        match self {
+            BoundValue::PatternMatching { val } => val.shift_in_range(range, by),
+            BoundValue::LetBinding { val } => val.shift_in_range(range, by),
+        }
+    }
+}
+
+impl Occurs for BoundValue {
+    fn occurs<F>(&self, ctx: &mut LevelCtx, f: &F) -> bool
+    where
+        F: Fn(&LevelCtx, &Exp) -> bool,
+    {
+        match self {
+            BoundValue::PatternMatching { val } => val.occurs(ctx, f),
+            BoundValue::LetBinding { val } => val.occurs(ctx, f),
+        }
+    }
+}
+
+impl Substitutable for BoundValue {
+    type Target = BoundValue;
+
+    fn subst<S: Substitution>(&self, ctx: &mut LevelCtx, by: &S) -> Result<Self::Target, S::Err> {
+        match self {
+            BoundValue::PatternMatching { val } => {
+                Ok(BoundValue::PatternMatching { val: val.subst(ctx, by)? })
+            }
+            BoundValue::LetBinding { val } => {
+                Ok(BoundValue::LetBinding { val: val.subst(ctx, by)? })
+            }
+        }
+    }
+}
+
+impl ContainsMetaVars for BoundValue {
+    fn contains_metavars(&self) -> bool {
+        match self {
+            BoundValue::PatternMatching { val } => val.contains_metavars(),
+            BoundValue::LetBinding { val } => val.contains_metavars(),
+        }
     }
 }

--- a/lang/driver/src/info/data.rs
+++ b/lang/driver/src/info/data.rs
@@ -1,6 +1,6 @@
 use printer::Print;
 
-use ast::ctx::values::{Binder as TypeCtxBinder, TypeCtx};
+use ast::ctx::values::{Binder as TypeCtxBinder, Binding, TypeCtx};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ctx {
@@ -21,14 +21,14 @@ impl From<TypeCtx> for Ctx {
     }
 }
 
-impl From<TypeCtxBinder<Box<ast::Exp>>> for Binder {
-    fn from(binder: TypeCtxBinder<Box<ast::Exp>>) -> Self {
+impl From<TypeCtxBinder<Binding>> for Binder {
+    fn from(binder: TypeCtxBinder<Binding>) -> Self {
         match binder.name {
             ast::VarBind::Var { id, .. } => {
-                Binder::Var { name: id, typ: binder.content.print_to_string(None) }
+                Binder::Var { name: id, typ: binder.content.typ.print_to_string(None) }
             }
             ast::VarBind::Wildcard { .. } => {
-                Binder::Wildcard { typ: binder.content.print_to_string(None) }
+                Binder::Wildcard { typ: binder.content.typ.print_to_string(None) }
             }
         }
     }

--- a/lang/elaborator/src/conversion_checking/mod.rs
+++ b/lang/elaborator/src/conversion_checking/mod.rs
@@ -127,7 +127,7 @@ pub fn convert(
 #[cfg(test)]
 mod test {
     use ast::{
-        ctx::values::{Binder, TypeCtx},
+        ctx::values::{Binder, Binding, TypeCtx},
         HashMap, Idx, MetaVar, MetaVarState, TypeUniv, VarBind, VarBound, Variable,
     };
 
@@ -165,11 +165,11 @@ mod test {
         let ctx = vec![vec![
             Binder {
                 name: VarBind::Var { span: None, id: "a".to_string() },
-                content: Box::new(TypeUniv { span: None }.into()),
+                content: Binding::from_type(Box::new(TypeUniv { span: None }.into())),
             },
             Binder {
                 name: VarBind::Var { span: None, id: "v".to_string() },
-                content: Box::new(
+                content: Binding::from_type(Box::new(
                     Variable {
                         span: None,
                         idx: Idx { fst: 0, snd: 1 },
@@ -177,7 +177,7 @@ mod test {
                         inferred_type: None,
                     }
                     .into(),
-                ),
+                )),
             },
         ]];
         check_eq(&ctx.into(), v.clone(), v)
@@ -203,11 +203,11 @@ mod test {
         let ctx = vec![vec![
             Binder {
                 name: VarBind::Var { span: None, id: "a".to_string() },
-                content: Box::new(TypeUniv { span: None }.into()),
+                content: Binding::from_type(Box::new(TypeUniv { span: None }.into())),
             },
             Binder {
                 name: VarBind::Var { span: None, id: "v'".to_string() },
-                content: Box::new(
+                content: Binding::from_type(Box::new(
                     Variable {
                         span: None,
                         idx: Idx { fst: 0, snd: 2 },
@@ -215,11 +215,11 @@ mod test {
                         inferred_type: None,
                     }
                     .into(),
-                ),
+                )),
             },
             Binder {
                 name: VarBind::Var { span: None, id: "v".to_string() },
-                content: Box::new(
+                content: Binding::from_type(Box::new(
                     Variable {
                         span: None,
                         idx: Idx { fst: 0, snd: 2 },
@@ -227,7 +227,7 @@ mod test {
                         inferred_type: None,
                     }
                     .into(),
-                ),
+                )),
             },
         ]];
 

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use ast::ctx::values::Binder;
+use ast::ctx::values::{Binder, Binding};
 use ast::ctx::{BindContext, LevelCtx};
 use ast::*;
 use miette_util::ToMiette;
@@ -62,7 +62,8 @@ fn compute_motive(
     let Motive { span, param, ret_typ } = motive;
     let mut self_t_nf = on_exp_typ.to_exp().normalize(&ctx.type_info_table, &mut ctx.env())?;
     self_t_nf.shift((1, 0));
-    let self_binder = Binder { name: param.name.clone(), content: self_t_nf.clone() };
+    let self_binder =
+        Binder { name: param.name.clone(), content: Binding::from_type(self_t_nf.clone()) };
 
     // Typecheck the motive
     let ret_typ_out = ctx.bind_single(self_binder.clone(), |ctx| {

--- a/lang/elaborator/src/typechecker/exprs/mod.rs
+++ b/lang/elaborator/src/typechecker/exprs/mod.rs
@@ -22,7 +22,7 @@ use super::ctx::*;
 use crate::normalizer::{env::ToEnv, normalize::Normalize};
 use crate::result::{TcResult, TypeError};
 
-use ast::ctx::values::Binder;
+use ast::ctx::values::{Binder, Binding};
 use ast::ctx::BindContext;
 
 /// The CheckInfer trait for bidirectional type inference.
@@ -240,7 +240,8 @@ impl CheckTelescope for TelescopeInst {
                     erased: *erased,
                 };
                 params_out.push(param_out);
-                let binder = Binder { name: param_actual.name.clone(), content: typ_nf };
+                let binder =
+                    Binder { name: param_actual.name.clone(), content: Binding::from_type(typ_nf) };
                 TcResult::<_>::Ok(binder)
             },
             |ctx, params| f(ctx, TelescopeInst { params }),
@@ -272,7 +273,8 @@ impl InferTelescope for Telescope {
                     erased: *erased,
                 };
                 params_out.push(param_out);
-                let binder = Binder { name: param.name.clone(), content: typ_nf };
+                let binder =
+                    Binder { name: param.name.clone(), content: Binding::from_type(typ_nf) };
                 TcResult::<_>::Ok(binder)
             },
             |ctx, params| f(ctx, Telescope { params }),
@@ -293,7 +295,7 @@ impl InferTelescope for SelfParam {
         let typ_nf = typ.to_exp().normalize(&ctx.type_info_table, &mut ctx.env())?;
         let typ_out = typ.infer(ctx)?;
         let param_out = SelfParam { info: *info, name: name.clone(), typ: typ_out };
-        let elem = Binder { name: name.clone(), content: typ_nf };
+        let elem = Binder { name: name.clone(), content: Binding::from_type(typ_nf) };
 
         // We need to shift the self parameter type here because we treat it as a 1-element telescope
         ctx.bind_single(shift_and_clone(&elem, (1, 0)), |ctx| f(ctx, param_out))

--- a/lang/transformations/src/lifting/fv.rs
+++ b/lang/transformations/src/lifting/fv.rs
@@ -117,7 +117,7 @@ impl FV for Variable {
         // Only consider this variable if it is bound in `type_ctx`.
         if lvl.fst < type_ctx.len() {
             let typ = shift_and_clone(
-                &type_ctx.lookup(lvl).content,
+                &type_ctx.lookup(lvl).content.typ,
                 ((lvl_ctx.len() - type_ctx.len()) as isize, 0),
             );
             let fv = FreeVar { name: name.id.clone(), lvl, typ: typ.clone(), ctx: lvl_ctx.clone() };


### PR DESCRIPTION
Prerequisite for any of the following:

* Reduce metavariable context by not including variables refined by pattern matching
* Implement let bindings
* Lazy substitutions

Although, right now I'm focusing on the first point. Could therefore remove the `LetBinding` variant for now if you prefer.