### PR TITLE
Pretty printing of empty doc-comment lines

### DIFF
--- a/lang/ast/src/decls.rs
+++ b/lang/ast/src/decls.rs
@@ -60,12 +60,12 @@ pub struct DocComment {
 impl Print for DocComment {
     fn print<'a>(&'a self, _cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let DocComment { docs } = self;
-        let prefix = "/// ";
-        alloc.concat(
-            docs.iter().map(|doc| {
-                alloc.comment(prefix).append(alloc.comment(doc)).append(alloc.hardline())
-            }),
-        )
+        let nonempty_prefix = "/// ";
+        let empty_prefix = "///";
+        alloc.concat(docs.iter().map(|doc| {
+            let prefix = if doc.is_empty() { empty_prefix } else { nonempty_prefix };
+            alloc.comment(prefix).append(alloc.comment(doc)).append(alloc.hardline())
+        }))
     }
 }
 

--- a/lang/parser/src/grammar/cst.lalrpop
+++ b/lang/parser/src/grammar/cst.lalrpop
@@ -119,8 +119,8 @@ Attr: String = <s:"Identifier"> => s.to_owned();
 Attributes: Attributes = "#" <attrs: BracketedArgs<Attr>> => Attributes { attrs };
 OptAttributes: Attributes = <attr: Attributes? > => attr.unwrap_or_default();
 
-DocCommentHelper: String = <doc: "DocComment"> => doc.strip_prefix("///").unwrap().trim().to_owned();
-DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs };
+DocCommentHelper: Vec<String> = <doc: "DocComment"> => doc.strip_prefix("///").unwrap().lines().map(|s| s.trim().to_owned()).collect();
+DocComment: DocComment = <docs: DocCommentHelper+> => DocComment { docs: docs.into_iter().flatten().collect() };
 
 Arg: Arg = {
   <e: Exp> => Arg::UnnamedArg(e),


### PR DESCRIPTION
We allow empty lines in doc-comments (which seems reasonable for structuring comments):
```
/// First line

/// Second line
data Bool { T, F }
```

But the parser trims those empty lines away. That's why the are "forgotten" when e.g. format-printing or in documentation.

The previous example would be formatted as:
```
/// First line
/// Second line
data Bool { T, F }
```

With these changes, the parser stores empty lines as well and prints empty doc-comment lines without trailing space.

The example would be formatted like so:
```
/// First line
///
/// Second line
data Bool { T, F }
```
Note that the empty line is prefixed with `///` which IMO is a reasonable default because the doc-comment can be recognized as a unit.