### PR TITLE
Fix mismatch between webpack and webpack-cli version

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "web",
       "workspaces": [
         "packages/app"
       ]
@@ -360,6 +359,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-11.1.1.tgz",
       "integrity": "sha512-8TC3AWZgXQGvXtV4fD3w9b0KCtoX1LqhfFGetaMHA8tUMOzBCVRQndTRD3zAW/MKigYuqBvBgUWCUq7mwpxJCA==",
+      "peer": true,
       "dependencies": {
         "@codingame/monaco-vscode-files-service-override": "11.1.1",
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
@@ -377,6 +377,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-11.1.1.tgz",
       "integrity": "sha512-9E06bF+LQk8MuF3BUzZyEz1ohwOzP/UFPZ4Fg4XtDbycwu9taZrFb52t3ppYzPzAwoAjXr8LJX26tQDrqDq76A==",
+      "peer": true,
       "dependencies": {
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
@@ -385,6 +386,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-11.1.1.tgz",
       "integrity": "sha512-hOPC0jF9bQyQVTeRG/J/oT/6ZYeu5vQsWQCit89tx3za8XuAEgPy1EEJLPXJFaAEzJF5A9B4rqXDoDtU9tu5Tw==",
+      "peer": true,
       "dependencies": {
         "@codingame/monaco-vscode-environment-service-override": "11.1.1",
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
@@ -394,6 +396,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-11.1.1.tgz",
       "integrity": "sha512-Sy/u5jzj9jk4VaGM+FebPlOU37uMkSR/poE+RvFthdrIQ9SnQwBywiyre6XQY7jRt8xsnTLfs6fQkNjXer7nNw==",
+      "peer": true,
       "dependencies": {
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
@@ -1331,8 +1334,7 @@
     "node_modules/@types/node": {
       "version": "18.0.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.11",
@@ -1468,7 +1470,6 @@
       "version": "5.30.5",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.30.5",
         "@typescript-eslint/types": "5.30.5",
@@ -1761,31 +1762,45 @@
       }
     },
     "node_modules/@webpack-cli/configtest": {
-      "version": "1.2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/info": {
-      "version": "1.5.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "envinfo": "^7.7.3"
+      "engines": {
+        "node": ">=14.15.0"
       },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       }
     },
     "node_modules/@webpack-cli/serve": {
-      "version": "1.7.0",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
       "peerDependencies": {
-        "webpack-cli": "4.x.x"
+        "webpack": "5.x.x",
+        "webpack-cli": "5.x.x"
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
@@ -1827,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1864,7 +1878,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2154,7 +2167,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -3052,7 +3064,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.8.1",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.19.0.tgz",
+      "integrity": "sha512-DoSM9VyG6O3vqBf+p3Gjgr/Q52HYBBtO3v+4koAxt1MnWr+zEnxE+nke/yXS4lt2P4SYCHQ4V3f1i88LQVOpAw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3189,7 +3203,6 @@
       "version": "8.19.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -4409,11 +4422,13 @@
       "dev": true
     },
     "node_modules/interpret": {
-      "version": "2.2.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -5625,7 +5640,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -5722,7 +5736,6 @@
       "version": "6.0.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5748,7 +5761,6 @@
       "version": "2.7.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -6005,14 +6017,16 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.1",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/redent": {
@@ -6238,7 +6252,6 @@
       "version": "8.11.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7160,8 +7173,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7222,7 +7234,6 @@
       "version": "4.7.4",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7468,7 +7479,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -7511,42 +7521,41 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.10.0",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
-        "commander": "^7.0.0",
+        "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x"
+        "webpack": "5.x.x"
       },
       "peerDependenciesMeta": {
         "@webpack-cli/generators": {
-          "optional": true
-        },
-        "@webpack-cli/migrate": {
           "optional": true
         },
         "webpack-bundle-analyzer": {
@@ -7558,11 +7567,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.2.0",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=14"
       }
     },
     "node_modules/webpack-dev-middleware": {
@@ -7864,7 +7875,7 @@
         "typescript": "^4.7.3",
         "vm-browserify": "^1.1.2",
         "webpack": "^5.94.0",
-        "webpack-cli": "^4.9.2",
+        "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.1"
       }
     }
@@ -8199,6 +8210,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-11.1.1.tgz",
       "integrity": "sha512-8TC3AWZgXQGvXtV4fD3w9b0KCtoX1LqhfFGetaMHA8tUMOzBCVRQndTRD3zAW/MKigYuqBvBgUWCUq7mwpxJCA==",
+      "peer": true,
       "requires": {
         "@codingame/monaco-vscode-files-service-override": "11.1.1",
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
@@ -8216,6 +8228,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-11.1.1.tgz",
       "integrity": "sha512-9E06bF+LQk8MuF3BUzZyEz1ohwOzP/UFPZ4Fg4XtDbycwu9taZrFb52t3ppYzPzAwoAjXr8LJX26tQDrqDq76A==",
+      "peer": true,
       "requires": {
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
@@ -8224,6 +8237,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-11.1.1.tgz",
       "integrity": "sha512-hOPC0jF9bQyQVTeRG/J/oT/6ZYeu5vQsWQCit89tx3za8XuAEgPy1EEJLPXJFaAEzJF5A9B4rqXDoDtU9tu5Tw==",
+      "peer": true,
       "requires": {
         "@codingame/monaco-vscode-environment-service-override": "11.1.1",
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
@@ -8233,6 +8247,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-11.1.1.tgz",
       "integrity": "sha512-Sy/u5jzj9jk4VaGM+FebPlOU37uMkSR/poE+RvFthdrIQ9SnQwBywiyre6XQY7jRt8xsnTLfs6fQkNjXer7nNw==",
+      "peer": true,
       "requires": {
         "vscode": "npm:@codingame/monaco-vscode-api@11.1.1"
       }
@@ -8820,8 +8835,7 @@
     },
     "@types/node": {
       "version": "18.0.3",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@types/node-forge": {
       "version": "1.3.11",
@@ -8930,7 +8944,6 @@
     "@typescript-eslint/parser": {
       "version": "5.30.5",
       "dev": true,
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.30.5",
         "@typescript-eslint/types": "5.30.5",
@@ -9144,19 +9157,23 @@
       }
     },
     "@webpack-cli/configtest": {
-      "version": "1.2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
+      "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
       "dev": true,
       "requires": {}
     },
     "@webpack-cli/info": {
-      "version": "1.5.0",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
+      "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
       "dev": true,
-      "requires": {
-        "envinfo": "^7.7.3"
-      }
+      "requires": {}
     },
     "@webpack-cli/serve": {
-      "version": "1.7.0",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
+      "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
       "dev": true,
       "requires": {}
     },
@@ -9188,8 +9205,7 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-import-attributes": {
       "version": "1.9.5",
@@ -9210,7 +9226,6 @@
     "ajv": {
       "version": "6.12.6",
       "dev": true,
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9400,7 +9415,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
       "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -9976,7 +9990,9 @@
       "dev": true
     },
     "envinfo": {
-      "version": "7.8.1",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.19.0.tgz",
+      "integrity": "sha512-DoSM9VyG6O3vqBf+p3Gjgr/Q52HYBBtO3v+4koAxt1MnWr+zEnxE+nke/yXS4lt2P4SYCHQ4V3f1i88LQVOpAw==",
       "dev": true
     },
     "error-ex": {
@@ -10071,7 +10087,6 @@
     "eslint": {
       "version": "8.19.0",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -10883,7 +10898,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "2.2.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
       "dev": true
     },
     "ipaddr.js": {
@@ -11399,7 +11416,7 @@
         "vscode-languageclient": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
         "webpack": "^5.94.0",
-        "webpack-cli": "^4.9.2",
+        "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.1"
       }
     },
@@ -11700,7 +11717,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -11757,7 +11773,6 @@
     "postcss-selector-parser": {
       "version": "6.0.10",
       "dev": true,
-      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11773,8 +11788,7 @@
     },
     "prettier": {
       "version": "2.7.1",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -11948,10 +11962,12 @@
       }
     },
     "rechoir": {
-      "version": "0.7.1",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dev": true,
       "requires": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       }
     },
     "redent": {
@@ -12076,7 +12092,6 @@
         "ajv": {
           "version": "8.11.0",
           "dev": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -12725,8 +12740,7 @@
     },
     "tslib": {
       "version": "2.4.0",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -12764,8 +12778,7 @@
     },
     "typescript": {
       "version": "4.7.4",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -12945,7 +12958,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -12990,26 +13002,30 @@
       }
     },
     "webpack-cli": {
-      "version": "4.10.0",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
+      "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.2.0",
-        "@webpack-cli/info": "^1.5.0",
-        "@webpack-cli/serve": "^1.7.0",
+        "@webpack-cli/configtest": "^2.1.1",
+        "@webpack-cli/info": "^2.0.2",
+        "@webpack-cli/serve": "^2.0.5",
         "colorette": "^2.0.14",
-        "commander": "^7.0.0",
+        "commander": "^10.0.1",
         "cross-spawn": "^7.0.3",
+        "envinfo": "^7.7.3",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
-        "interpret": "^2.2.0",
-        "rechoir": "^0.7.0",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
         "commander": {
-          "version": "7.2.0",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
           "dev": true
         }
       }

--- a/web/packages/app/package.json
+++ b/web/packages/app/package.json
@@ -22,7 +22,7 @@
     "build": "webpack --mode production",
     "format": "prettier --write '**/*.{js,json,ts,tsx,yml,yaml}'",
     "lint": "eslint 'src/**/*.{js,ts,tsx}' && prettier --check '**/*.{json,yml,yaml}'",
-    "app": "webpack-dev-server --open"
+    "app": "webpack serve --open"
   },
   "devDependencies": {
     "@types/debounce": "^1.2.1",
@@ -49,7 +49,7 @@
     "typescript": "^4.7.3",
     "vm-browserify": "^1.1.2",
     "webpack": "^5.94.0",
-    "webpack-cli": "^4.9.2",
+    "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.1"
   },
   "dependencies": {

--- a/web/packages/app/src/editor/pol.tmLanguage.json
+++ b/web/packages/app/src/editor/pol.tmLanguage.json
@@ -39,13 +39,13 @@
           "name": "string.quoted.double",
           "begin": "\"",
           "end": "\"",
-          "patterns": [ { "include": "#escapes" } ]
+          "patterns": [{ "include": "#escapes" }]
         },
         {
           "name": "string.quoted.single.char",
           "begin": "'",
           "end": "'",
-          "patterns": [ { "include": "#escapes" } ]
+          "patterns": [{ "include": "#escapes" }]
         }
       ]
     },


### PR DESCRIPTION
Previously, we encountered the following issue locally when trying to use `make run` in the `web/` folder to test the web editor:

```
Development mode [webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema. - options has an unknown property '_assetEmittingPreviousFiles'. These properties are valid: object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, ipc?, liveReload?, onListening?, open?, port?, proxy?, server?, app?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? } npm error Lifecycle script app failed with error: npm error code 2 npm error path /home/tim/Dev/polarity-lang/polarity/web/packages/app
```

This was caused by a mismatch between the `webpack` and `webpack-cli` version. Please verify that it works on your machine with this PR.