### PR TITLE
Add local let expressions to ast

### DIFF
--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -59,10 +59,10 @@ impl Occurs for LocalLet {
     where
         F: Fn(&crate::ctx::LevelCtx, &Exp) -> bool,
     {
-        let LocalLet { bound, body, span: _, name: bs, typ, inferred_type: _ } = self;
+        let LocalLet { bound, body, span: _, name, typ, inferred_type: _ } = self;
         bound.occurs(ctx, f)
             || typ.as_ref().is_some_and(|t| t.occurs(ctx, f))
-            || ctx.bind_single(bs.clone(), |ctx| body.occurs(ctx, f))
+            || ctx.bind_single(name.clone(), |ctx| body.occurs(ctx, f))
     }
 }
 

--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -60,8 +60,8 @@ impl Occurs for LocalLet {
         F: Fn(&crate::ctx::LevelCtx, &Exp) -> bool,
     {
         let LocalLet { span: _, name, typ, bound, body, inferred_type: _ } = self;
-        bound.occurs(ctx, f)
-            || typ.as_ref().is_some_and(|t| t.occurs(ctx, f))
+        typ.as_ref().is_some_and(|t| t.occurs(ctx, f))
+            || bound.occurs(ctx, f)
             || ctx.bind_single(name.clone(), |ctx| body.occurs(ctx, f))
     }
 }

--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -1,0 +1,170 @@
+use derivative::Derivative;
+use miette_util::codespan::Span;
+use pretty::DocAllocator;
+use printer::{
+    Print,
+    theme::ThemeExt,
+    tokens::{COLON, COLONEQ, LET, SEMICOLON},
+};
+
+use crate::{
+    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRangeExt, Substitutable, Zonk,
+    ctx::BindContext, rename::Rename,
+};
+
+use super::{Exp, VarBind};
+
+/// Local let bindings:
+/// ```text
+/// let x : t := e; e
+/// let x := e ; e
+/// ```
+#[derive(Debug, Clone, Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+pub struct LocalLet {
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    pub span: Span,
+    /// The name of the variable being bound.
+    pub name: VarBind,
+    /// Optionally annotated type of the bound expression.
+    pub typ: Option<Box<Exp>>,
+    /// Expression that is being bound to the variable.
+    pub bound: Box<Exp>,
+    /// The body of the let expression, which can refer to the bound variable.
+    pub body: Box<Exp>,
+    /// Type of the let expression inferred during elaboration.
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    pub inferred_type: Option<Box<Exp>>,
+}
+
+impl HasSpan for LocalLet {
+    fn span(&self) -> Option<Span> {
+        Some(self.span)
+    }
+}
+
+impl Shift for LocalLet {
+    fn shift_in_range<R: crate::ShiftRange>(&mut self, range: &R, by: (isize, isize)) {
+        let LocalLet { span: _, name: _, typ, bound, body, inferred_type } = self;
+
+        typ.shift_in_range(range, by);
+        bound.shift_in_range(range, by);
+        body.shift_in_range(&range.clone().shift(1), by);
+        *inferred_type = None;
+    }
+}
+
+impl Occurs for LocalLet {
+    fn occurs<F>(&self, ctx: &mut crate::ctx::LevelCtx, f: &F) -> bool
+    where
+        F: Fn(&crate::ctx::LevelCtx, &Exp) -> bool,
+    {
+        let LocalLet { bound, body, span: _, name: bs, typ, inferred_type: _ } = self;
+        bound.occurs(ctx, f)
+            || typ.as_ref().is_some_and(|t| t.occurs(ctx, f))
+            || ctx.bind_single(bs.clone(), |ctx| body.occurs(ctx, f))
+    }
+}
+
+impl HasType for LocalLet {
+    fn typ(&self) -> Option<Box<Exp>> {
+        self.inferred_type.clone()
+    }
+}
+
+impl Substitutable for LocalLet {
+    type Target = LocalLet;
+
+    fn subst<S: crate::Substitution>(
+        &self,
+        ctx: &mut crate::ctx::LevelCtx,
+        by: &S,
+    ) -> Result<Self::Target, S::Err> {
+        let LocalLet { span, name, typ, bound, body, inferred_type: _ } = self;
+
+        let typ = typ.subst(ctx, by)?;
+        let bound = bound.subst(ctx, by)?;
+
+        ctx.bind_single(name.clone(), |ctx| {
+            Ok(LocalLet {
+                span: *span,
+                name: name.clone(),
+                typ,
+                bound,
+                body: body.subst(ctx, by)?,
+                inferred_type: None,
+            })
+        })
+    }
+}
+
+impl Print for LocalLet {
+    fn print<'a>(
+        &'a self,
+        cfg: &printer::PrintCfg,
+        alloc: &'a printer::Alloc<'a>,
+    ) -> printer::Builder<'a> {
+        let LocalLet { span: _, name, typ, bound, body, inferred_type: _ } = self;
+
+        let typ = typ
+            .as_ref()
+            .map(|t| alloc.text(COLON).append(alloc.space()).append(t.print(cfg, alloc)));
+
+        let head = alloc
+            .keyword(LET)
+            .append(alloc.space())
+            .append(name.print(cfg, alloc))
+            .append(typ)
+            .append(alloc.space())
+            .append(COLONEQ)
+            .append(bound.print(cfg, alloc))
+            .append(SEMICOLON)
+            .group();
+
+        let body = body.print(cfg, alloc);
+
+        head.append(alloc.hardline()).append(body)
+    }
+}
+
+impl Zonk for LocalLet {
+    fn zonk(
+        &mut self,
+        meta_vars: &crate::HashMap<crate::MetaVar, crate::MetaVarState>,
+    ) -> Result<(), crate::ZonkError> {
+        let LocalLet { span: _, name: _, typ, bound, body, inferred_type: _ } = self;
+        typ.zonk(meta_vars)?;
+        bound.zonk(meta_vars)?;
+        body.zonk(meta_vars)?;
+        Ok(())
+    }
+}
+
+impl ContainsMetaVars for LocalLet {
+    fn contains_metavars(&self) -> bool {
+        let LocalLet { span: _, name: _, typ, bound, body, inferred_type } = self;
+        typ.contains_metavars()
+            || bound.contains_metavars()
+            || body.contains_metavars()
+            || inferred_type.as_ref().is_some_and(|t| t.contains_metavars())
+    }
+}
+
+impl Rename for LocalLet {
+    fn rename_in_ctx(&mut self, ctx: &mut crate::rename::RenameCtx) {
+        let LocalLet { span: _, name, typ, bound, body, inferred_type: _ } = self;
+
+        typ.rename_in_ctx(ctx);
+        bound.rename_in_ctx(ctx);
+
+        ctx.bind_single(name.clone(), |ctx| {
+            body.rename_in_ctx(ctx);
+        })
+    }
+}
+
+impl From<LocalLet> for Exp {
+    fn from(val: LocalLet) -> Self {
+        Exp::LocalLet(val)
+    }
+}

