### PR TITLE
Fix warnings for clippy 1.87.0

### DIFF
--- a/lang/docs/src/render/html.rs
+++ b/lang/docs/src/render/html.rs
@@ -32,7 +32,7 @@ where
     }
 
     fn fail_doc(&self) -> Self::Error {
-        io::Error::new(io::ErrorKind::Other, "Document failed to render")
+        io::Error::other("Document failed to render")
     }
 }
 

--- a/lang/printer/src/render/latex.rs
+++ b/lang/printer/src/render/latex.rs
@@ -28,7 +28,7 @@ where
     }
 
     fn fail_doc(&self) -> Self::Error {
-        io::Error::new(io::ErrorKind::Other, "Document failed to render")
+        io::Error::other("Document failed to render")
     }
 }
 

--- a/lang/printer/src/render/termcolor.rs
+++ b/lang/printer/src/render/termcolor.rs
@@ -38,7 +38,7 @@ where
     }
 
     fn fail_doc(&self) -> Self::Error {
-        io::Error::new(io::ErrorKind::Other, "Document failed to render")
+        io::Error::other("Document failed to render")
     }
 }
 


### PR DESCRIPTION
Fix warnings for new clippy hints that were introduced in Rust 1.87