### PR TITLE
Refactor lowering errors

### DIFF
--- a/lang/driver/src/result.rs
+++ b/lang/driver/src/result.rs
@@ -11,7 +11,7 @@ use backend::result::BackendError;
 #[error(transparent)]
 pub enum Error {
     Parser(#[from] parser::ParseError),
-    Lowering(#[from] lowering::LoweringError),
+    Lowering(#[from] Box<lowering::LoweringError>),
     Type(#[from] Box<elaborator::result::TypeError>),
     Xfunc(#[from] transformations::result::XfuncError),
     Driver(#[from] DriverError),

--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -10,6 +10,7 @@ use parser::cst::ident::Ident;
 use url::Url;
 
 use crate::symbol_table::SymbolTable;
+use crate::LoweringResult;
 
 use super::result::LoweringError;
 
@@ -65,7 +66,7 @@ impl Ctx {
         &mut self,
         user_name: Option<Ident>,
         info: &Span,
-    ) -> Result<ast::Label, LoweringError> {
+    ) -> LoweringResult<ast::Label> {
         if let Some(user_name) = &user_name {
             if self.symbol_table.lookup_exists(user_name) {
                 return Err(LoweringError::LabelNotUnique {

--- a/lang/lowering/src/ctx.rs
+++ b/lang/lowering/src/ctx.rs
@@ -72,21 +72,24 @@ impl Ctx {
                 return Err(LoweringError::LabelNotUnique {
                     name: user_name.id.to_owned(),
                     span: info.to_miette(),
-                });
+                }
+                .into());
             }
 
             if self.lookup_local(user_name).is_some() {
                 return Err(LoweringError::LabelShadowed {
                     name: user_name.id.to_owned(),
                     span: info.to_miette(),
-                });
+                }
+                .into());
             }
 
             if self.user_labels.contains(user_name) {
                 return Err(LoweringError::LabelNotUnique {
                     name: user_name.id.to_owned(),
                     span: info.to_miette(),
-                });
+                }
+                .into());
             }
             self.user_labels.insert(user_name.to_owned());
         }

--- a/lang/lowering/src/lib.rs
+++ b/lang/lowering/src/lib.rs
@@ -21,7 +21,7 @@ pub use symbol_table::SymbolTable;
 pub fn lower_module_with_symbol_table(
     prg: &cst::decls::Module,
     symbol_table: &SymbolTable,
-) -> Result<ast::Module, LoweringError> {
+) -> LoweringResult<ast::Module> {
     let mut ctx = Ctx::empty(prg.uri.clone(), symbol_table.clone());
 
     let use_decls = prg.use_decls.lower(&mut ctx)?;

--- a/lang/lowering/src/lower/decls/codata_declaration.rs
+++ b/lang/lowering/src/lower/decls/codata_declaration.rs
@@ -55,7 +55,8 @@ fn lower_destructor(
                         xtor: name.clone(),
                         typ: type_name.clone(),
                         span: span.to_miette(),
-                    });
+                    }
+                    .into());
                 }
             }
         };

--- a/lang/lowering/src/lower/decls/codata_declaration.rs
+++ b/lang/lowering/src/lower/decls/codata_declaration.rs
@@ -10,7 +10,7 @@ use super::lower_telescope;
 impl Lower for cst::decls::Codata {
     type Target = ast::Codata;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         log::trace!("Lowering codata declaration: {}", self.name.id);
         let cst::decls::Codata { span, doc, name, attr, params, dtors } = self;
 
@@ -35,7 +35,7 @@ fn lower_destructor(
     ctx: &mut Ctx,
     type_name: &Ident,
     type_arity: usize,
-) -> Result<ast::Dtor, LoweringError> {
+) -> LoweringResult<ast::Dtor> {
     log::trace!("Lowering destructor: {:?}", dtor.name);
     let cst::decls::Dtor { span, doc, name, params, destructee, ret_typ } = dtor;
 

--- a/lang/lowering/src/lower/decls/codefinition.rs
+++ b/lang/lowering/src/lower/decls/codefinition.rs
@@ -8,7 +8,7 @@ use super::lower_telescope;
 impl Lower for cst::decls::Codef {
     type Target = ast::Codef;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         log::trace!("Lowering codefinition: {}", self.name.id);
 
         let cst::decls::Codef { span, doc, name, attr, params, typ, cases, .. } = self;

--- a/lang/lowering/src/lower/decls/data_declaration.rs
+++ b/lang/lowering/src/lower/decls/data_declaration.rs
@@ -9,7 +9,7 @@ use super::lower_telescope;
 impl Lower for cst::decls::Data {
     type Target = ast::Data;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         log::trace!("Lowering data declaration: {}", self.name.id);
         let cst::decls::Data { span, doc, name, attr, params, ctors } = self;
 
@@ -34,7 +34,7 @@ fn lower_constructor(
     ctx: &mut Ctx,
     typ_name: &Ident,
     type_arity: usize,
-) -> Result<ast::Ctor, LoweringError> {
+) -> LoweringResult<ast::Ctor> {
     log::trace!("Lowering constructor: {:?}", ctor.name);
     let cst::decls::Ctor { span, doc, name, params, typ } = ctor;
 

--- a/lang/lowering/src/lower/decls/data_declaration.rs
+++ b/lang/lowering/src/lower/decls/data_declaration.rs
@@ -62,7 +62,8 @@ fn lower_constructor(
                         xtor: name.clone(),
                         typ: typ_name.clone(),
                         span: span.to_miette(),
-                    });
+                    }
+                    .into());
                 }
             }
         };

--- a/lang/lowering/src/lower/decls/definition.rs
+++ b/lang/lowering/src/lower/decls/definition.rs
@@ -8,7 +8,7 @@ use super::lower_telescope;
 impl Lower for cst::decls::Def {
     type Target = ast::Def;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         log::trace!("Lowering definition: {}", self.name.id);
 
         let cst::decls::Def { span, doc, name, attr, params, scrutinee, ret_typ, cases } = self;

--- a/lang/lowering/src/lower/decls/infix_declaration.rs
+++ b/lang/lowering/src/lower/decls/infix_declaration.rs
@@ -6,7 +6,7 @@ use super::super::*;
 impl Lower for cst::decls::Infix {
     type Target = ast::Infix;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         let cst::decls::Infix { span, doc, lhs, rhs } = self;
 
         // Check that LHS is of the form `_ + _`
@@ -15,7 +15,8 @@ impl Lower for cst::decls::Infix {
                 message: "The left hand side of an infix declaration must have the form \"_ + _\"."
                     .to_owned(),
                 span: lhs.span.to_miette(),
-            });
+            }
+            .into());
         }
 
         // Check that RHS is of the form `T(_,_)`
@@ -25,7 +26,8 @@ impl Lower for cst::decls::Infix {
                     "The right hand side of an infix declaration must take exactly two arguments."
                         .to_owned(),
                 span: rhs.span.to_miette(),
-            });
+            }
+            .into());
         }
         if !(rhs.args[0].is_underscore() && rhs.args[1].is_underscore()) {
             return Err(LoweringError::InvalidInfixDeclaration {
@@ -33,7 +35,8 @@ impl Lower for cst::decls::Infix {
                     "The right hand side of an infix declaration must have the form \"T(_,_)\"."
                         .to_owned(),
                 span: rhs.span.to_miette(),
-            });
+            }
+            .into());
         }
 
         // Check that the name on the RHS is available at the location