--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -59,7 +59,7 @@ impl Occurs for LocalLet {
     where
         F: Fn(&crate::ctx::LevelCtx, &Exp) -> bool,
     {
-        let LocalLet { bound, body, span: _, name, typ, inferred_type: _ } = self;
+        let LocalLet { span: _, name, typ, bound, body, inferred_type: _ } = self;
         bound.occurs(ctx, f)
             || typ.as_ref().is_some_and(|t| t.occurs(ctx, f))
             || ctx.bind_single(name.clone(), |ctx| body.occurs(ctx, f))

--- a/lang/ast/src/exp/mod.rs
+++ b/lang/ast/src/exp/mod.rs
@@ -24,11 +24,13 @@ mod case;
 mod dot_call;
 mod hole;
 mod local_comatch;
+mod local_let;
 mod local_match;
 mod telescope_inst;
 mod typ_ctor;
 mod type_univ;
 mod variable;
+
 pub use anno::*;
 pub use args::*;
 pub use call::*;
@@ -36,6 +38,7 @@ pub use case::*;
 pub use dot_call::*;
 pub use hole::*;
 pub use local_comatch::*;
+pub use local_let::*;
 pub use local_match::*;
 pub use telescope_inst::*;
 pub use typ_ctor::*;
@@ -77,6 +80,7 @@ pub enum Exp {
     LocalMatch(LocalMatch),
     LocalComatch(LocalComatch),
     Hole(Hole),
+    LocalLet(LocalLet),
 }
 
 impl Exp {
@@ -100,6 +104,7 @@ impl HasSpan for Exp {
             Exp::LocalMatch(e) => e.span(),
             Exp::LocalComatch(e) => e.span(),
             Exp::Hole(e) => e.span(),
+            Exp::LocalLet(e) => e.span(),
         }
     }
 }
@@ -116,6 +121,7 @@ impl Shift for Exp {
             Exp::LocalMatch(e) => e.shift_in_range(range, by),
             Exp::LocalComatch(e) => e.shift_in_range(range, by),
             Exp::Hole(e) => e.shift_in_range(range, by),
+            Exp::LocalLet(e) => e.shift_in_range(range, by),
         }
     }
 }
