### PR TITLE
Fix substitution for local let expressions

### DIFF
--- a/lang/ast/src/exp/local_let.rs
+++ b/lang/ast/src/exp/local_let.rs
@@ -88,12 +88,14 @@ impl Substitutable for LocalLet {
         let bound = bound.subst(ctx, by)?;
 
         ctx.bind_single(name.clone(), |ctx| {
+            let mut by = (*by).clone();
+            by.shift((1, 0));
             Ok(LocalLet {
                 span: *span,
                 name: name.clone(),
                 typ,
                 bound,
-                body: body.subst(ctx, by)?,
+                body: body.subst(ctx, &by)?,
                 inferred_type: None,
             })
         })


### PR DESCRIPTION
When we substitute in the body of a local let expression then we need to shift the body of the substitution by one.