--- a/lang/lowering/src/lower/decls/mod.rs
+++ b/lang/lowering/src/lower/decls/mod.rs
@@ -141,7 +141,7 @@ where
     ctx.bind_fold_failable(
         tel.0.iter(),
         vec![],
-        |ctx, params_out, param| {
+        |ctx, params_out, param| -> LoweringResult<Binder<()>> {
             let cst::decls::Param { implicit, name, names: _, typ } = param; // The `names` field has been removed by `desugar_telescope`.
             let typ_out = typ.lower(ctx)?;
             let name = name.lower(ctx)?;

--- a/lang/lowering/src/lower/decls/toplevel_let.rs
+++ b/lang/lowering/src/lower/decls/toplevel_let.rs
@@ -7,7 +7,7 @@ use super::lower_telescope;
 impl Lower for cst::decls::Let {
     type Target = ast::Let;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         log::trace!("Lowering top-level let: {}", self.name.id);
 
         let cst::decls::Let { span, doc, name, attr, params, typ, body } = self;

--- a/lang/lowering/src/lower/exp/anno.rs
+++ b/lang/lowering/src/lower/exp/anno.rs
@@ -1,0 +1,18 @@
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+impl Lower for cst::exp::Anno {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Anno { span, exp, typ } = self;
+        Ok(ast::Anno {
+            span: Some(*span),
+            exp: exp.lower(ctx)?,
+            typ: typ.lower(ctx)?,
+            normalized_type: None,
+        }
+        .into())
+    }
+}

--- a/lang/lowering/src/lower/exp/args.rs
+++ b/lang/lowering/src/lower/exp/args.rs
@@ -1,0 +1,195 @@
+use ast::{Hole, MetaVarKind, VarBound};
+use miette_util::{codespan::Span, ToMiette};
+use parser::cst::{self, exp::BindingSite};
+use printer::Print;
+
+use crate::{lower::Lower, Ctx, LoweringError, LoweringResult};
+
+/// Lowers a list of arguments, ensuring that named arguments match the expected parameter names.
+///
+/// This function processes a mix of named and unnamed arguments provided by the user (`given`)
+/// and matches them against the expected parameters (`expected`). It handles implicit parameters
+/// by inserting fresh metavariables when necessary and ensures that named arguments correspond to the correct
+/// parameters as declared.
+///
+/// # Parameters
+///
+/// - `given`: A slice of `cst::exp::Arg` representing the arguments provided by the user.
+/// - `expected`: A `Telescope` containing the expected parameters.
+/// - `ctx`: A mutable reference to the current context (`Ctx`), used for tracking variables and generating fresh metavariables.
+///
+/// # Returns
+///
+/// - `Ok(ast::Args)`: The successfully lowered arguments.
+/// - `Err(LoweringError)`: An error indicating issues such as missing arguments, too many arguments,
+///   mismatched named arguments, or improper use of wildcards.
+///
+/// # Errors
+///
+/// This function may return a `LoweringError` in the following cases:
+///
+/// - **MissingArgForParam**: A required argument is missing for a parameter.
+/// - **TooManyArgs**: More arguments are provided than there are expected parameters.
+/// - **MismatchedNamedArgs**: A named argument does not match the expected parameter name.
+/// - **NamedArgForWildcard**: A named argument is provided for a wildcard parameter, which is not allowed.
+///
+/// # Example
+///
+/// ```text
+/// data Bool { True, False }
+///
+/// data List {
+///     Nil,
+///     Cons(head: Bool, tail: List)
+/// }
+///
+/// let example1 : List {
+///     Cons(x := True, xs := Nil)
+/// }
+/// ```
+///
+/// In this example, an error is thrown because the named arguments `x` and `xs` do not match
+/// the expected parameter names `head` and `tail`.
+pub fn lower_args(
+    span: Span,
+    given: &[cst::exp::Arg],
+    expected: cst::decls::Telescope,
+    ctx: &mut Ctx,
+) -> LoweringResult<ast::Args> {
+    let mut args_out = vec![];
+
+    // Ensure that the number of given arguments does not exceed the number of expected parameters.
+    // Some expected parameters might be implicit and not require corresponding given arguments.
+    if given.len() > expected.len() {
+        // The unwrap is safe because in this branch there must be at least one given.
+        let err = LoweringError::TooManyArgs { span: given.first().unwrap().span().to_miette() };
+        return Err(err);
+    }
+
+    // Create a peekable iterator over the given arguments to allow lookahead.
+    let mut given_iter = given.iter().peekable();
+
+    /// Processes a single argument, matching it against the expected parameter binding site.
+    ///
+    /// This function consumes one argument from the `given` iterator and attempts to match it with the
+    /// expected binding site (`expected_bs`). It handles both named and unnamed arguments and ensures
+    /// that named arguments match the expected parameter names.
+    ///
+    /// # Parameters
+    ///
+    /// - `span`: The source span of the given argument list.
+    /// - `given`: A mutable iterator over the given arguments.
+    /// - `expected_bs`: The binding site of the expected parameter.
+    /// - `args_out`: A mutable vector to collect the lowered arguments.
+    /// - `ctx`: A mutable reference to the current context.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())`: The argument was successfully processed and added to `args_out`.
+    /// - `Err(LoweringError)`: An error occurred while processing the argument.
+    fn pop_arg<'a>(
+        span: Span,
+        given: &mut impl Iterator<Item = &'a cst::exp::Arg>,
+        expected_bs: &BindingSite,
+        args_out: &mut Vec<ast::Arg>,
+        ctx: &mut Ctx,
+    ) -> LoweringResult {
+        let Some(arg) = given.next() else {
+            let expected = expected_bs.lower(ctx)?;
+            let expected = expected.print_to_string(None);
+            return Err(LoweringError::MissingArgForParam { expected, span: span.to_miette() });
+        };
+        match arg {
+            cst::exp::Arg::UnnamedArg(exp) => {
+                args_out.push(ast::Arg::UnnamedArg { arg: exp.lower(ctx)?, erased: false });
+            }
+            cst::exp::Arg::NamedArg(name, exp) => {
+                let expected_name = match &expected_bs {
+                    BindingSite::Var { name, .. } => name,
+                    BindingSite::Wildcard { span } => {
+                        return Err(LoweringError::NamedArgForWildcard {
+                            given: name.clone(),
+                            span: span.to_miette(),
+                        });
+                    }
+                };
+                if name.id != expected_name.id {
+                    return Err(LoweringError::MismatchedNamedArgs {
+                        given: name.to_owned(),
+                        expected: expected_name.to_owned(),
+                        span: exp.span().to_miette(),
+                    });
+                }
+                let name = VarBound { span: Some(name.span), id: name.id.clone() };
+                args_out.push(ast::Arg::NamedArg { name, arg: exp.lower(ctx)?, erased: false });
+            }
+        }
+        Ok(())
+    }
+
+    for expected_param in expected.0.iter() {
+        // Each parameter can have multiple names (e.g., aliases).
+        let names_iter = std::iter::once(&expected_param.name).chain(expected_param.names.iter());
+        for expected_bs in names_iter {
+            if expected_param.implicit {
+                if let Some(cst::exp::Arg::NamedArg(given_name, exp)) = given_iter.peek() {
+                    let BindingSite::Var { name: expected_name, .. } = &expected_bs else {
+                        return Err(LoweringError::NamedArgForWildcard {
+                            given: given_name.clone(),
+                            span: exp.span().to_miette(),
+                        });
+                    };
+                    if expected_name == given_name {
+                        pop_arg(span, &mut given_iter, expected_bs, &mut args_out, ctx)?;
+                        continue;
+                    }
+                }
+
+                let mv = ctx.fresh_metavar(Some(span), MetaVarKind::Inserted);
+                let args = ctx.subst_from_ctx();
+                let hole = Hole {
+                    span: None,
+                    kind: ast::MetaVarKind::Inserted,
+                    metavar: mv,
+                    inferred_type: None,
+                    inferred_ctx: None,
+                    args,
+                    solution: None,
+                };
+
+                args_out.push(ast::Arg::InsertedImplicitArg { hole, erased: false });
+            } else {
+                pop_arg(span, &mut given_iter, expected_bs, &mut args_out, ctx)?;
+            }
+        }
+    }
+
+    // Check for any extra arguments that were not matched to parameters.
+    if let Some(extra_arg) = given_iter.next() {
+        return Err(LoweringError::TooManyArgs { span: extra_arg.span().to_miette() });
+    }
+
+    // All arguments have been successfully processed.
+    Ok(ast::Args { args: args_out })
+}
+
+#[cfg(test)]
+mod lower_args_tests {
+    use url::Url;
+
+    use parser::cst::decls::Telescope;
+
+    use crate::symbol_table::SymbolTable;
+
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let given = vec![];
+        let expected = Telescope(vec![]);
+        let mut ctx =
+            Ctx::empty(Url::parse("inmemory:///scratch.pol").unwrap(), SymbolTable::default());
+        let res = lower_args(Span::default(), &given, expected, &mut ctx);
+        assert_eq!(res.unwrap(), ast::Args { args: vec![] })
+    }
+}

--- a/lang/lowering/src/lower/exp/binop.rs
+++ b/lang/lowering/src/lower/exp/binop.rs
@@ -1,0 +1,26 @@
+use parser::cst::{self};
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+impl Lower for cst::exp::BinOp {
+    type Target = ast::Exp;
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::BinOp { span, operator, lhs, rhs } = self;
+
+        let (id, _url) = ctx.symbol_table.lookup_operator(operator)?;
+        let (_, uri) = ctx.symbol_table.lookup(id)?;
+
+        Ok(ast::TypCtor {
+            span: Some(*span),
+            name: ast::IdBound { span: Some(*span), id: id.id.clone(), uri: uri.clone() },
+            args: ast::Args {
+                args: vec![
+                    ast::Arg::UnnamedArg { arg: lhs.lower(ctx)?, erased: false },
+                    ast::Arg::UnnamedArg { arg: rhs.lower(ctx)?, erased: false },
+                ],
+            },
+            is_bin_op: Some(operator.id.clone()),
+        }
+        .into())
+    }
+}