@@ -144,6 +150,7 @@ impl Occurs for Exp {
             Exp::LocalMatch(e) => e.occurs(ctx, f),
             Exp::LocalComatch(e) => e.occurs(ctx, f),
             Exp::Hole(e) => e.occurs(ctx, f),
+            Exp::LocalLet(e) => e.occurs(ctx, f),
         }
     }
 }
@@ -160,6 +167,7 @@ impl HasType for Exp {
             Exp::LocalMatch(e) => e.typ(),
             Exp::LocalComatch(e) => e.typ(),
             Exp::Hole(e) => e.typ(),
+            Exp::LocalLet(e) => e.typ(),
         }
     }
 }
@@ -177,6 +185,7 @@ impl Substitutable for Exp {
             Exp::LocalMatch(e) => Ok(e.subst(ctx, by)?.into()),
             Exp::LocalComatch(e) => Ok(e.subst(ctx, by)?.into()),
             Exp::Hole(e) => Ok(e.subst(ctx, by)?.into()),
+            Exp::LocalLet(e) => Ok(e.subst(ctx, by)?.into()),
         }
     }
 }
@@ -198,6 +207,7 @@ impl Print for Exp {
             Exp::LocalMatch(e) => e.print_prec(cfg, alloc, prec),
             Exp::LocalComatch(e) => e.print_prec(cfg, alloc, prec),
             Exp::Hole(e) => e.print_prec(cfg, alloc, prec),
+            Exp::LocalLet(e) => e.print_prec(cfg, alloc, prec),
         }
     }
 }
@@ -217,6 +227,7 @@ impl Zonk for Exp {
             Exp::LocalMatch(e) => e.zonk(meta_vars),
             Exp::LocalComatch(e) => e.zonk(meta_vars),
             Exp::Hole(e) => e.zonk(meta_vars),
+            Exp::LocalLet(e) => e.zonk(meta_vars),
         }
     }
 }
@@ -233,6 +244,7 @@ impl ContainsMetaVars for Exp {
             Exp::LocalMatch(local_match) => local_match.contains_metavars(),
             Exp::LocalComatch(local_comatch) => local_comatch.contains_metavars(),
             Exp::Hole(hole) => hole.contains_metavars(),
+            Exp::LocalLet(local_let) => local_let.contains_metavars(),
         }
     }
 }
@@ -249,6 +261,7 @@ impl Rename for Exp {
             Exp::Call(e) => e.rename_in_ctx(ctx),
             Exp::LocalMatch(e) => e.rename_in_ctx(ctx),
             Exp::DotCall(e) => e.rename_in_ctx(ctx),
+            Exp::LocalLet(e) => e.rename_in_ctx(ctx),
         }
     }
 }

--- a/lang/backend/src/ast2ir/exprs.rs
+++ b/lang/backend/src/ast2ir/exprs.rs
@@ -19,6 +19,11 @@ impl ToIR for ast::Exp {
             ast::Exp::LocalMatch(local_match) => ir::Exp::LocalMatch(local_match.to_ir()?),
             ast::Exp::LocalComatch(local_comatch) => ir::Exp::LocalComatch(local_comatch.to_ir()?),
             ast::Exp::Hole(hole) => hole.to_ir()?,
+            ast::Exp::LocalLet(_) => {
+                return Err(BackendError::Impossible(
+                    "Compiling local let expressions is not implemented yet".to_owned(),
+                ));
+            }
         };
 
         Ok(out)

