### PR TITLE
Add some IO primitives

### DIFF
--- a/examples/hello_world.pol
+++ b/examples/hello_world.pol
@@ -1,0 +1,9 @@
+extern String: Type
+extern Unit: Type
+
+extern IO(a: Type): Type
+extern println(s: String): IO(Unit)
+
+let main: IO(Unit) {
+    println("Hello, World!")
+}

--- a/examples/index.json
+++ b/examples/index.json
@@ -42,5 +42,9 @@
     {
         "name": "λ-Encoding: Scott",
         "path": "encoding_scott.pol"
+    },
+    {
+        "name": "Hello World",
+        "path": "hello_world.pol"
     }
   ]

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -204,7 +204,8 @@ impl ir::Call {
                 }],
                 type_args: None,
             })),
-            // undefined
+            // void 0
+            // (This is a safe way to evaluate to undefined)
             "unit" => Ok(*js::Expr::undefined(DUMMY_SP)),
             // (() => 〚x 〛)
             "return_io" => Ok(thunk_expr(*args[0].expr.clone())),

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -5,7 +5,7 @@ use swc_ecma_ast as js;
 
 use crate::ir;
 use crate::ir2js::traits::ToJSStmt;
-use crate::ir2js::util::{force_expr, paren_expr, thunk_expr};
+use crate::ir2js::util::{force_expr, paren_expr, thunk_block, thunk_expr};
 use crate::result::BackendResult;
 
 use super::tokens::*;
@@ -339,31 +339,8 @@ impl ToJSExpr for ir::LocalMatch {
             cases,
         });
 
-        let arrow_fn = js::ArrowExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            params: vec![],
-            body: Box::new(js::BlockStmtOrExpr::BlockStmt(js::BlockStmt {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                stmts: vec![var_decl, switch_stmt],
-            })),
-            is_async: false,
-            is_generator: false,
-            type_params: None,
-            return_type: None,
-        };
-
-        Ok(js::Expr::Call(js::CallExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            callee: js::Callee::Expr(Box::new(js::Expr::Paren(js::ParenExpr {
-                span: DUMMY_SP,
-                expr: Box::new(js::Expr::Arrow(arrow_fn)),
-            }))),
-            args: vec![],
-            type_args: None,
-        }))
+        let thunk = thunk_block(vec![var_decl, switch_stmt]);
+        Ok(force_expr(thunk))
     }
 }
 
@@ -431,31 +408,8 @@ impl ToJSExpr for ir::Panic {
             })),
         });
 
-        let arrow_fn = js::ArrowExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            params: vec![],
-            body: Box::new(js::BlockStmtOrExpr::BlockStmt(js::BlockStmt {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                stmts: vec![throw_stmt],
-            })),
-            is_async: false,
-            is_generator: false,
-            type_params: None,
-            return_type: None,
-        };
-
-        Ok(js::Expr::Call(js::CallExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            callee: js::Callee::Expr(Box::new(js::Expr::Paren(js::ParenExpr {
-                span: DUMMY_SP,
-                expr: Box::new(js::Expr::Arrow(arrow_fn)),
-            }))),
-            args: vec![],
-            type_args: None,
-        }))
+        let thunk = thunk_block(vec![throw_stmt]);
+        Ok(force_expr(thunk))
     }
 }
 
@@ -540,22 +494,7 @@ impl ToJSExpr for ir::DoBlock {
         let mut js_stmts = js_bindings;
         js_stmts.push(js_return_stmt);
 
-        let arrow_fn = js::Expr::Arrow(js::ArrowExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            params: vec![],
-            body: Box::new(js::BlockStmtOrExpr::BlockStmt(js::BlockStmt {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                stmts: js_stmts,
-            })),
-            is_async: false,
-            is_generator: false,
-            type_params: None,
-            return_type: None,
-        });
-
-        Ok(paren_expr(arrow_fn))
+        Ok(thunk_block(js_stmts))
     }
 }
 

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -209,6 +209,27 @@ impl ir::Call {
             "unit" => Ok(*js::Expr::undefined(DUMMY_SP)),
             // (() => 〚x 〛)
             "return_io" => Ok(thunk_expr(*args[0].expr.clone())),
+            // (() => { console.log(〚s 〛); return void 0; })
+            "println" => Ok(thunk_block(vec![
+                js::Stmt::Expr(js::ExprStmt {
+                    span: DUMMY_SP,
+                    expr: Box::new(js::Expr::Call(js::CallExpr {
+                        span: DUMMY_SP,
+                        ctxt: SyntaxContext::empty(),
+                        callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
+                            span: DUMMY_SP,
+                            obj: Box::new(js::Expr::Ident(js::Ident::from("console"))),
+                            prop: js::MemberProp::Ident(js::IdentName::from("log")),
+                        }))),
+                        args: vec![js::ExprOrSpread { spread: None, expr: args[0].expr.clone() }],
+                        type_args: None,
+                    })),
+                }),
+                js::Stmt::Return(js::ReturnStmt {
+                    span: DUMMY_SP,
+                    arg: Some(js::Expr::undefined(DUMMY_SP)),
+                }),
+            ])),
             _ => self.to_js_function_call(),
         }
     }

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -5,7 +5,7 @@ use swc_ecma_ast as js;
 
 use crate::ir;
 use crate::ir2js::traits::ToJSStmt;
