### PR TITLE
Add cst node for parenthesized expressions

### DIFF
--- a/lang/lowering/src/lower/exp/mod.rs
+++ b/lang/lowering/src/lower/exp/mod.rs
@@ -20,6 +20,7 @@ mod local_comatch;
 mod local_let;
 mod local_match;
 mod nat_lit;
+mod parens;
 
 impl Lower for cst::exp::Exp {
     type Target = ast::Exp;
@@ -36,6 +37,7 @@ impl Lower for cst::exp::Exp {
             cst::exp::Exp::BinOp(e) => e.lower(ctx),
             cst::exp::Exp::Lam(e) => e.lower(ctx),
             cst::exp::Exp::LocalLet(e) => e.lower(ctx),
+            cst::exp::Exp::Parens(e) => e.lower(ctx),
         }
     }
 }

--- a/lang/lowering/src/lower/exp/parens.rs
+++ b/lang/lowering/src/lower/exp/parens.rs
@@ -1,0 +1,12 @@
+use parser::cst;
+
+use crate::lower::Lower;
+
+impl Lower for cst::exp::Parens {
+    type Target = ast::Exp;
+
+    fn lower(&self, ctx: &mut crate::Ctx) -> crate::LoweringResult<Self::Target> {
+        let e = self.exp.lower(ctx)?;
+        Ok(*e)
+    }
+}

--- a/lang/parser/src/cst/exp.rs
+++ b/lang/parser/src/cst/exp.rs
@@ -77,6 +77,7 @@ pub enum Exp {
     BinOp(BinOp),
     Lam(Lam),
     LocalLet(LocalLet),
+    Parens(Parens),
 }
 
 impl Exp {
@@ -92,6 +93,7 @@ impl Exp {
             Exp::BinOp(binop) => binop.span,
             Exp::Lam(lam) => lam.span,
             Exp::LocalLet(local_let) => local_let.span,
+            Exp::Parens(parens) => parens.span,
         }
     }
 
@@ -199,6 +201,13 @@ pub struct BinOp {
 pub struct Lam {
     pub span: Span,
     pub case: Case<Copattern>,
+}
+
+#[derive(Debug, Clone)]
+/// A parenthesized expression
+pub struct Parens {
+    pub span: Span,
+    pub exp: Box<Exp>,
 }
 
 #[derive(Debug, Clone)]

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -272,7 +272,7 @@ pub Holes: Box<Exp> = {
 
 pub Atom: Box<Exp> = {
     <e: NatLit> => Box::new(Exp::NatLit(e)),
-    "(" <exp: Exp> ")" => exp,
+    <e: ParensExp> => Box::new(Exp::Parens(e)),
     <e: CallWithoutArgs> => Box::new(Exp::Call(e)),
 }
 
@@ -314,6 +314,9 @@ NatLit: NatLit = <l: @L> <n: "NumLit"> <r: @R> =>
 
 LocalLet: LocalLet = <l: @L> "let" <bs: BindingSite> <typ: (":" <NonLet>)?> ":=" <bound: NonLet> ";" <body: Exp> <r: @R> =>
   LocalLet { span: span(l,r), bs, typ, bound, body };
+
+ParensExp: Parens = <l: @L> "(" <exp: Exp> ")" <r: @R> =>
+  Parens { span: span(l,r), exp };
 
 // Helpers
 //


### PR DESCRIPTION
I will need a proper representation of  parenthesized expressions in lowering later, if we want to implement associativity and precedence for binary operators.