--- a/lang/driver/src/info/collect.rs
+++ b/lang/driver/src/info/collect.rs
@@ -317,6 +317,7 @@ impl CollectInfo for Exp {
             Exp::Anno(e) => e.collect_info(db, collector),
             Exp::LocalMatch(e) => e.collect_info(db, collector),
             Exp::LocalComatch(e) => e.collect_info(db, collector),
+            Exp::LocalLet(_) => todo!(),
         }
     }
 }

--- a/lang/elaborator/src/normalizer/eval.rs
+++ b/lang/elaborator/src/normalizer/eval.rs
@@ -42,6 +42,11 @@ impl Eval for Exp {
             Exp::LocalMatch(e) => e.eval(info_table, env),
             Exp::LocalComatch(e) => e.eval(info_table, env),
             Exp::Hole(e) => e.eval(info_table, env),
+            Exp::LocalLet(_) => Err(TypeError::Impossible {
+                message: "Evaluating local let expressions is not implemented yet".to_owned(),
+                span: self.span().to_miette(),
+            }
+            .into()),
         };
         trace!(
             "{} |- {} ▷ {}",

--- a/lang/elaborator/src/typechecker/erasure.rs
+++ b/lang/elaborator/src/typechecker/erasure.rs
@@ -34,6 +34,7 @@ pub fn is_runtime_irrelevant(typ: &ast::Exp) -> bool {
         ast::Exp::Hole(hole) => {
             hole.solution.as_ref().map(|s| is_runtime_irrelevant(s)).unwrap_or(false)
         }
+        ast::Exp::LocalLet(_) => false,
     }
 }
 

--- a/lang/elaborator/src/typechecker/exprs/mod.rs
+++ b/lang/elaborator/src/typechecker/exprs/mod.rs
@@ -88,6 +88,10 @@ impl CheckInfer for Exp {
             Exp::Hole(e) => Ok(e.check(ctx, t)?.into()),
             Exp::LocalMatch(e) => Ok(e.check(ctx, t)?.into()),
             Exp::LocalComatch(e) => Ok(e.check(ctx, t)?.into()),
+            Exp::LocalLet(local_let) => Err(Box::new(TypeError::Impossible {
+                message: "Checking local let expressions is not implemented yet".to_owned(),
+                span: local_let.span().to_miette(),
+            })),
         }
     }
 
@@ -102,6 +106,10 @@ impl CheckInfer for Exp {
             Exp::Hole(e) => Ok(e.infer(ctx)?.into()),
             Exp::LocalMatch(e) => Ok(e.infer(ctx)?.into()),
             Exp::LocalComatch(e) => Ok(e.infer(ctx)?.into()),
+            Exp::LocalLet(local_let) => Err(Box::new(TypeError::Impossible {
+                message: "Inferring local let expressions is not implemented yet".to_owned(),
+                span: local_let.span().to_miette(),
+            })),
         };
         trace!(
             "{} |- {} => {}",

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -32,6 +32,9 @@ pub const COLONEQ: &str = ":=";
 /// The symbol `_`
 pub const UNDERSCORE: &str = "_";
 
+/// The symbol `;`
+pub const SEMICOLON: &str = ";";
+
 // Keywords
 //
 //

--- a/lang/transformations/src/lifting/fv.rs
+++ b/lang/transformations/src/lifting/fv.rs
@@ -96,6 +96,7 @@ impl FV for Exp {
             Exp::Hole(hole) => hole.free_vars_closure(lvl_ctx, type_ctx),
             Exp::TypeUniv(_) => HashSet::default(),
             Exp::LocalMatch(local_match) => local_match.free_vars_closure(lvl_ctx, type_ctx),
+            Exp::LocalLet(_) => todo!(),
         }
     }
 }

--- a/lang/transformations/src/lifting/mod.rs
+++ b/lang/transformations/src/lifting/mod.rs
@@ -302,6 +302,7 @@ impl Lift for Exp {
             Exp::Hole(e) => e.lift(ctx).into(),
             Exp::LocalMatch(e) => e.lift(ctx),
             Exp::LocalComatch(e) => e.lift(ctx),
+            Exp::LocalLet(_) => todo!(),
         }
     }
 }


### PR DESCRIPTION
This PR adds local let expressions to the AST, implementing the necessary traits implemented for `ast::Exp`. It leaves TODOs in form of `todo!()`s or internal (`Impossible`) error messages in other places.