--- a/lang/lowering/src/lower/exp/binop.rs
+++ b/lang/lowering/src/lower/exp/binop.rs
@@ -8,11 +8,11 @@ impl Lower for cst::exp::BinOp {
         let cst::exp::BinOp { span, operator, lhs, rhs } = self;
 
         let (id, _url) = ctx.symbol_table.lookup_operator(operator)?;
-        let (_, uri) = ctx.symbol_table.lookup(id)?;
+        let (_, name) = ctx.symbol_table.lookup(id)?;
 
         Ok(ast::TypCtor {
             span: Some(*span),
-            name: ast::IdBound { span: Some(*span), id: id.id.clone(), uri: uri.clone() },
+            name,
             args: ast::Args {
                 args: vec![
                     ast::Arg::UnnamedArg { arg: lhs.lower(ctx)?, erased: false },

--- a/lang/lowering/src/lower/exp/call.rs
+++ b/lang/lowering/src/lower/exp/call.rs
@@ -16,7 +16,7 @@ impl Lower for cst::exp::Call {
         // For this reason we have to special case the logic for lowering the type universe here.
         if name.id == "Type" {
             if !args.is_empty() {
-                return Err(LoweringError::TypeUnivArgs { span: span.to_miette() });
+                return Err(LoweringError::TypeUnivArgs { span: span.to_miette() }.into());
             }
             return Ok(TypeUniv { span: Some(*span) }.into());
         }
@@ -46,7 +46,8 @@ impl Lower for cst::exp::Call {
                 }))
             }
             DeclMeta::Def { .. } | DeclMeta::Dtor { .. } => {
-                Err(LoweringError::MustUseAsDotCall { name: name.clone(), span: span.to_miette() })
+                Err(LoweringError::MustUseAsDotCall { name: name.clone(), span: span.to_miette() }
+                    .into())
             }
             DeclMeta::Ctor { params, .. } => Ok(ast::Exp::Call(ast::Call {
                 span: Some(*span),

--- a/lang/lowering/src/lower/exp/call.rs
+++ b/lang/lowering/src/lower/exp/call.rs
@@ -1,0 +1,84 @@
+use ast::{IdBound, TypeUniv, VarBound, Variable};
+use miette_util::ToMiette;
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, DeclMeta, LoweringError, LoweringResult};
+
+use super::args::lower_args;
+
+impl Lower for cst::exp::Call {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Call { span, name, args } = self;
+
+        // The type universe "Type" is treated as an ordinary call in the lexer and parser.
+        // For this reason we have to special case the logic for lowering the type universe here.
+        if name.id == "Type" {
+            if !args.is_empty() {
+                return Err(LoweringError::TypeUnivArgs { span: span.to_miette() });
+            }
+            return Ok(TypeUniv { span: Some(*span) }.into());
+        }
+
+        // If we find the identifier in the local context then we have to lower
+        // it to a variable.
+        if let Some(idx) = ctx.lookup_local(name) {
+            let name = VarBound { span: Some(name.span), id: name.id.clone() };
+            return Ok(ast::Exp::Variable(Variable {
+                span: Some(*span),
+                idx,
+                name,
+                inferred_type: None,
+            }));
+        }
+
+        // If we find the identifier in the global context then we have to lower
+        // it to a call or a type constructor.
+        let (meta, uri) = ctx.symbol_table.lookup(name)?;
+        match meta {
+            DeclMeta::Data { params, .. } | DeclMeta::Codata { params, .. } => {
+                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
+                Ok(ast::Exp::TypCtor(ast::TypCtor {
+                    span: Some(*span),
+                    name,
+                    args: lower_args(*span, args, params.clone(), ctx)?,
+                    is_bin_op: None,
+                }))
+            }
+            DeclMeta::Def { .. } | DeclMeta::Dtor { .. } => {
+                Err(LoweringError::MustUseAsDotCall { name: name.clone(), span: span.to_miette() })
+            }
+            DeclMeta::Ctor { params, .. } => {
+                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
+                Ok(ast::Exp::Call(ast::Call {
+                    span: Some(*span),
+                    kind: ast::CallKind::Constructor,
+                    name,
+                    args: lower_args(*span, args, params.clone(), ctx)?,
+                    inferred_type: None,
+                }))
+            }
+            DeclMeta::Codef { params, .. } => {
+                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
+                Ok(ast::Exp::Call(ast::Call {
+                    span: Some(*span),
+                    kind: ast::CallKind::Codefinition,
+                    name,
+                    args: lower_args(*span, args, params.clone(), ctx)?,
+                    inferred_type: None,
+                }))
+            }
+            DeclMeta::Let { params, .. } => {
+                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
+                Ok(ast::Exp::Call(ast::Call {
+                    span: Some(*span),
+                    kind: ast::CallKind::LetBound,
+                    name,
+                    args: lower_args(*span, args, params.clone(), ctx)?,
+                    inferred_type: None,
+                }))
+            }
+        }
+    }
+}

--- a/lang/lowering/src/lower/exp/dot_call.rs
+++ b/lang/lowering/src/lower/exp/dot_call.rs
@@ -30,7 +30,7 @@ impl Lower for cst::exp::DotCall {
                 args: lower_args(*span, args, params, ctx)?,
                 inferred_type: None,
             })),
-            _ => Err(LoweringError::CannotUseAsDotCall { name, span: span.to_miette() }),
+            _ => Err(LoweringError::CannotUseAsDotCall { name, span: span.to_miette() }.into()),
         }
     }
 }

--- a/lang/lowering/src/lower/exp/dot_call.rs
+++ b/lang/lowering/src/lower/exp/dot_call.rs
@@ -1,0 +1,41 @@
+use ast::IdBound;
+use miette_util::ToMiette;
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, DeclMeta, LoweringError, LoweringResult};
+
+use super::args::lower_args;
+
+impl Lower for cst::exp::DotCall {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::DotCall { span, exp, name, args } = self;
+
+        let (meta, uri) = ctx.symbol_table.lookup(name)?;
+        let (meta, uri) = (meta.clone(), uri.clone());
+
+        match meta {
+            DeclMeta::Dtor { params, .. } => Ok(ast::Exp::DotCall(ast::DotCall {
+                span: Some(*span),
+                kind: ast::DotCallKind::Destructor,
+                exp: exp.lower(ctx)?,
+                name: IdBound { span: Some(name.span), id: name.id.clone(), uri },
+                args: lower_args(*span, args, params, ctx)?,
+                inferred_type: None,
+            })),
+            DeclMeta::Def { params, .. } => Ok(ast::Exp::DotCall(ast::DotCall {
+                span: Some(*span),
+                kind: ast::DotCallKind::Definition,
+                exp: exp.lower(ctx)?,
+                name: IdBound { span: Some(name.span), id: name.id.clone(), uri },
+                args: lower_args(*span, args, params, ctx)?,
+                inferred_type: None,
+            })),
+            _ => Err(LoweringError::CannotUseAsDotCall {
+                name: name.clone(),
+                span: span.to_miette(),
+            }),
+        }
+    }
+}

--- a/lang/lowering/src/lower/exp/hole.rs
+++ b/lang/lowering/src/lower/exp/hole.rs
@@ -1,0 +1,36 @@
+use ast::Hole;
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+impl Lower for cst::exp::HoleKind {
+    type Target = ast::MetaVarKind;
+
+    fn lower(&self, _ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        match self {
+            cst::exp::HoleKind::MustSolve => Ok(ast::MetaVarKind::MustSolve),
+            cst::exp::HoleKind::CanSolve => Ok(ast::MetaVarKind::CanSolve),
+        }
+    }
+}
+
+impl Lower for cst::exp::Hole {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Hole { span, kind, .. } = self;
+        let kind = kind.lower(ctx)?;
+        let mv = ctx.fresh_metavar(Some(*span), kind);
+        let args = ctx.subst_from_ctx();
+        Ok(Hole {
+            span: Some(*span),
+            kind,
+            metavar: mv,
+            inferred_type: None,
+            inferred_ctx: None,
+            args,
+            solution: None,
+        }
+        .into())
+    }
+}

