### PR TITLE
Add closure field to LocalMatch

### DIFF
--- a/lang/ast/src/exp/local_comatch.rs
+++ b/lang/ast/src/exp/local_comatch.rs
@@ -151,11 +151,14 @@ impl Zonk for LocalComatch {
             name: _,
             closure,
             is_lambda_sugar: _,
-            cases: _,
+            cases,
             inferred_type,
         } = self;
         closure.zonk(meta_vars)?;
         inferred_type.zonk(meta_vars)?;
+        for case in cases.iter_mut() {
+            case.zonk(meta_vars)?;
+        }
         Ok(())
     }
 }
@@ -168,11 +171,13 @@ impl ContainsMetaVars for LocalComatch {
             name: _,
             closure,
             is_lambda_sugar: _,
-            cases: _,
+            cases,
             inferred_type,
         } = self;
 
-        closure.contains_metavars() || inferred_type.contains_metavars()
+        closure.contains_metavars()
+            || cases.contains_metavars()
+            || inferred_type.contains_metavars()
     }
 }
 
@@ -193,10 +198,11 @@ impl FreeVars for LocalComatch {
             name: _,
             closure,
             is_lambda_sugar: _,
-            cases: _,
+            cases,
             inferred_type: _,
         } = self;
 
-        closure.free_vars_mut(ctx, cutoff, fvs)
+        closure.free_vars_mut(ctx, cutoff, fvs);
+        cases.free_vars_mut(ctx, cutoff, fvs);
     }
 }

--- a/lang/elaborator/src/normalizer/val.rs
+++ b/lang/elaborator/src/normalizer/val.rs
@@ -562,6 +562,7 @@ impl ReadBack for LocalMatch {
             span: *span,
             ctx: None,
             motive: None,
+            closure: ast::Closure { args: Vec::default() },
             ret_typ: None,
             name: name.clone(),
             on_exp: on_exp.read_back(info_table)?,

--- a/lang/elaborator/src/typechecker/exprs/local_match.rs
+++ b/lang/elaborator/src/typechecker/exprs/local_match.rs
@@ -98,7 +98,7 @@ fn compute_motive(
 
 impl CheckInfer for LocalMatch {
     fn check(&self, ctx: &mut Ctx, t: &Exp) -> TcResult<Self> {
-        let LocalMatch { span, name, on_exp, motive, cases, .. } = self;
+        let LocalMatch { span, name, closure, on_exp, motive, cases, .. } = self;
 
         // Compute the type of the expression we are pattern matching on.
         // This should always be a type constructor for a data type.
@@ -129,6 +129,7 @@ impl CheckInfer for LocalMatch {
             span: *span,
             ctx: Some(ctx.vars.clone()),
             name: name.clone(),
+            closure: closure.clone(),
             on_exp: on_exp_out,
             motive: motive_out,
             ret_typ: Some(Box::new(t.clone())),

--- a/lang/transformations/src/lifting/mod.rs
+++ b/lang/transformations/src/lifting/mod.rs
@@ -405,13 +405,23 @@ impl Lift for LocalMatch {
     type Target = Exp;
 
     fn lift(&self, ctx: &mut Ctx) -> Self::Target {
-        let LocalMatch { span, ctx: type_ctx, name, on_exp, motive, ret_typ, cases, inferred_type } =
-            self;
+        let LocalMatch {
+            span,
+            ctx: type_ctx,
+            name,
+            closure,
+            on_exp,
+            motive,
+            ret_typ,
+            cases,
+            inferred_type,
+        } = self;
         ctx.lift_match(
             span,
             &inferred_type.clone().unwrap(),
             &type_ctx.clone().unwrap(),
             name,
+            closure,
             on_exp,
             motive,
             ret_typ,
@@ -591,6 +601,7 @@ impl Ctx {
         inferred_type: &TypCtor,
         type_ctx: &TypeCtx,
         name: &Label,
+        closure: &Closure,
         on_exp: &Exp,
         motive: &Option<Motive>,
         ret_typ: &Option<Box<Exp>>,
@@ -603,6 +614,7 @@ impl Ctx {
                 inferred_type: None,
                 ctx: None,
                 name: name.clone(),
+                closure: closure.clone(),
                 on_exp: Box::new(on_exp.lift(self)),
                 motive: motive.lift(self),
                 ret_typ: None,


### PR DESCRIPTION
Add closure field to `LocalMatch` and also fix some implementations for `LocalComatch` that no longer went in the `cases` even though this is still needed.