### PR TITLE
Add free variables trait to ast

### DIFF
--- a/lang/ast/src/exp/anno.rs
+++ b/lang/ast/src/exp/anno.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -120,5 +120,14 @@ impl Rename for Anno {
         self.exp.rename_in_ctx(ctx);
         self.typ.rename_in_ctx(ctx);
         self.normalized_type.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for Anno {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let Anno { span: _, exp, typ, normalized_type: _ } = self;
+        let mut fvs = exp.free_vars(ctx, cutoff);
+        fvs.extend(typ.free_vars(ctx, cutoff));
+        fvs
     }
 }

--- a/lang/ast/src/exp/call.rs
+++ b/lang/ast/src/exp/call.rs
@@ -3,8 +3,8 @@ use miette_util::codespan::Span;
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg, theme::ThemeExt};
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -130,5 +130,13 @@ impl Rename for Call {
     fn rename_in_ctx(&mut self, ctx: &mut RenameCtx) {
         self.args.rename_in_ctx(ctx);
         self.inferred_type.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for Call {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let Call { span: _, kind: _, name: _, args, inferred_type: _ } = self;
+
+        args.free_vars(ctx, cutoff)
     }
 }

--- a/lang/ast/src/exp/case.rs
+++ b/lang/ast/src/exp/case.rs
@@ -9,8 +9,8 @@ use printer::{
 };
 
 use crate::{
-    ContainsMetaVars, Occurs, Shift, ShiftRange, ShiftRangeExt, Substitutable, Substitution, Zonk,
-    ZonkError,
+    ContainsMetaVars, FreeVars, Occurs, Shift, ShiftRange, ShiftRangeExt, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::{BindContext, LevelCtx},
     rename::{Rename, RenameCtx},
 };
@@ -187,5 +187,13 @@ impl Rename for Case {
         ctx.bind_iter(self.pattern.params.params.iter(), |new_ctx| {
             self.body.rename_in_ctx(new_ctx);
         })
+    }
+}
+
+impl FreeVars for Case {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let Case { span: _, pattern: _, body } = self;
+
+        body.free_vars(ctx, cutoff + 1)
     }
 }

--- a/lang/ast/src/exp/dot_call.rs
+++ b/lang/ast/src/exp/dot_call.rs
@@ -4,8 +4,8 @@ use pretty::DocAllocator;
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg, theme::ThemeExt, tokens::DOT};
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -154,5 +154,13 @@ impl Rename for DotCall {
         self.exp.rename_in_ctx(ctx);
         self.args.rename_in_ctx(ctx);
         self.inferred_type.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for DotCall {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let DotCall { span: _, kind: _, exp, name: _, args, inferred_type: _ } = self;
+
+        exp.free_vars(ctx, cutoff).union(&args.free_vars(ctx, cutoff)).cloned().collect()
     }
 }

--- a/lang/ast/src/exp/hole.rs
+++ b/lang/ast/src/exp/hole.rs
@@ -8,8 +8,8 @@ use printer::{
 };
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::{
         LevelCtx,
         values::{Binder, TypeCtx},
@@ -264,5 +264,23 @@ impl Rename for Hole {
         self.inferred_ctx = None;
         self.inferred_type.rename_in_ctx(ctx);
         self.args.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for Hole {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let Hole {
+            span: _,
+            kind: _,
+            metavar: _,
+            inferred_type: _,
+            inferred_ctx: _,
+            args,
+            solution,
+        } = self;
+
+        let mut fvs = args.free_vars(ctx, cutoff);
+        fvs.extend(solution.free_vars(ctx, cutoff));
+        fvs
     }
 }

--- a/lang/ast/src/exp/local_comatch.rs
+++ b/lang/ast/src/exp/local_comatch.rs
@@ -10,8 +10,8 @@ use printer::{
 };
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::{LevelCtx, values::TypeCtx},
     rename::{Rename, RenameCtx},
 };
@@ -156,5 +156,14 @@ impl Rename for LocalComatch {
         self.ctx = None;
         self.inferred_type = None;
         self.cases.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for LocalComatch {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let LocalComatch { span: _, ctx: _, name: _, is_lambda_sugar: _, cases, inferred_type: _ } =
+            self;
+
+        cases.free_vars(ctx, cutoff)
     }
 }

--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -8,8 +8,10 @@ use printer::{
 };
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRangeExt, Substitutable, Zonk,
-    ctx::BindContext, rename::Rename,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRangeExt, Substitutable,
+    Zonk,
+    ctx::{BindContext, LevelCtx},
+    rename::Rename,
 };
 
 use super::{Exp, VarBind};
@@ -171,5 +173,15 @@ impl Rename for LocalLet {
 impl From<LocalLet> for Exp {
     fn from(val: LocalLet) -> Self {
         Exp::LocalLet(val)
+    }
+}
+
+impl FreeVars for LocalLet {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let LocalLet { span: _, name: _, typ, bound, body, inferred_type: _ } = self;
+        let mut fvs = bound.free_vars(ctx, cutoff);
+        fvs.extend(typ.free_vars(ctx, cutoff));
+        fvs.extend(body.free_vars(ctx, cutoff + 1));
+        fvs
     }
 }

--- a/lang/ast/src/exp/local_match.rs
+++ b/lang/ast/src/exp/local_match.rs
@@ -8,8 +8,8 @@ use printer::{
 };
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::{LevelCtx, values::TypeCtx},
     rename::{Rename, RenameCtx},
 };
