### PR TITLE
Fix well-formedness check for top-level lets

### DIFF
--- a/lang/elaborator/src/typechecker/decls/global_let.rs
+++ b/lang/elaborator/src/typechecker/decls/global_let.rs
@@ -21,7 +21,7 @@ impl CheckToplevel for Let {
         let Let { span, doc, name, attr, params, typ, body } = self;
 
         params.infer_telescope(ctx, |ctx, mut params_out| {
-            let typ_out = typ.infer(ctx)?;
+            let typ_out = typ.check(ctx, &TypeUniv::new().into())?;
             let typ_nf = typ.normalize(&ctx.type_info_table, &mut ctx.env())?;
             let body_out = body.check(ctx, &typ_nf)?;
 

--- a/test/suites/fail-check/Regr-598.expected
+++ b/test/suites/fail-check/Regr-598.expected
@@ -1,0 +1,9 @@
+T-016
+
+  × Cannot automatically decide whether Foo and Type unify
+   ╭─[Regr-598.pol:2:10]
+ 1 │ data Foo { C }
+ 2 │ let bug: C { bug }
+   ·          ┬
+   ·          ╰── While elaborating
+   ╰────

--- a/test/suites/fail-check/Regr-598.pol
+++ b/test/suites/fail-check/Regr-598.pol
@@ -1,0 +1,2 @@
+data Foo { C }
+let bug: C { bug }


### PR DESCRIPTION
Previously, the following example typechecked, because we forgot to check that the return type lives in `Type`.

```
data Foo { C }
let bug: C { bug }
```