### PR TITLE
Fix hyperlink format of URLs in doc-comments

### DIFF
--- a/lang/elaborator/src/conversion_checking/unify.rs
+++ b/lang/elaborator/src/conversion_checking/unify.rs
@@ -4,7 +4,7 @@
 //!
 //! * Andreas Abel, and Brigitte Pientka. "Higher-order dynamic pattern unification for dependent types and records." (2011)
 //! * Adam Gundry and Conor McBride. "A tutorial implementation of dynamic pattern unification." (2013).
-//! * András Kovács's elaboration-zoo (https://github.com/AndrasKovacs/elaboration-zoo)
+//! * András Kovács's elaboration-zoo (<https://github.com/AndrasKovacs/elaboration-zoo>)
 
 use ast::{Variable, ctx::values::Binder};
 use ctx::LevelCtx;

--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -117,7 +117,7 @@ pub enum Token {
     //
     #[regex(r"0|[1-9][0-9]*", |lex| BigUint::parse_bytes(lex.slice().as_ref(), 10).unwrap())]
     NumLit(BigUint),
-    /// The regexp is from `https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5`
+    /// The regexp is from <https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5>
     /// We do not allow multi line strings.
     #[regex(r###""([^"\\]|\\.)*""###, |lex| {
         let slice = lex.slice();


### PR DESCRIPTION
When I generated documentation for the Rust crates, Cargo complained about URLs in doc-comments that were not formatted correctly, so I fixed it.

Now, the URLs get generated as actual hyperlinks in the documentation.