@@ -153,5 +153,25 @@ impl Rename for LocalMatch {
         self.motive.rename_in_ctx(ctx);
         self.ret_typ.rename_in_ctx(ctx);
         self.cases.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for LocalMatch {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let LocalMatch {
+            span: _,
+            ctx: _,
+            name: _,
+            on_exp,
+            motive,
+            ret_typ: _,
+            cases,
+            inferred_type: _,
+        } = self;
+
+        let mut fvs = on_exp.free_vars(ctx, cutoff);
+        fvs.extend(motive.free_vars(ctx, cutoff));
+        fvs.extend(cases.free_vars(ctx, cutoff));
+        fvs
     }
 }

--- a/lang/ast/src/exp/typ_ctor.rs
+++ b/lang/ast/src/exp/typ_ctor.rs
@@ -4,8 +4,8 @@ use pretty::DocAllocator;
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg, theme::ThemeExt, util::ParensIfExt};
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable, Substitution,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Occurs, Shift, ShiftRange, Substitutable,
+    Substitution, Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -140,5 +140,13 @@ impl ContainsMetaVars for TypCtor {
 impl Rename for TypCtor {
     fn rename_in_ctx(&mut self, ctx: &mut RenameCtx) {
         self.args.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for TypCtor {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let TypCtor { span: _, name: _, args, is_bin_op: _ } = self;
+
+        args.free_vars(ctx, cutoff)
     }
 }

--- a/lang/ast/src/exp/type_univ.rs
+++ b/lang/ast/src/exp/type_univ.rs
@@ -3,8 +3,8 @@ use miette_util::codespan::Span;
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg, theme::ThemeExt, tokens::TYPE};
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Shift, ShiftRange, Substitutable, Substitution, Zonk,
-    ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Shift, ShiftRange, Substitutable, Substitution,
+    Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -97,4 +97,10 @@ impl ContainsMetaVars for TypeUniv {
 
 impl Rename for TypeUniv {
     fn rename_in_ctx(&mut self, _ctx: &mut RenameCtx) {}
+}
+
+impl FreeVars for TypeUniv {
+    fn free_vars(&self, _ctx: &LevelCtx, _cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        crate::HashSet::default()
+    }
 }

--- a/lang/ast/src/exp/variable.rs
+++ b/lang/ast/src/exp/variable.rs
@@ -4,8 +4,8 @@ use pretty::DocAllocator;
 use printer::{Alloc, Builder, Precedence, Print, PrintCfg};
 
 use crate::{
-    ContainsMetaVars, HasSpan, HasType, Shift, ShiftRange, Substitutable, Substitution, VarBind,
-    Zonk, ZonkError,
+    ContainsMetaVars, FreeVars, HasSpan, HasType, Shift, ShiftRange, Substitutable, Substitution,
+    VarBind, Zonk, ZonkError,
     ctx::LevelCtx,
     rename::{Rename, RenameCtx},
 };
@@ -125,5 +125,17 @@ impl Rename for Variable {
         };
         self.name = VarBound::from_string(&name);
         self.inferred_type.rename_in_ctx(ctx);
+    }
+}
+
+impl FreeVars for Variable {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> crate::HashSet<crate::Lvl> {
+        let Variable { span: _, idx, name: _, inferred_type: _ } = self;
+
+        if idx.fst < cutoff {
+            crate::HashSet::default()
+        } else {
+            crate::HashSet::from_iter([ctx.idx_to_lvl(*idx)])
+        }
     }
 }

--- a/lang/ast/src/traits/free_vars.rs
+++ b/lang/ast/src/traits/free_vars.rs
@@ -1,0 +1,46 @@
+use crate::{
+    HashSet, Lvl,
+    ctx::{LevelCtx, values::Binder},
+};
+
+pub trait FreeVars {
+    /// Set of free variables that occur syntactically in the expression.
+    ///
+    /// This is not the same as the free variables closure, which would also includes variables
+    /// occuring in the types of the free variables, recursively.
+    ///
+    /// Parameters:
+    ///
+    /// - `ctx`: The context in which the free variables are computed.
+    ///   Any free variables computed will be bound in this context.
+    /// - `cutoff`: The cutoff (de Bruijn index). Any variable with an index less than `cutoff` is considered bound.
+    ///   Alternatively, you can think of `cutoff` tracking the number of de Bruijn levels that are bound after `ctx`.
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> HashSet<Lvl>;
+}
+
+impl<T: FreeVars> FreeVars for Option<T> {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> HashSet<Lvl> {
+        match self {
+            Some(exp) => exp.free_vars(ctx, cutoff),
+            None => HashSet::default(),
+        }
+    }
+}
+
+impl<T: FreeVars> FreeVars for Vec<T> {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> HashSet<Lvl> {
+        self.iter().flat_map(|exp| exp.free_vars(ctx, cutoff)).collect()
+    }
+}
+
+impl<T: FreeVars> FreeVars for Box<T> {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> HashSet<Lvl> {
+        self.as_ref().free_vars(ctx, cutoff)
+    }
+}
+
+impl<T: FreeVars> FreeVars for Binder<T> {
+    fn free_vars(&self, ctx: &LevelCtx, cutoff: usize) -> HashSet<Lvl> {
+        self.content.free_vars(ctx, cutoff)
+    }
+}

--- a/lang/ast/src/traits/mod.rs
+++ b/lang/ast/src/traits/mod.rs
@@ -1,4 +1,5 @@
 mod contains_metavars;
+mod free_vars;
 mod has_span;
 mod has_type;
 mod occurs;
@@ -8,6 +9,7 @@ pub mod subst;
 mod zonk;
 
 pub use contains_metavars::*;
+pub use free_vars::*;
 pub use has_span::*;
 pub use has_type::*;
 pub use occurs::*;


### PR DESCRIPTION
Compute the set of free variables that syntactically occur in an expression (this does not close over free variables in the type of syntactic occurrences.

The motivation for this is twofold:

1. We need it for computing the initial closure to attach to (co)matches in lowering.
2. We can simplify the typed free variables closure in lifting.