-use crate::ir2js::util::{force_expr, paren_expr};
+use crate::ir2js::util::{force_expr, paren_expr, thunk_expr};
 use crate::result::BackendResult;
 
 use super::tokens::*;
@@ -206,6 +206,8 @@ impl ir::Call {
             })),
             // undefined
             "unit" => Ok(*js::Expr::undefined(DUMMY_SP)),
+            // (() => 〚x 〛)
+            "return_io" => Ok(thunk_expr(*args[0].expr.clone())),
             _ => self.to_js_function_call(),
         }
     }

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -204,6 +204,8 @@ impl ir::Call {
                 }],
                 type_args: None,
             })),
+            // undefined
+            "unit" => Ok(*js::Expr::undefined(DUMMY_SP)),
             _ => self.to_js_function_call(),
         }
     }

--- a/lang/backend/src/ir2js/util.rs
+++ b/lang/backend/src/ir2js/util.rs
@@ -16,3 +16,18 @@ pub fn force_expr(e: js::Expr) -> js::Expr {
         type_args: None,
     })
 }
+
+/// Wrap expression in a thunk
+pub fn thunk_expr(e: js::Expr) -> js::Expr {
+    let arr = js::Expr::Arrow(js::ArrowExpr {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        params: vec![],
+        body: Box::new(js::BlockStmtOrExpr::Expr(Box::new(e))),
+        is_async: false,
+        is_generator: false,
+        type_params: None,
+        return_type: None,
+    });
+    paren_expr(arr)
+}

--- a/lang/backend/src/ir2js/util.rs
+++ b/lang/backend/src/ir2js/util.rs
@@ -31,3 +31,22 @@ pub fn thunk_expr(e: js::Expr) -> js::Expr {
     });
     paren_expr(arr)
 }
+
+/// Wrap expression in a thunk
+pub fn thunk_block(block: Vec<js::Stmt>) -> js::Expr {
+    let arr = js::Expr::Arrow(js::ArrowExpr {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        params: vec![],
+        body: Box::new(js::BlockStmtOrExpr::BlockStmt(js::BlockStmt {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            stmts: block,
+        })),
+        is_async: false,
+        is_generator: false,
+        type_params: None,
+        return_type: None,
+    });
+    paren_expr(arr)
+}

--- a/std/io/io.pol
+++ b/std/io/io.pol
@@ -1,0 +1,5 @@
+// Input/Output type.
+extern IO(a: Type): Type
+
+// Wrap a value into an IO context without performing any side-effect.
+extern return_io(a: Type, x: a): IO(a)

--- a/std/io/io.pol
+++ b/std/io/io.pol
@@ -1,5 +1,5 @@
-// Input/Output type.
+/// Input/Output type.
 extern IO(a: Type): Type
 
-// Wrap a value into an IO context without performing any side-effect.
+/// Wrap a value into an IO context without performing any side-effect.
 extern return_io(a: Type, x: a): IO(a)

--- a/std/io/print.pol
+++ b/std/io/print.pol
@@ -1,0 +1,6 @@
+use "io.pol"
+use "../prim/string.pol"
+use "../prim/unit.pol"
+
+/// Print a string to the console, appending a newline.
+extern println(s: String): IO(Unit)

--- a/std/prim/unit.pol
+++ b/std/prim/unit.pol
@@ -1,0 +1,3 @@
+// An opaque unit type with a single constructor.
+extern Unit: Type
+extern unit: Unit

--- a/std/prim/unit.pol
+++ b/std/prim/unit.pol
@@ -1,3 +1,3 @@
-// An opaque unit type with a single constructor.
+/// An opaque unit type with a single constructor.
 extern Unit: Type
 extern unit: Unit


### PR DESCRIPTION
This PR adds some IO primitives, namely `return_io` and `println`.

That means, we can finally print "Hello, World!" to the console! :tada: 

```
extern String: Type
extern Unit: Type
extern IO(a: Type): Type
extern println(s: String): IO(Unit)

let main: IO(Unit) {
    println("Hello, World!")
}
```