--- a/lang/lowering/src/lower/exp/lam.rs
+++ b/lang/lowering/src/lower/exp/lam.rs
@@ -1,0 +1,18 @@
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+impl Lower for cst::exp::Lam {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Lam { span, case } = self;
+        let comatch = cst::exp::Exp::LocalComatch(cst::exp::LocalComatch {
+            span: *span,
+            name: None,
+            is_lambda_sugar: true,
+            cases: vec![case.clone()],
+        });
+        comatch.lower(ctx)
+    }
+}

--- a/lang/lowering/src/lower/exp/local_comatch.rs
+++ b/lang/lowering/src/lower/exp/local_comatch.rs
@@ -1,0 +1,49 @@
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+use super::lower_telescope_inst;
+
+impl Lower for cst::exp::LocalComatch {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::LocalComatch { span, name, is_lambda_sugar, cases } = self;
+        Ok(ast::LocalComatch {
+            span: Some(*span),
+            ctx: None,
+            name: ctx.unique_label(name.to_owned(), span)?,
+            is_lambda_sugar: *is_lambda_sugar,
+            cases: cases.lower(ctx)?,
+            inferred_type: None,
+        }
+        .into())
+    }
+}
+
+impl Lower for cst::exp::Case<cst::exp::Copattern> {
+    type Target = ast::Case;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Case { span, pattern, body } = self;
+
+        lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
+            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
+            let name = ast::IdBound {
+                span: Some(pattern.name.span),
+                id: pattern.name.id.clone(),
+                uri: uri.clone(),
+            };
+            Ok(ast::Case {
+                span: Some(*span),
+                pattern: ast::Pattern {
+                    span: Some(pattern.span),
+                    is_copattern: true,
+                    name,
+                    params,
+                },
+                body: body.lower(ctx)?,
+            })
+        })
+    }
+}

