### PR TITLE
Do not show the "Hide code" button for data and codata types

### DIFF
--- a/lang/docs/templates/codata.html
+++ b/lang/docs/templates/codata.html
@@ -4,9 +4,6 @@
         <div>
             <span><span class="keyword">codata</span> {{name}}{{attr}} {{typ}}</span>
         </div>
-        <div>
-            <button class="button"  onclick="toggleCard(this)">hide code</button>
-        </div>
     </div>
     <div class="doc" style="display: block;">
         <span>{{doc}}</span>

--- a/lang/docs/templates/data.html
+++ b/lang/docs/templates/data.html
@@ -3,9 +3,6 @@
     <div class="card-header">
         <div>
             <span><span class="keyword">data</span> {{name}}{{attr}}{{typ}}</span>
-        </div>  
-        <div>
-            <button class="button"  onclick="toggleCard(this)">hide code</button>
         </div>
     </div>
     <div class="doc" style="display: block;">


### PR DESCRIPTION
We always want to display constructors and destructors of data and codata types.