### PR TITLE
Add an env variable to shell.nix for VS Code and rust-analyzer

### DIFF
--- a/contrib/nix/shell.nix
+++ b/contrib/nix/shell.nix
@@ -21,4 +21,8 @@ pkgs.mkShell.override { inherit stdenv; } {
       pkgs.libiconv
       pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
     ];
+
+  # Certain Rust tools won't work without this, for example VS Code with rust analyzer
+  # See https://nixos.wiki/wiki/Rust#Shell.nix_example and https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/3?u=samuela. for more details.
+  RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 }


### PR DESCRIPTION
Without it I kept getting

```
rust-analyzer failed to load workspace: Failed to find sysroot for Cargo.toml file ~/project/Cargo.toml. Is rust-src installed?: can't load standard library from sysroot /nix/store/<hash>-rustc-1.86.0 (discovered via `rustc --print sysroot`) try installing the Rust source the same way you installed rustc
```