### PR TITLE
Add test cases on eta for co-matches

### DIFF
--- a/test/suites/fail-check/013-eta-comatch.expected
+++ b/test/suites/fail-check/013-eta-comatch.expected
@@ -1,0 +1,22 @@
+T-002
+
+  × The following terms are not equal:
+  │   1: Eq(Test, comatch { .test(_) => T }, comatch { .test(_) => T })
+  │   2: Eq(Test, comatch { .test(_) => T }, comatch { .test(_) => F })
+  │ 
+   ╭─[013-eta-comatch.pol:6:26]
+ 5 │ data Eq(a: Type, x y: a) {
+ 6 │     Refl(a: Type, x: a): Eq(a, x, x),
+   ·                          ─────┬─────
+   ·                               ╰── Source of (1)
+ 7 │ }
+   ╰────
+    ╭─[013-eta-comatch.pol:15:9]
+ 14 │     
+ 15 │ ╭─▶ let eq: Eq(Test, f.ap(Bool, Test, T), f.ap(Bool, Test, F)) {Refl(Test,
+    · │           ─────────────────────────┬────────────────────────
+    · │                                    ╰── Source of (2)
+ 16 │ ├─▶                                                                  f.ap(Bool, Test, T))}
+    · ╰──── While elaborating
+    ╰────
+  help: The two subterms T and F are not equal.

--- a/test/suites/fail-check/013-eta-comatch.pol
+++ b/test/suites/fail-check/013-eta-comatch.pol
@@ -1,0 +1,16 @@
+codata Fun(a b: Type) {
+    Fun(a, b).ap(a b: Type, x: a): b,
+}
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x),
+}
+
+data Bool { T, F }
+
+codata Test { .test(x: Bool): Bool }
+
+codef f: Fun(Bool, Test) { .ap(Bool, Bool, x) => comatch { .test(_) => x } }
+
+let eq: Eq(Test, f.ap(Bool, Test, T), f.ap(Bool, Test, F)) {Refl(Test,
+                                                                 f.ap(Bool, Test, T))}

--- a/test/suites/success/040-absurd-lam.ir.expected
+++ b/test/suites/success/040-absurd-lam.ir.expected
@@ -1,0 +1,1 @@
+let example { comatch { .d(x) absurd } }

--- a/test/suites/success/041-eta-comatch.ir.expected
+++ b/test/suites/success/041-eta-comatch.ir.expected
@@ -1,0 +1,3 @@
+codef f { .ap(x) => comatch { .test(x0) => x0 } }
+
+let eq { Refl(f.ap(T)) }

--- a/test/suites/success/041-eta-comatch.pol
+++ b/test/suites/success/041-eta-comatch.pol
@@ -1,0 +1,16 @@
+codata Fun(a b: Type) {
+    Fun(a, b).ap(a b: Type, x: a): b,
+}
+
+data Eq(a: Type, x y: a) {
+    Refl(a: Type, x: a): Eq(a, x, x),
+}
+
+data Bool { T, F }
+
+codata Test { .test(x: Bool): Bool }
+
+codef f: Fun(Bool, Test) { .ap(Bool, Bool, _) => comatch { .test(x) => x } }
+
+let eq: Eq(Test, f.ap(Bool, Test, T), f.ap(Bool, Test, F)) {Refl(Test,
+                                                                 f.ap(Bool, Test, T))}


### PR DESCRIPTION
I'm not sure if this is good enough, because the successful case should really compute and then trigger the shortcut syntactic equality rule.
But since there's no shortcut rule in the conversion checker atm, this does the job.