--- a/lang/lowering/src/lower/exp/local_comatch.rs
+++ b/lang/lowering/src/lower/exp/local_comatch.rs
@@ -28,12 +28,7 @@ impl Lower for cst::exp::Case<cst::exp::Copattern> {
         let cst::exp::Case { span, pattern, body } = self;
 
         lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
-            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
-            let name = ast::IdBound {
-                span: Some(pattern.name.span),
-                id: pattern.name.id.clone(),
-                uri: uri.clone(),
-            };
+            let (_, name) = ctx.symbol_table.lookup(&pattern.name)?;
             Ok(ast::Case {
                 span: Some(*span),
                 pattern: ast::Pattern {

--- a/lang/lowering/src/lower/exp/local_match.rs
+++ b/lang/lowering/src/lower/exp/local_match.rs
@@ -1,4 +1,3 @@
-use ast::IdBound;
 use parser::cst;
 
 use crate::{lower::Lower, Ctx, LoweringResult};
@@ -31,12 +30,7 @@ impl Lower for cst::exp::Case<cst::exp::Pattern> {
         let cst::exp::Case { span, pattern, body } = self;
 
         lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
-            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
-            let name = IdBound {
-                span: Some(pattern.name.span),
-                id: pattern.name.id.clone(),
-                uri: uri.clone(),
-            };
+            let (_, name) = ctx.symbol_table.lookup(&pattern.name)?;
             Ok(ast::Case {
                 span: Some(*span),
                 pattern: ast::Pattern {

--- a/lang/lowering/src/lower/exp/local_match.rs
+++ b/lang/lowering/src/lower/exp/local_match.rs
@@ -1,0 +1,52 @@
+use ast::IdBound;
+use parser::cst;
+
+use crate::{lower::Lower, Ctx, LoweringResult};
+
+use super::lower_telescope_inst;
+
+impl Lower for cst::exp::LocalMatch {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::LocalMatch { span, name, on_exp, motive, cases } = self;
+        Ok(ast::LocalMatch {
+            span: Some(*span),
+            ctx: None,
+            name: ctx.unique_label(name.to_owned(), span)?,
+            on_exp: on_exp.lower(ctx)?,
+            motive: motive.lower(ctx)?,
+            ret_typ: None,
+            cases: cases.lower(ctx)?,
+            inferred_type: None,
+        }
+        .into())
+    }
+}
+
+impl Lower for cst::exp::Case<cst::exp::Pattern> {
+    type Target = ast::Case;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::Case { span, pattern, body } = self;
+
+        lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
+            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
+            let name = IdBound {
+                span: Some(pattern.name.span),
+                id: pattern.name.id.clone(),
+                uri: uri.clone(),
+            };
+            Ok(ast::Case {
+                span: Some(*span),
+                pattern: ast::Pattern {
+                    span: Some(pattern.span),
+                    is_copattern: false,
+                    name,
+                    params,
+                },
+                body: body.lower(ctx)?,
+            })
+        })
+    }
+}

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -1,32 +1,29 @@
 use ast::ctx::values::Binder;
-use ast::HasSpan;
-use ast::IdBound;
-use ast::MetaVarKind;
-use ast::VarBound;
-use miette_util::codespan::Span;
-use num_bigint::BigUint;
-
 use ast::ctx::BindContext;
-use ast::Hole;
-use ast::TypeUniv;
-use ast::Variable;
+use ast::HasSpan;
 use miette_util::ToMiette;
 use parser::cst;
-use parser::cst::decls::Telescope;
 use parser::cst::exp::BindingSite;
-use parser::cst::ident::Ident;
-use printer::Print;
-
-use crate::ctx::*;
-use crate::result::*;
-use crate::symbol_table::DeclMeta;
 
 use super::Lower;
+use crate::ctx::*;
+use crate::result::*;
+
+mod anno;
+mod args;
+mod binop;
+mod call;
+mod dot_call;
+mod hole;
+mod lam;
+mod local_comatch;
+mod local_match;
+mod nat_lit;
 
 impl Lower for cst::exp::Exp {
     type Target = ast::Exp;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         match self {
             cst::exp::Exp::Call(e) => e.lower(ctx),
             cst::exp::Exp::DotCall(e) => e.lower(ctx),
@@ -41,11 +38,11 @@ impl Lower for cst::exp::Exp {
     }
 }
 
-fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ast::TelescopeInst) -> Result<T, LoweringError>>(
+fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ast::TelescopeInst) -> LoweringResult<T>>(
     tel_inst: &[cst::exp::BindingSite],
     ctx: &mut Ctx,
     f: F,
-) -> Result<T, LoweringError> {
+) -> LoweringResult<T> {
     let tel_inst = tel_inst.iter().map(|bs| bs.lower(ctx)).collect::<Result<Vec<_>, _>>()?;
     ctx.bind_fold_failable(
         tel_inst.into_iter(),
@@ -59,507 +56,11 @@ fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ast::TelescopeInst) -> Result<T, 
         |ctx, params| f(ctx, ast::TelescopeInst { params }),
     )?
 }
-/// Lowers a list of arguments, ensuring that named arguments match the expected parameter names.
-///
-/// This function processes a mix of named and unnamed arguments provided by the user (`given`)
-/// and matches them against the expected parameters (`expected`). It handles implicit parameters
-/// by inserting fresh metavariables when necessary and ensures that named arguments correspond to the correct
-/// parameters as declared.
-///
-/// # Parameters
-///
-/// - `given`: A slice of `cst::exp::Arg` representing the arguments provided by the user.
-/// - `expected`: A `Telescope` containing the expected parameters.
-/// - `ctx`: A mutable reference to the current context (`Ctx`), used for tracking variables and generating fresh metavariables.
-///
-/// # Returns
-///
-/// - `Ok(ast::Args)`: The successfully lowered arguments.
-/// - `Err(LoweringError)`: An error indicating issues such as missing arguments, too many arguments,
-///   mismatched named arguments, or improper use of wildcards.
-///
-/// # Errors
-///
-/// This function may return a `LoweringError` in the following cases:
-///
-/// - **MissingArgForParam**: A required argument is missing for a parameter.
-/// - **TooManyArgs**: More arguments are provided than there are expected parameters.
-/// - **MismatchedNamedArgs**: A named argument does not match the expected parameter name.
-/// - **NamedArgForWildcard**: A named argument is provided for a wildcard parameter, which is not allowed.
-///
-/// # Example
-///
-/// ```text
-/// data Bool { True, False }
-///
-/// data List {
-///     Nil,
-///     Cons(head: Bool, tail: List)
-/// }
-///
-/// let example1 : List {
-///     Cons(x := True, xs := Nil)
-/// }
-/// ```
-///
-/// In this example, an error is thrown because the named arguments `x` and `xs` do not match
-/// the expected parameter names `head` and `tail`.
-fn lower_args(
-    span: Span,
-    given: &[cst::exp::Arg],
-    expected: Telescope,
-    ctx: &mut Ctx,
-) -> Result<ast::Args, LoweringError> {
-    let mut args_out = vec![];
-
-    // Ensure that the number of given arguments does not exceed the number of expected parameters.
-    // Some expected parameters might be implicit and not require corresponding given arguments.
-    if given.len() > expected.len() {
-        // The unwrap is safe because in this branch there must be at least one given.
-        let err = LoweringError::TooManyArgs { span: given.first().unwrap().span().to_miette() };
-        return Err(err);
-    }
-
-    // Create a peekable iterator over the given arguments to allow lookahead.
-    let mut given_iter = given.iter().peekable();
-
-    /// Processes a single argument, matching it against the expected parameter binding site.
-    ///
-    /// This function consumes one argument from the `given` iterator and attempts to match it with the
-    /// expected binding site (`expected_bs`). It handles both named and unnamed arguments and ensures
-    /// that named arguments match the expected parameter names.
-    ///
-    /// # Parameters
-    ///
-    /// - `span`: The source span of the given argument list.
-    /// - `given`: A mutable iterator over the given arguments.
-    /// - `expected_bs`: The binding site of the expected parameter.
-    /// - `args_out`: A mutable vector to collect the lowered arguments.
-    /// - `ctx`: A mutable reference to the current context.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(())`: The argument was successfully processed and added to `args_out`.
-    /// - `Err(LoweringError)`: An error occurred while processing the argument.
-    fn pop_arg<'a>(
-        span: Span,
-        given: &mut impl Iterator<Item = &'a cst::exp::Arg>,
-        expected_bs: &BindingSite,
-        args_out: &mut Vec<ast::Arg>,
-        ctx: &mut Ctx,
-    ) -> Result<(), LoweringError> {
-        let Some(arg) = given.next() else {
-            let expected = expected_bs.lower(ctx)?;
-            let expected = expected.print_to_string(None);
-            return Err(LoweringError::MissingArgForParam { expected, span: span.to_miette() });
-        };
-        match arg {
-            cst::exp::Arg::UnnamedArg(exp) => {
-                args_out.push(ast::Arg::UnnamedArg { arg: exp.lower(ctx)?, erased: false });
-            }
-            cst::exp::Arg::NamedArg(name, exp) => {
-                let expected_name = match &expected_bs {
-                    BindingSite::Var { name, .. } => name,
-                    BindingSite::Wildcard { span } => {
-                        return Err(LoweringError::NamedArgForWildcard {
-                            given: name.clone(),
-                            span: span.to_miette(),
-                        });
-                    }
-                };
-                if name.id != expected_name.id {
-                    return Err(LoweringError::MismatchedNamedArgs {
-                        given: name.to_owned(),
-                        expected: expected_name.to_owned(),
-                        span: exp.span().to_miette(),
-                    });
-                }
-                let name = VarBound { span: Some(name.span), id: name.id.clone() };
-                args_out.push(ast::Arg::NamedArg { name, arg: exp.lower(ctx)?, erased: false });
-            }
-        }
-        Ok(())
-    }
-
-    for expected_param in expected.0.iter() {
-        // Each parameter can have multiple names (e.g., aliases).
-        let names_iter = std::iter::once(&expected_param.name).chain(expected_param.names.iter());
-        for expected_bs in names_iter {
-            if expected_param.implicit {
-                if let Some(cst::exp::Arg::NamedArg(given_name, exp)) = given_iter.peek() {
-                    let BindingSite::Var { name: expected_name, .. } = &expected_bs else {
-                        return Err(LoweringError::NamedArgForWildcard {
-                            given: given_name.clone(),
-                            span: exp.span().to_miette(),
-                        });
-                    };
-                    if expected_name == given_name {
-                        pop_arg(span, &mut given_iter, expected_bs, &mut args_out, ctx)?;
-                        continue;
-                    }
-                }
-
-                let mv = ctx.fresh_metavar(Some(span), MetaVarKind::Inserted);
-                let args = ctx.subst_from_ctx();
-                let hole = Hole {
-                    span: None,
-                    kind: ast::MetaVarKind::Inserted,
-                    metavar: mv,
-                    inferred_type: None,
-                    inferred_ctx: None,
-                    args,
-                    solution: None,
-                };
-
-                args_out.push(ast::Arg::InsertedImplicitArg { hole, erased: false });
-            } else {
-                pop_arg(span, &mut given_iter, expected_bs, &mut args_out, ctx)?;
-            }
-        }
-    }
-
-    // Check for any extra arguments that were not matched to parameters.
-    if let Some(extra_arg) = given_iter.next() {
-        return Err(LoweringError::TooManyArgs { span: extra_arg.span().to_miette() });
-    }
-
-    // All arguments have been successfully processed.
-    Ok(ast::Args { args: args_out })
-}
-
-impl Lower for cst::exp::Case<cst::exp::Pattern> {
-    type Target = ast::Case;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Case { span, pattern, body } = self;
-
-        lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
-            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
-            let name = IdBound {
-                span: Some(pattern.name.span),
-                id: pattern.name.id.clone(),
-                uri: uri.clone(),
-            };
-            Ok(ast::Case {
-                span: Some(*span),
-                pattern: ast::Pattern {
-                    span: Some(pattern.span),
-                    is_copattern: false,
-                    name,
-                    params,
-                },
-                body: body.lower(ctx)?,
-            })
-        })
-    }
-}
-
-impl Lower for cst::exp::Case<cst::exp::Copattern> {
-    type Target = ast::Case;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Case { span, pattern, body } = self;
-
-        lower_telescope_inst(&pattern.params, ctx, |ctx, params| {
-            let (_, uri) = ctx.symbol_table.lookup(&pattern.name)?;
-            let name = ast::IdBound {
-                span: Some(pattern.name.span),
-                id: pattern.name.id.clone(),
-                uri: uri.clone(),
-            };
-            Ok(ast::Case {
-                span: Some(*span),
-                pattern: ast::Pattern {
-                    span: Some(pattern.span),
-                    is_copattern: true,
-                    name,
-                    params,
-                },
-                body: body.lower(ctx)?,
-            })
-        })
-    }
-}
-
-impl Lower for cst::exp::Call {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Call { span, name, args } = self;
-
-        // The type universe "Type" is treated as an ordinary call in the lexer and parser.
-        // For this reason we have to special case the logic for lowering the type universe here.
-        if name.id == "Type" {
-            if !args.is_empty() {
-                return Err(LoweringError::TypeUnivArgs { span: span.to_miette() });
-            }
-            return Ok(TypeUniv { span: Some(*span) }.into());
-        }
-
-        // If we find the identifier in the local context then we have to lower
-        // it to a variable.
-        if let Some(idx) = ctx.lookup_local(name) {
-            let name = VarBound { span: Some(name.span), id: name.id.clone() };
-            return Ok(ast::Exp::Variable(Variable {
-                span: Some(*span),
-                idx,
-                name,
-                inferred_type: None,
-            }));
-        }
-
-        // If we find the identifier in the global context then we have to lower
-        // it to a call or a type constructor.
-        let (meta, uri) = ctx.symbol_table.lookup(name)?;
-        match meta {
-            DeclMeta::Data { params, .. } | DeclMeta::Codata { params, .. } => {
-                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
-                Ok(ast::Exp::TypCtor(ast::TypCtor {
-                    span: Some(*span),
-                    name,
-                    args: lower_args(*span, args, params.clone(), ctx)?,
-                    is_bin_op: None,
-                }))
-            }
-            DeclMeta::Def { .. } | DeclMeta::Dtor { .. } => {
-                Err(LoweringError::MustUseAsDotCall { name: name.clone(), span: span.to_miette() })
-            }
-            DeclMeta::Ctor { params, .. } => {
-                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
-                Ok(ast::Exp::Call(ast::Call {
-                    span: Some(*span),
-                    kind: ast::CallKind::Constructor,
-                    name,
-                    args: lower_args(*span, args, params.clone(), ctx)?,
-                    inferred_type: None,
-                }))
-            }
-            DeclMeta::Codef { params, .. } => {
-                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
-                Ok(ast::Exp::Call(ast::Call {
-                    span: Some(*span),
-                    kind: ast::CallKind::Codefinition,
-                    name,
-                    args: lower_args(*span, args, params.clone(), ctx)?,
-                    inferred_type: None,
-                }))
-            }
-            DeclMeta::Let { params, .. } => {
-                let name = IdBound { span: Some(name.span), id: name.id.clone(), uri: uri.clone() };
-                Ok(ast::Exp::Call(ast::Call {
-                    span: Some(*span),
-                    kind: ast::CallKind::LetBound,
-                    name,
-                    args: lower_args(*span, args, params.clone(), ctx)?,
-                    inferred_type: None,
-                }))
-            }
-        }
-    }
-}
-
-impl Lower for cst::exp::DotCall {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::DotCall { span, exp, name, args } = self;
-
-        let (meta, uri) = ctx.symbol_table.lookup(name)?;
-        let (meta, uri) = (meta.clone(), uri.clone());
-
-        match meta {
-            DeclMeta::Dtor { params, .. } => Ok(ast::Exp::DotCall(ast::DotCall {
-                span: Some(*span),
-                kind: ast::DotCallKind::Destructor,
-                exp: exp.lower(ctx)?,
-                name: IdBound { span: Some(name.span), id: name.id.clone(), uri },
-                args: lower_args(*span, args, params, ctx)?,
-                inferred_type: None,
-            })),
-            DeclMeta::Def { params, .. } => Ok(ast::Exp::DotCall(ast::DotCall {
-                span: Some(*span),
-                kind: ast::DotCallKind::Definition,
-                exp: exp.lower(ctx)?,
-                name: IdBound { span: Some(name.span), id: name.id.clone(), uri },
-                args: lower_args(*span, args, params, ctx)?,
-                inferred_type: None,
-            })),
-            _ => Err(LoweringError::CannotUseAsDotCall {
-                name: name.clone(),
-                span: span.to_miette(),
-            }),
-        }
-    }
-}
-
-impl Lower for cst::exp::Anno {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Anno { span, exp, typ } = self;
-        Ok(ast::Anno {
-            span: Some(*span),
-            exp: exp.lower(ctx)?,
-            typ: typ.lower(ctx)?,
-            normalized_type: None,
-        }
-        .into())
-    }
-}
-
-impl Lower for cst::exp::LocalMatch {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalMatch { span, name, on_exp, motive, cases } = self;
-        Ok(ast::LocalMatch {
-            span: Some(*span),
-            ctx: None,
-            name: ctx.unique_label(name.to_owned(), span)?,
-            on_exp: on_exp.lower(ctx)?,
-            motive: motive.lower(ctx)?,
-            ret_typ: None,
-            cases: cases.lower(ctx)?,
-            inferred_type: None,
-        }
-        .into())
-    }
-}
-
-impl Lower for cst::exp::LocalComatch {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::LocalComatch { span, name, is_lambda_sugar, cases } = self;
-        Ok(ast::LocalComatch {
-            span: Some(*span),
-            ctx: None,
-            name: ctx.unique_label(name.to_owned(), span)?,
-            is_lambda_sugar: *is_lambda_sugar,
-            cases: cases.lower(ctx)?,
-            inferred_type: None,
-        }
-        .into())
-    }
-}
-
-impl Lower for cst::exp::HoleKind {
-    type Target = ast::MetaVarKind;
-
-    fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        match self {
-            cst::exp::HoleKind::MustSolve => Ok(ast::MetaVarKind::MustSolve),
-            cst::exp::HoleKind::CanSolve => Ok(ast::MetaVarKind::CanSolve),
-        }
-    }
-}
-
-impl Lower for cst::exp::Hole {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Hole { span, kind, .. } = self;
-        let kind = kind.lower(ctx)?;
-        let mv = ctx.fresh_metavar(Some(*span), kind);
-        let args = ctx.subst_from_ctx();
-        Ok(Hole {
-            span: Some(*span),
-            kind,
-            metavar: mv,
-            inferred_type: None,
-            inferred_ctx: None,
-            args,
-            solution: None,
-        }
-        .into())
-    }
-}
-
-impl Lower for cst::exp::NatLit {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::NatLit { span, val } = self;
-
-        // We have to check whether "Z" is declared as a constructor or codefinition.
-        // We assume that if Z exists, then S exists as well and is of the same kind.
-        let (z_kind, uri) = ctx
-            .symbol_table
-            .lookup(&Ident { span: *span, id: "Z".to_string() })
-            .map_err(|_| LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() })?;
-        let call_kind = match z_kind {
-            DeclMeta::Codef { .. } => ast::CallKind::Codefinition,
-            DeclMeta::Ctor { .. } => ast::CallKind::Constructor,
-            _ => return Err(LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() }),
-        };
-
-        let mut out = ast::Exp::Call(ast::Call {
-            span: Some(*span),
-            kind: call_kind,
-            name: ast::IdBound { span: Some(*span), id: "Z".to_owned(), uri: uri.clone() },
-            args: ast::Args { args: vec![] },
-            inferred_type: None,
-        });
-
-        let mut i = BigUint::from(0usize);
-
-        while &i != val {
-            i += 1usize;
-            out = ast::Exp::Call(ast::Call {
-                span: Some(*span),
-                kind: call_kind,
-                name: ast::IdBound { span: Some(*span), id: "S".to_owned(), uri: uri.clone() },
-                args: ast::Args {
-                    args: vec![ast::Arg::UnnamedArg { arg: Box::new(out), erased: false }],
-                },
-                inferred_type: None,
-            });
-        }
-
-        Ok(out)
-    }
-}
-
-impl Lower for cst::exp::BinOp {
-    type Target = ast::Exp;
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::BinOp { span, operator, lhs, rhs } = self;
-        let (id, _url) = ctx.symbol_table.lookup_operator(operator)?;
-        let (_, uri) = ctx.symbol_table.lookup(id)?;
-        Ok(ast::TypCtor {
-            span: Some(*span),
-            name: ast::IdBound { span: Some(*span), id: id.id.clone(), uri: uri.clone() },
-            args: ast::Args {
-                args: vec![
-                    ast::Arg::UnnamedArg { arg: lhs.lower(ctx)?, erased: false },
-                    ast::Arg::UnnamedArg { arg: rhs.lower(ctx)?, erased: false },
-                ],
-            },
-            is_bin_op: Some(operator.id.clone()),
-        }
-        .into())
-    }
-}
-
-impl Lower for cst::exp::Lam {
-    type Target = ast::Exp;
-
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
-        let cst::exp::Lam { span, case } = self;
-        let comatch = cst::exp::Exp::LocalComatch(cst::exp::LocalComatch {
-            span: *span,
-            name: None,
-            is_lambda_sugar: true,
-            cases: vec![case.clone()],
-        });
-        comatch.lower(ctx)
-    }
-}
 
 impl Lower for cst::exp::BindingSite {
     type Target = ast::VarBind;
 
-    fn lower(&self, _ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, _ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         match self {
             BindingSite::Var { span, name } => {
                 if name.id == "Type" {
@@ -576,7 +77,7 @@ impl Lower for cst::exp::BindingSite {
 impl Lower for cst::exp::Motive {
     type Target = ast::Motive;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         let cst::exp::Motive { span, param, ret_typ } = self;
 
         let name = param.lower(ctx)?;
@@ -591,26 +92,5 @@ impl Lower for cst::exp::Motive {
             },
             ret_typ: ctx.bind_single(name, |ctx| ret_typ.lower(ctx))?,
         })
-    }
-}
-
-#[cfg(test)]
-mod lower_args_tests {
-    use url::Url;
-
-    use parser::cst::decls::Telescope;
-
-    use crate::symbol_table::SymbolTable;
-
-    use super::*;
-
-    #[test]
-    fn test_empty() {
-        let given = vec![];
-        let expected = Telescope(vec![]);
-        let mut ctx =
-            Ctx::empty(Url::parse("inmemory:///scratch.pol").unwrap(), SymbolTable::default());
-        let res = lower_args(Span::default(), &given, expected, &mut ctx);
-        assert_eq!(res.unwrap(), ast::Args { args: vec![] })
     }
 }

--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -47,7 +47,7 @@ fn lower_telescope_inst<T, F: FnOnce(&mut Ctx, ast::TelescopeInst) -> LoweringRe
     ctx.bind_fold_failable(
         tel_inst.into_iter(),
         vec![],
-        |_ctx, params_out, name| {
+        |_ctx, params_out, name| -> LoweringResult<Binder<()>> {
             let param_out =
                 ast::ParamInst { span: name.span(), name: name.clone(), typ: None, erased: false };
             params_out.push(param_out);
@@ -64,7 +64,7 @@ impl Lower for cst::exp::BindingSite {
         match self {
             BindingSite::Var { span, name } => {
                 if name.id == "Type" {
-                    Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() })
+                    Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() }.into())
                 } else {
                     Ok(ast::VarBind::Var { span: Some(*span), id: name.id.clone() })
                 }

--- a/lang/lowering/src/lower/exp/nat_lit.rs
+++ b/lang/lowering/src/lower/exp/nat_lit.rs
@@ -1,0 +1,50 @@
+use miette_util::ToMiette;
+use num_bigint::BigUint;
+use parser::cst::{self, Ident};
+
+use crate::{lower::Lower, Ctx, DeclMeta, LoweringError, LoweringResult};
+
+impl Lower for cst::exp::NatLit {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
+        let cst::exp::NatLit { span, val } = self;
+
+        // We have to check whether "Z" is declared as a constructor or codefinition.
+        // We assume that if Z exists, then S exists as well and is of the same kind.
+        let (z_kind, uri) = ctx
+            .symbol_table
+            .lookup(&Ident { span: *span, id: "Z".to_string() })
+            .map_err(|_| LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() })?;
+        let call_kind = match z_kind {
+            DeclMeta::Codef { .. } => ast::CallKind::Codefinition,
+            DeclMeta::Ctor { .. } => ast::CallKind::Constructor,
+            _ => return Err(LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() }),
+        };
+
+        let mut out = ast::Exp::Call(ast::Call {
+            span: Some(*span),
+            kind: call_kind,
+            name: ast::IdBound { span: Some(*span), id: "Z".to_owned(), uri: uri.clone() },
+            args: ast::Args { args: vec![] },
+            inferred_type: None,
+        });
+
+        let mut i = BigUint::from(0usize);
+
+        while &i != val {
+            i += 1usize;
+            out = ast::Exp::Call(ast::Call {
+                span: Some(*span),
+                kind: call_kind,
+                name: ast::IdBound { span: Some(*span), id: "S".to_owned(), uri: uri.clone() },
+                args: ast::Args {
+                    args: vec![ast::Arg::UnnamedArg { arg: Box::new(out), erased: false }],
+                },
+                inferred_type: None,
+            });
+        }
+
+        Ok(out)
+    }
+}

--- a/lang/lowering/src/lower/exp/nat_lit.rs
+++ b/lang/lowering/src/lower/exp/nat_lit.rs
@@ -12,10 +12,10 @@ impl Lower for cst::exp::NatLit {
 
         // We have to check whether "Z" is declared as a constructor or codefinition.
         // We assume that if Z exists, then S exists as well and is of the same kind.
-        let (z_kind, uri) = ctx
-            .symbol_table
-            .lookup(&Ident { span: *span, id: "Z".to_string() })
-            .map_err(|_| LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() })?;
+        let (z_kind, name) =
+            ctx.symbol_table.lookup(&Ident { span: *span, id: "Z".to_string() }).map_err(|_| {
+                LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() }
+            })?;
         let call_kind = match z_kind {
             DeclMeta::Codef { .. } => ast::CallKind::Codefinition,
             DeclMeta::Ctor { .. } => ast::CallKind::Constructor,
@@ -25,7 +25,7 @@ impl Lower for cst::exp::NatLit {
         let mut out = ast::Exp::Call(ast::Call {
             span: Some(*span),
             kind: call_kind,
-            name: ast::IdBound { span: Some(*span), id: "Z".to_owned(), uri: uri.clone() },
+            name: name.clone(),
             args: ast::Args { args: vec![] },
             inferred_type: None,
         });
@@ -37,7 +37,7 @@ impl Lower for cst::exp::NatLit {
             out = ast::Exp::Call(ast::Call {
                 span: Some(*span),
                 kind: call_kind,
-                name: ast::IdBound { span: Some(*span), id: "S".to_owned(), uri: uri.clone() },
+                name: ast::IdBound { span: Some(*span), id: "S".to_owned(), uri: name.uri.clone() },
                 args: ast::Args {
                     args: vec![ast::Arg::UnnamedArg { arg: Box::new(out), erased: false }],
                 },

--- a/lang/lowering/src/lower/exp/nat_lit.rs
+++ b/lang/lowering/src/lower/exp/nat_lit.rs
@@ -19,7 +19,11 @@ impl Lower for cst::exp::NatLit {
         let call_kind = match z_kind {
             DeclMeta::Codef { .. } => ast::CallKind::Codefinition,
             DeclMeta::Ctor { .. } => ast::CallKind::Constructor,
-            _ => return Err(LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() }),
+            _ => {
+                return Err(
+                    LoweringError::NatLiteralCannotBeDesugared { span: span.to_miette() }.into()
+                )
+            }
         };
 
         let mut out = ast::Exp::Call(ast::Call {

--- a/lang/lowering/src/lower/mod.rs
+++ b/lang/lowering/src/lower/mod.rs
@@ -6,13 +6,13 @@ mod exp;
 pub trait Lower {
     type Target;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError>;
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target>;
 }
 
 impl<T: Lower> Lower for Option<T> {
     type Target = Option<T::Target>;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         self.as_ref().map(|x| x.lower(ctx)).transpose()
     }
 }
@@ -20,7 +20,7 @@ impl<T: Lower> Lower for Option<T> {
 impl<T: Lower> Lower for Vec<T> {
     type Target = Vec<T::Target>;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         self.iter().map(|x| x.lower(ctx)).collect()
     }
 }
@@ -28,7 +28,7 @@ impl<T: Lower> Lower for Vec<T> {
 impl<T: Lower> Lower for Box<T> {
     type Target = Box<T::Target>;
 
-    fn lower(&self, ctx: &mut Ctx) -> Result<Self::Target, LoweringError> {
+    fn lower(&self, ctx: &mut Ctx) -> LoweringResult<Self::Target> {
         Ok(Box::new((**self).lower(ctx)?))
     }
 }

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -2,6 +2,10 @@ use miette::{Diagnostic, SourceSpan};
 use parser::cst::ident::Ident;
 use thiserror::Error;
 
+/// The result type specialized to lowering errors.
+pub type LoweringResult<T = ()> = Result<T, LoweringError>;
+
+/// All the errors that can be emitted during lowering
 #[derive(Error, Diagnostic, Debug, Clone)]
 pub enum LoweringError {
     #[error("Undefined identifier {}", name.id)]

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -1,3 +1,4 @@
+use ast::IdBound;
 use miette::{Diagnostic, SourceSpan};
 use parser::cst::ident::Ident;
 use thiserror::Error;
@@ -25,14 +26,14 @@ pub enum LoweringError {
     #[error("{} must be used as destructor", name.id)]
     #[diagnostic(code("L-003"))]
     MustUseAsDotCall {
-        name: Ident,
+        name: IdBound,
         #[label]
         span: SourceSpan,
     },
     #[error("{} cannot be used as a destructor", name.id)]
     #[diagnostic(code("L-004"))]
     CannotUseAsDotCall {
-        name: Ident,
+        name: IdBound,
         #[label]
         span: SourceSpan,
     },

--- a/lang/lowering/src/result.rs
+++ b/lang/lowering/src/result.rs
@@ -4,7 +4,7 @@ use parser::cst::ident::Ident;
 use thiserror::Error;
 
 /// The result type specialized to lowering errors.
-pub type LoweringResult<T = ()> = Result<T, LoweringError>;
+pub type LoweringResult<T = ()> = Result<T, Box<LoweringError>>;
 
 /// All the errors that can be emitted during lowering
 #[derive(Error, Diagnostic, Debug, Clone)]

--- a/lang/lowering/src/symbol_table/build.rs
+++ b/lang/lowering/src/symbol_table/build.rs
@@ -3,12 +3,12 @@ use miette_util::codespan::Span;
 use miette_util::ToMiette;
 use parser::cst::*;
 
-use crate::LoweringError;
+use crate::{LoweringError, LoweringResult};
 
 use super::{DeclMeta, ModuleSymbolTable};
 
-pub fn build_symbol_table(module: &Module) -> Result<ModuleSymbolTable, LoweringError> {
-    let mut symbol_table = Default::default();
+pub fn build_symbol_table(module: &Module) -> LoweringResult<ModuleSymbolTable> {
+    let mut symbol_table = ModuleSymbolTable::default();
 
     let Module { decls, .. } = module;
 
@@ -20,11 +20,7 @@ pub fn build_symbol_table(module: &Module) -> Result<ModuleSymbolTable, Lowering
 }
 
 /// Checks whether the identifier is reserved or already defined.
-fn check_name(
-    symbol_table: &mut ModuleSymbolTable,
-    name: &Ident,
-    span: &Span,
-) -> Result<(), LoweringError> {
+fn check_name(symbol_table: &mut ModuleSymbolTable, name: &Ident, span: &Span) -> LoweringResult {
     if name.id == "Type" {
         return Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() });
     }
@@ -38,11 +34,11 @@ fn check_name(
 }
 
 trait BuildSymbolTable {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError>;
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult;
 }
 
 impl BuildSymbolTable for Decl {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         match self {
             Decl::Data(data) => data.build(symbol_table),
             Decl::Codata(codata) => codata.build(symbol_table),
@@ -55,7 +51,7 @@ impl BuildSymbolTable for Decl {
 }
 
 impl BuildSymbolTable for Data {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Data { span, name, params, ctors, .. } = self;
 
         check_name(symbol_table, name, span)?;
@@ -71,7 +67,7 @@ impl BuildSymbolTable for Data {
 }
 
 impl BuildSymbolTable for Ctor {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Ctor { span, name, params, .. } = self;
         check_name(symbol_table, name, span)?;
 
@@ -83,7 +79,7 @@ impl BuildSymbolTable for Ctor {
 }
 
 impl BuildSymbolTable for Codata {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Codata { span, name, params, dtors, .. } = self;
         check_name(symbol_table, name, span)?;
 
@@ -98,7 +94,7 @@ impl BuildSymbolTable for Codata {
 }
 
 impl BuildSymbolTable for Dtor {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Dtor { span, name, params, .. } = self;
         check_name(symbol_table, name, span)?;
 

--- a/lang/lowering/src/symbol_table/build.rs
+++ b/lang/lowering/src/symbol_table/build.rs
@@ -22,13 +22,14 @@ pub fn build_symbol_table(module: &Module) -> LoweringResult<ModuleSymbolTable> 
 /// Checks whether the identifier is reserved or already defined.
 fn check_name(symbol_table: &mut ModuleSymbolTable, name: &Ident, span: &Span) -> LoweringResult {
     if name.id == "Type" {
-        return Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() });
+        return Err(LoweringError::TypeUnivIdentifier { span: span.to_miette() }.into());
     }
     if symbol_table.idents.contains_key(name) {
         return Err(LoweringError::AlreadyDefined {
             name: name.to_owned(),
             span: span.to_miette(),
-        });
+        }
+        .into());
     }
     Ok(())
 }
@@ -106,7 +107,7 @@ impl BuildSymbolTable for Dtor {
 }
 
 impl BuildSymbolTable for Def {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Def { span, name, params, .. } = self;
         check_name(symbol_table, name, span)?;
 
@@ -118,7 +119,7 @@ impl BuildSymbolTable for Def {
 }
 
 impl BuildSymbolTable for Codef {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Codef { span, name, params, .. } = self;
         check_name(symbol_table, name, span)?;
 
@@ -130,7 +131,7 @@ impl BuildSymbolTable for Codef {
 }
 
 impl BuildSymbolTable for Let {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Let { span, name, params, .. } = self;
         check_name(symbol_table, name, span)?;
 
@@ -142,14 +143,15 @@ impl BuildSymbolTable for Let {
 }
 
 impl BuildSymbolTable for Infix {
-    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> Result<(), LoweringError> {
+    fn build(&self, symbol_table: &mut ModuleSymbolTable) -> LoweringResult {
         let Infix { span, doc: _, lhs, rhs } = self;
 
         if symbol_table.infix_ops.contains_key(&lhs.operator) {
             return Err(LoweringError::OperatorAlreadyDefined {
                 operator: lhs.operator.id.to_owned(),
                 span: span.to_miette(),
-            });
+            }
+            .into());
         }
         symbol_table.infix_ops.insert(lhs.operator.clone(), rhs.name.clone());
 

--- a/lang/lowering/src/symbol_table/lookup.rs
+++ b/lang/lowering/src/symbol_table/lookup.rs
@@ -32,7 +32,8 @@ impl SymbolTable {
                 None => continue,
             }
         }
-        Err(LoweringError::UndefinedIdent { name: name.clone(), span: name.span.to_miette() })
+        Err(LoweringError::UndefinedIdent { name: name.clone(), span: name.span.to_miette() }
+            .into())
     }
 
     /// Check whether the operator already exists in any of the symbol tables.
@@ -45,13 +46,14 @@ impl SymbolTable {
         false
     }
 
-    pub fn lookup_operator(&self, op: &Operator) -> Result<(&Ident, &Url), LoweringError> {
+    pub fn lookup_operator(&self, op: &Operator) -> LoweringResult<(&Ident, &Url)> {
         for (module_uri, symbol_table) in self.map.iter() {
             match symbol_table.infix_ops.get(op) {
                 Some(id) => return Ok((id, module_uri)),
                 None => continue,
             }
         }
-        Err(LoweringError::UnknownOperator { span: op.span.to_miette(), operator: op.id.clone() })
+        Err(LoweringError::UnknownOperator { span: op.span.to_miette(), operator: op.id.clone() }
+            .into())
     }
 }

--- a/lang/lowering/src/symbol_table/lookup.rs
+++ b/lang/lowering/src/symbol_table/lookup.rs
@@ -1,3 +1,4 @@
+use ast::IdBound;
 use miette_util::ToMiette;
 use parser::cst::ident::{Ident, Operator};
 use url::Url;
@@ -17,10 +18,17 @@ impl SymbolTable {
         false
     }
 
-    pub fn lookup(&self, name: &Ident) -> LoweringResult<(&DeclMeta, &Url)> {
+    pub fn lookup(&self, name: &Ident) -> LoweringResult<(&DeclMeta, IdBound)> {
         for (module_uri, symbol_table) in self.map.iter() {
             match symbol_table.idents.get(name) {
-                Some(meta) => return Ok((meta, module_uri)),
+                Some(meta) => {
+                    let name = IdBound {
+                        span: Some(name.span),
+                        id: name.id.clone(),
+                        uri: module_uri.clone(),
+                    };
+                    return Ok((meta, name));
+                }
                 None => continue,
             }
         }

--- a/lang/lowering/src/symbol_table/lookup.rs
+++ b/lang/lowering/src/symbol_table/lookup.rs
@@ -2,7 +2,7 @@ use miette_util::ToMiette;
 use parser::cst::ident::{Ident, Operator};
 use url::Url;
 
-use crate::LoweringError;
+use crate::{LoweringError, LoweringResult};
 
 use super::{DeclMeta, SymbolTable};
 
@@ -17,7 +17,7 @@ impl SymbolTable {
         false
     }
 
-    pub fn lookup(&self, name: &Ident) -> Result<(&DeclMeta, &Url), LoweringError> {
+    pub fn lookup(&self, name: &Ident) -> LoweringResult<(&DeclMeta, &Url)> {
         for (module_uri, symbol_table) in self.map.iter() {
             match symbol_table.idents.get(name) {
                 Some(meta) => return Ok((meta, module_uri)),

--- a/lang/parser/src/cst/mod.rs
+++ b/lang/parser/src/cst/mod.rs
@@ -1,3 +1,9 @@
+//! # Concrete syntax tree (CST)
+//!
+//! This representation is used as the output of the parser and as the input of the lowering stage that follows
+//! in the compiler pipeline. The structure of the CST therefore corresponds closely to the grammar of the surface
+//! syntax as implemented by the parser.
+
 pub mod decls;
 pub mod exp;
 pub mod ident;


### PR DESCRIPTION
This is in preparation for emitting more than one error during lowering. Emitting more than one lowering error at a time should be a huge usability improvement.