### PR TITLE
Add TODO comment for multi-line strings in lexer

### DIFF
--- a/lang/parser/src/lexer/mod.rs
+++ b/lang/parser/src/lexer/mod.rs
@@ -127,7 +127,7 @@ pub enum Token {
     #[regex(r"0|[1-9][0-9]*", |lex| BigUint::parse_bytes(lex.slice().as_ref(), 10).unwrap())]
     NumLit(BigUint),
     /// The regexp is from <https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5>
-    /// We do not allow multi line strings.
+    /// TODO: Maybe forbid multi-line strings or have a separate syntax?
     #[regex(r###""([^"\\]|\\.)*""###, |lex| StringLit::parse(lex.slice()))]
     StringLit(StringLit),
     #[regex(r###"'([^'\\]|\\.)*'"###, |lex| CharLit::parse(lex.slice()))]


### PR DESCRIPTION
I stumbled across a comment that incorrectly documents our string lexing behavior. This removes the comment and adds a TODO to think about multi-line strings in the future.