### PR TITLE
Test runner returns zero exit code if all failures are resolved by --update-expected

### DIFF
--- a/test/test-runner/src/main.rs
+++ b/test/test-runner/src/main.rs
@@ -46,12 +46,18 @@ fn main() {
         runner::Runner::load(crate::TEST_SUITES_PATH, crate::EXAMPLES_PATH, crate::STDLIB_PATH);
     let mut res = runner.run(&args);
     if args.update_expected {
-        res.update_expected();
+        let all_tests_fixed = res.update_expected();
         println!("Updated expected outputs.");
+
+        // Return non-zero exit code if not all tests could be fixed
+        if !all_tests_fixed {
+            println!("Warning: There were tests of which expected output could not be updated, because they failed for a reason other than having an unexpected output.");
+            std::process::exit(1);
+        }
     } else {
         res.print();
-    }
-    if !res.success() {
-        std::process::exit(1);
+        if !res.success() {
+            std::process::exit(1);
+        }
     }
 }

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -137,12 +137,22 @@ impl RunResult {
         self.failed_cases == 0
     }
 
-    pub fn update_expected(&self) {
-        for CaseResult { case, result } in self.case_results() {
-            if let Err(Failure::Mismatch { phase, ref actual, .. }) = result {
-                case.set_expected(phase, actual);
+    /// Updates the expected output of failed tests on disk
+    /// Returns all failed tests were successfully updated.
+    /// Tests can not be updated if they failed for a reason other than a mismatched output.
+    pub fn update_expected(&self) -> bool {
+        self.case_results().all(|CaseResult { case, result }| {
+            match result {
+                Ok(_) => true,
+                Err(Failure::Mismatch { phase, ref actual, .. }) => {
+                    case.set_expected(phase, actual);
+                    true
+                }
+                Err(_) => {
+                    false
+                }
             }
-        }
+        })
     }
 
     fn case_results(&self) -> impl Iterator<Item = &CaseResult> {

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -141,17 +141,13 @@ impl RunResult {
     /// Returns true when all failed tests were due to unexpected output.
     /// Tests can not be updated if they failed for a reason other than a mismatched output.
     pub fn update_expected(&self) -> bool {
-        self.case_results().all(|CaseResult { case, result }| {
-            match result {
-                Ok(_) => true,
-                Err(Failure::Mismatch { phase, ref actual, .. }) => {
-                    case.set_expected(phase, actual);
-                    true
-                }
-                Err(_) => {
-                    false
-                }
+        self.case_results().all(|CaseResult { case, result }| match result {
+            Ok(_) => true,
+            Err(Failure::Mismatch { phase, ref actual, .. }) => {
+                case.set_expected(phase, actual);
+                true
             }
+            Err(_) => false,
         })
     }
 

--- a/test/test-runner/src/runner.rs
+++ b/test/test-runner/src/runner.rs
@@ -138,7 +138,7 @@ impl RunResult {
     }
 
     /// Updates the expected output of failed tests on disk
-    /// Returns all failed tests were successfully updated.
+    /// Returns true when all failed tests were due to unexpected output.
     /// Tests can not be updated if they failed for a reason other than a mismatched output.
     pub fn update_expected(&self) -> bool {
         self.case_results().all(|CaseResult { case, result }| {


### PR DESCRIPTION
Fixes https://github.com/polarity-lang/polarity/issues/513