### PR TITLE
Cleanup SWC usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,10 +1933,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-core",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4509,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4521,38 +4524,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-core",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4560,22 +4545,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4595,9 +4580,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,16 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64-simd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
-dependencies = [
- "outref",
- "vsimd",
-]
-
-[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,18 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,7 +512,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -583,6 +561,39 @@ checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
 dependencies = [
  "bytes",
  "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -908,12 +919,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -932,11 +967,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.111",
 ]
@@ -953,22 +999,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
 ]
 
 [[package]]
@@ -990,6 +1020,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1036,6 +1097,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "either"
@@ -1257,12 +1324,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1748,12 +1809,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -2362,12 +2417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "outref"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
 name = "ownedbytes"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2430,15 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "par-core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96cbd21255b7fb29a5d51ef38a779b517a91abd59e2756c039583f43ef4c90f"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "parking"
@@ -2610,9 +2668,7 @@ dependencies = [
  "miette",
  "polarity-lang-ast",
  "polarity-lang-printer",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_codegen",
+ "swc_core",
  "thiserror 1.0.69",
  "url",
 ]
@@ -2913,12 +2969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,12 +3225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "ryu-js"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3282,16 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3368,6 +3422,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,9 +3541,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "18.0.1"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c06698254e9b47daaf9bbb062af489a350bd8d10dfaab0cabbd32d46cec69d"
+checksum = "078f2144aa2c33ff8485773f1b81b9985fa2d00f4ad60879158ad6897db2de88"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -3500,10 +3565,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_ecma_ast"
-version = "19.0.0"
+name = "swc_core"
+version = "65.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724195600825cbdd2a899d5473d2ce1f24ae418bff1231f160ecf38a3bc81f46"
+checksum = "e66f853257a352ef841ce72e43bdf73739e317ed2cf74ca4ebb36ae66df315de"
+dependencies = [
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_quote_macros",
+ "swc_ecma_transforms_base",
+ "vergen",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f4173ab7e676eed4938d5ad8bbdf14418f87c9a8d36e6cdda82ac9645912b0"
 dependencies = [
  "bitflags 2.10.0",
  "is-macro",
@@ -3520,25 +3601,24 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "21.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c77d9d21345ca986ae3b5ff1a4fa3607b15b07ed397506e6dba32e867cf40fd"
+checksum = "fafbcdd29cc03b0c04860bb0143e781e13a4e2dac03eb8747df520f602e0aa94"
 dependencies = [
  "ascii",
  "compact_str",
+ "dragonbox_ecma",
  "memchr",
  "num-bigint",
  "once_cell",
  "regex",
  "rustc-hash",
- "ryu-js",
  "serde",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_sourcemap",
  "tracing",
 ]
 
@@ -3551,6 +3631,100 @@ dependencies = [
  "proc-macro2",
  "swc_macros_common",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "39.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94d9deb6d91ade011685df51fdbb345f33de17e0b70ea7b2028051a8b76da36"
+dependencies = [
+ "bitflags 2.10.0",
+ "either",
+ "num-bigint",
+ "phf",
+ "rustc-hash",
+ "seq-macro",
+ "serde",
+ "smartstring",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_quote_macros"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e4d28106d86d9c45d187687688d03bab7064bd8480d8bc783df9ff2a5d5a9a"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_macros_common",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e58612045e827e7d3ae9f1dc6ae3590ba9abc6a3d93ff2adf27350ab409822"
+dependencies = [
+ "better_scoped_tls",
+ "indexmap",
+ "once_cell",
+ "par-core",
+ "phf",
+ "rustc-hash",
+ "serde",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "29.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e64243f2c9e9c9e631a18b42ad51f62137cf4f57b21fb93b1d58836322c2c81"
+dependencies = [
+ "dragonbox_ecma",
+ "indexmap",
+ "num_cpus",
+ "once_cell",
+ "par-core",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad65d392ed427dc9e94f16a3d802b02e27722c21227639c8d5f45f19757b447b"
+dependencies = [
+ "new_debug_unreachable",
+ "num-bigint",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_visit",
+ "tracing",
 ]
 
 [[package]]
@@ -3573,25 +3747,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "swc_sourcemap"
-version = "9.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de08ef00f816acdd1a58ee8a81c0e1a59eefef2093aefe5611f256fa6b64c4d7"
-dependencies = [
- "base64-simd",
- "bitvec",
- "bytes-str",
- "data-encoding",
- "debugid",
- "if_chain",
- "rustc-hash",
- "serde",
- "serde_json",
- "unicode-id-start",
- "url",
 ]
 
 [[package]]
@@ -3777,12 +3932,6 @@ dependencies = [
  "once_cell",
  "regex",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4285,16 +4434,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vsimd"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -4668,15 +4836,6 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xdg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["app"]
 [workspace.package]
 version      = "0.1.0"
 edition      = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 authors      = ["Tim Süberkrüb", "David Binder"]
 license      = "MIT OR Apache-2.0"
 homepage     = "https://polarity-lang.github.io/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,7 @@ ropey                    = { version = "1" }
 rust-lapper              = { version = "1" }
 serde                    = { version = "1" }
 serde_derive             = { version = "1" }
-swc_ecma_ast             = { version = "19" }
-swc_ecma_codegen         = { version = "21" }
-swc_common               = { version = "18" }
+swc_core                 = { version = "65", features = ["__common", "__ecma", "ecma_ast", "ecma_codegen", "ecma_quote"] }
 tantivy                  = { version = "0.18" }
 tempfile                 = { version = "3.23.0" }
 termcolor                = { version = "1.4.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ url                      = { version = "2.5.0" }
 walkdir                  = { version = "2.5.0" }
 # We pin the version because a matching `wasm-bindgen-cli` is needed.
 # If you update the version, make sure to update the nix flake accordingly.
-wasm-bindgen             = { version = "=0.2.104" }
+wasm-bindgen             = { version = "=0.2.117" }
 wasm-bindgen-futures     = { version = "0.4" }
 wasm-streams             = { version = "0.2" }
 web-sys                  = { version = "0.3" }

--- a/contrib/nix/shell.nix
+++ b/contrib/nix/shell.nix
@@ -25,7 +25,7 @@ pkgs.mkShell.override { inherit stdenv; } {
       wasm-bindgen-cli
 
       # formatting
-      nixfmt-rfc-style
+      nixfmt
 
       # libraries
       pkg-config

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762040540,
-        "narHash": "sha256-z5PlZ47j50VNF3R+IMS9LmzI5fYRGY/Z5O5tol1c9I4=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0010412d62a25d959151790968765a70c436598b",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762156382,
-        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           packages = import ./contrib/nix/default.nix { inherit pkgs; } // {
             default = config.packages.polarity;
           };
-          formatter = pkgs.nixfmt-rfc-style;
+          formatter = pkgs.nixfmt;
         };
     };
 }

--- a/lang/ast/src/exp/hole.rs
+++ b/lang/ast/src/exp/hole.rs
@@ -144,14 +144,13 @@ impl Print for Hole {
                     doc = doc.append(print_hole_args(&self.args, cfg, alloc))
                 }
 
-                if cfg.print_metavar_solutions {
-                    if let Some(solution) = &self.solution {
+                if cfg.print_metavar_solutions
+                    && let Some(solution) = &self.solution {
                         doc = doc
                             .append("<")
                             .append(solution.print_prec(cfg, alloc, prec))
                             .append(">")
                     }
-                }
 
                 doc
             }
@@ -166,14 +165,13 @@ impl Print for Hole {
                     doc = doc.append(print_hole_args(&self.args, cfg, alloc))
                 }
 
-                if cfg.print_metavar_solutions {
-                    if let Some(solution) = &self.solution {
+                if cfg.print_metavar_solutions
+                    && let Some(solution) = &self.solution {
                         doc = doc
                             .append("<")
                             .append(solution.print_prec(cfg, alloc, prec))
                             .append(">")
                     }
-                }
 
                 doc
             }

--- a/lang/ast/src/exp/hole.rs
+++ b/lang/ast/src/exp/hole.rs
@@ -145,12 +145,10 @@ impl Print for Hole {
                 }
 
                 if cfg.print_metavar_solutions
-                    && let Some(solution) = &self.solution {
-                        doc = doc
-                            .append("<")
-                            .append(solution.print_prec(cfg, alloc, prec))
-                            .append(">")
-                    }
+                    && let Some(solution) = &self.solution
+                {
+                    doc = doc.append("<").append(solution.print_prec(cfg, alloc, prec)).append(">")
+                }
 
                 doc
             }
@@ -166,12 +164,10 @@ impl Print for Hole {
                 }
 
                 if cfg.print_metavar_solutions
-                    && let Some(solution) = &self.solution {
-                        doc = doc
-                            .append("<")
-                            .append(solution.print_prec(cfg, alloc, prec))
-                            .append(">")
-                    }
+                    && let Some(solution) = &self.solution
+                {
+                    doc = doc.append("<").append(solution.print_prec(cfg, alloc, prec)).append(">")
+                }
 
                 doc
             }

--- a/lang/backend/Cargo.toml
+++ b/lang/backend/Cargo.toml
@@ -18,9 +18,7 @@ thiserror = { workspace = true }
 url       = { workspace = true }
 
 # SWC for JS code generation
-swc_ecma_ast     = { workspace = true }
-swc_ecma_codegen = { workspace = true }
-swc_common       = { workspace = true }
+swc_core   = { workspace = true }
 
 # workspace dependencies
 polarity-lang-ast     = { workspace = true }

--- a/lang/backend/src/ir2js/decls.rs
+++ b/lang/backend/src/ir2js/decls.rs
@@ -61,7 +61,7 @@ impl ToJSStmt for ir::Let {
         let body_expr = body.to_js_expr()?;
 
         Ok(js::Stmt::Decl(js::Decl::Fn(js::FnDecl {
-            ident: js::Ident::new(name.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
+            ident: name.to_string().into(),
             declare: false,
             function: Box::new(js::Function {
                 params,
@@ -110,10 +110,7 @@ impl ToJSStmt for ir::Def {
         let mut all_params = vec![js::Param {
             span: DUMMY_SP,
             decorators: vec![],
-            pat: js::Pat::Ident(js::BindingIdent {
-                id: js::Ident::new(SELF_PARAM_NAME.into(), DUMMY_SP, SyntaxContext::empty()),
-                type_ann: None,
-            }),
+            pat: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(SELF_PARAM_NAME))),
         }];
         all_params.extend(params_to_js_params(params));
 
@@ -127,18 +124,14 @@ impl ToJSStmt for ir::Def {
             span: DUMMY_SP,
             discriminant: Box::new(js::Expr::Member(js::MemberExpr {
                 span: DUMMY_SP,
-                obj: Box::new(js::Expr::Ident(js::Ident::new(
-                    SELF_PARAM_NAME.into(),
-                    DUMMY_SP,
-                    SyntaxContext::empty(),
-                ))),
-                prop: js::MemberProp::Ident(js::IdentName { span: DUMMY_SP, sym: CTOR_TAG.into() }),
+                obj: Box::new(js::Expr::Ident(SELF_PARAM_NAME.into())),
+                prop: js::MemberProp::Ident(CTOR_TAG.into()),
             })),
             cases,
         })];
 
         Ok(js::Stmt::Decl(js::Decl::Fn(js::FnDecl {
-            ident: js::Ident::new(name.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
+            ident: name.to_string().into(),
             declare: false,
             function: Box::new(js::Function {
                 params: all_params,
@@ -191,7 +184,7 @@ impl ToJSStmt for ir::Codef {
         });
 
         Ok(js::Stmt::Decl(js::Decl::Fn(js::FnDecl {
-            ident: js::Ident::new(name.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
+            ident: name.to_string().into(),
             declare: false,
             function: Box::new(js::Function {
                 params,
@@ -218,10 +211,7 @@ fn params_to_js_params(params: &[ir::Ident]) -> Vec<js::Param> {
         .map(|p| js::Param {
             span: DUMMY_SP,
             decorators: vec![],
-            pat: js::Pat::Ident(js::BindingIdent {
-                id: js::Ident::new(p.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
-                type_ann: None,
-            }),
+            pat: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(p.to_string()))),
         })
         .collect()
 }

--- a/lang/backend/src/ir2js/decls.rs
+++ b/lang/backend/src/ir2js/decls.rs
@@ -1,5 +1,5 @@
-use swc_common::{DUMMY_SP, SyntaxContext};
-use swc_ecma_ast as js;
+use swc_core::common::{DUMMY_SP, SyntaxContext};
+use swc_core::ecma::ast as js;
 
 use crate::ir;
 use crate::result::BackendResult;

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -6,7 +6,7 @@ use swc_core::quote_expr;
 
 use crate::ir;
 use crate::ir2js::traits::ToJSStmt;
-use crate::ir2js::util::{force_expr, paren_expr, thunk_block, thunk_expr};
+use crate::ir2js::util::{force_expr, paren_expr, thunk_block};
 use crate::result::BackendResult;
 
 use super::tokens::*;
@@ -47,12 +47,7 @@ impl ToJSExpr for ir::Exp {
 impl ToJSExpr for ir::Variable {
     fn to_js_expr(&self) -> BackendResult<js::Expr> {
         let Self { name } = self;
-        let name = name.clone();
-        Ok(js::Expr::Ident(js::Ident::new(
-            name.to_string().into(),
-            DUMMY_SP,
-            SyntaxContext::empty(),
-        )))
+        Ok(js::Expr::Ident(name.to_string().into()))
     }
 }
 
@@ -74,15 +69,11 @@ impl ir::Call {
 
         let props = vec![
             js::PropOrSpread::Prop(Box::new(js::Prop::KeyValue(js::KeyValueProp {
-                key: js::PropName::Ident(js::IdentName { span: DUMMY_SP, sym: CTOR_TAG.into() }),
-                value: Box::new(js::Expr::Lit(js::Lit::Str(js::Str {
-                    span: DUMMY_SP,
-                    value: name.to_string().into(),
-                    raw: None,
-                }))),
+                key: js::PropName::Ident(CTOR_TAG.into()),
+                value: Box::new(js_str_lit(name.to_string())),
             }))),
             js::PropOrSpread::Prop(Box::new(js::Prop::KeyValue(js::KeyValueProp {
-                key: js::PropName::Ident(js::IdentName { span: DUMMY_SP, sym: CTOR_ARGS.into() }),
+                key: js::PropName::Ident(CTOR_ARGS.into()),
                 value: Box::new(js::Expr::Array(args)),
             }))),
         ];
@@ -108,11 +99,7 @@ impl ir::Call {
         Ok(js::Expr::Call(js::CallExpr {
             span: DUMMY_SP,
             ctxt: SyntaxContext::empty(),
-            callee: js::Callee::Expr(Box::new(js::Expr::Ident(js::Ident::new(
-                name.to_string().into(),
-                DUMMY_SP,
-                SyntaxContext::empty(),
-            )))),
+            callee: js::Callee::Expr(Box::new(js::Expr::Ident(name.to_string().into()))),
             args,
             type_args: None,
         }))
@@ -153,10 +140,7 @@ impl ir::DotCall {
             callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
                 span: DUMMY_SP,
                 obj: Box::new(obj_expr),
-                prop: js::MemberProp::Ident(js::IdentName {
-                    span: DUMMY_SP,
-                    sym: name.to_string().into(),
-                }),
+                prop: js::MemberProp::Ident(name.to_string().into()),
             }))),
             args,
             type_args: None,
@@ -184,11 +168,7 @@ impl ir::DotCall {
         Ok(js::Expr::Call(js::CallExpr {
             span: DUMMY_SP,
             ctxt: SyntaxContext::empty(),
-            callee: js::Callee::Expr(Box::new(js::Expr::Ident(js::Ident::new(
-                name.to_string().into(),
-                DUMMY_SP,
-                SyntaxContext::empty(),
-            )))),
+            callee: js::Callee::Expr(Box::new(js::Expr::Ident(name.to_string().into()))),
             args: all_args,
             type_args: None,
         }))
@@ -300,33 +280,9 @@ impl ToJSExpr for ir::LocalComatch {
 impl ToJSExpr for ir::Panic {
     fn to_js_expr(&self) -> BackendResult<js::Expr> {
         let Self { message } = self;
-        let message = message.clone();
+        let message = js_str_lit(message.as_str());
 
-        // Generate IIFE: (() => { throw new Error("message"); })()
-        let throw_stmt = js::Stmt::Throw(js::ThrowStmt {
-            span: DUMMY_SP,
-            arg: Box::new(js::Expr::New(js::NewExpr {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                callee: Box::new(js::Expr::Ident(js::Ident::new(
-                    "Error".into(),
-                    DUMMY_SP,
-                    SyntaxContext::empty(),
-                ))),
-                args: Some(vec![js::ExprOrSpread {
-                    spread: None,
-                    expr: Box::new(js::Expr::Lit(js::Lit::Str(js::Str {
-                        span: DUMMY_SP,
-                        value: message.into(),
-                        raw: None,
-                    }))),
-                }]),
-                type_args: None,
-            })),
-        });
-
-        let thunk = thunk_block(vec![throw_stmt]);
-        Ok(force_expr(thunk))
+        Ok(*quote_expr!(r#"(() => { throw new Error($msg)})()"#, msg: Expr = message))
     }
 }
 
@@ -346,36 +302,15 @@ impl ToJSExpr for ir::LocalLet {
     fn to_js_expr(&self) -> BackendResult<js::Expr> {
         let Self { name, bound, body } = self;
 
-        let body_expr = body.to_js_expr()?;
+        let body = body.to_js_expr()?;
+        let bound = bound.to_js_expr()?;
 
-        // Wrap the body expression in parentheses.
-        // Without them, returning some expressions (such as objects literals) from an arrow function is not valid JavaScript syntax.
-        let paren_body = paren_expr(body_expr);
-
-        let arrow_fn = js::ArrowExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            params: vec![js::Pat::Ident(js::BindingIdent {
-                id: js::Ident::new(name.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
-                type_ann: None,
-            })],
-            body: Box::new(js::BlockStmtOrExpr::Expr(Box::new(paren_body))),
-            is_async: false,
-            is_generator: false,
-            type_params: None,
-            return_type: None,
-        };
-
-        Ok(js::Expr::Call(js::CallExpr {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            callee: js::Callee::Expr(Box::new(js::Expr::Paren(js::ParenExpr {
-                span: DUMMY_SP,
-                expr: Box::new(js::Expr::Arrow(arrow_fn)),
-            }))),
-            args: args_to_js_exprs(&[*bound.clone()])?,
-            type_args: None,
-        }))
+        Ok(*quote_expr!(
+            "(($name) => ($body))($bound)",
+            name = name.to_string().into(),
+            body: Expr = body,
+            bound: Expr = bound
+        ))
     }
 }
 
@@ -433,19 +368,13 @@ impl ToJSStmt for ir::DoBinding {
         let var_declarator = match self {
             ir::DoBinding::Let { name, bound } => js::VarDeclarator {
                 span: DUMMY_SP,
-                name: js::Pat::Ident(js::BindingIdent {
-                    id: js::Ident::from(name.to_string()),
-                    type_ann: None,
-                }),
+                name: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(name.to_string()))),
                 init: Some(Box::new(bound.to_js_expr()?)),
                 definite: false,
             },
             ir::DoBinding::Bind { name, bound } => js::VarDeclarator {
                 span: DUMMY_SP,
-                name: js::Pat::Ident(js::BindingIdent {
-                    id: js::Ident::from(name.to_string()),
-                    type_ann: None,
-                }),
+                name: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(name.to_string()))),
                 init: Some(Box::new(force_expr(bound.to_js_expr()?))),
                 definite: false,
             },
@@ -482,16 +411,12 @@ impl ToJSStmt for ir::DoBinding {
 /// ```
 impl ToJSExpr for ir::Literal {
     fn to_js_expr(&self) -> BackendResult<js::Expr> {
-        match self {
-            ir::Literal::I64(int) => {
-                Ok(js::Expr::Lit(js::Lit::BigInt(js::BigIntValue::from(*int).into())))
-            }
-            ir::Literal::F64(float) => Ok(js::Expr::Lit(js::Lit::Num(js::Number::from(*float)))),
-            ir::Literal::Char(c) => Ok(js::Expr::Lit(js::Lit::Num(js::Number::from(*c as usize)))),
-            ir::Literal::String(string) => {
-                Ok(js::Expr::Lit(js::Lit::Str(js::Str::from(string.as_str()))))
-            }
-        }
+        Ok(match self {
+            ir::Literal::I64(int) => js_bigint_lit(*int),
+            ir::Literal::F64(float) => js_num_lit(*float),
+            ir::Literal::Char(c) => js_num_lit(*c as usize),
+            ir::Literal::String(string) => js_str_lit(string.as_str()),
+        })
     }
 }
 
@@ -513,11 +438,7 @@ impl ir::Case {
     pub fn to_js_switch_case(&self, scrutinee_name: &str) -> BackendResult<js::SwitchCase> {
         let Self { pattern, body } = self;
         let pattern_name = pattern.name.clone();
-        let test = js::Expr::Lit(js::Lit::Str(js::Str {
-            span: DUMMY_SP,
-            value: pattern_name.to_string().into(),
-            raw: None,
-        }));
+        let test = js_str_lit(pattern_name.to_string());
 
         let mut stmts = vec![];
 
@@ -531,35 +452,19 @@ impl ir::Case {
                 declare: false,
                 decls: vec![js::VarDeclarator {
                     span: DUMMY_SP,
-                    name: js::Pat::Ident(js::BindingIdent {
-                        id: js::Ident::new(
-                            param_name.to_string().into(),
-                            DUMMY_SP,
-                            SyntaxContext::empty(),
-                        ),
-                        type_ann: None,
-                    }),
+                    name: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(
+                        param_name.to_string(),
+                    ))),
                     init: Some(Box::new(js::Expr::Member(js::MemberExpr {
                         span: DUMMY_SP,
                         obj: Box::new(js::Expr::Member(js::MemberExpr {
                             span: DUMMY_SP,
-                            obj: Box::new(js::Expr::Ident(js::Ident::new(
-                                scrutinee_name.into(),
-                                DUMMY_SP,
-                                SyntaxContext::empty(),
-                            ))),
-                            prop: js::MemberProp::Ident(js::IdentName {
-                                span: DUMMY_SP,
-                                sym: CTOR_ARGS.into(),
-                            }),
+                            obj: Box::new(js::Expr::Ident(scrutinee_name.into())),
+                            prop: js::MemberProp::Ident(CTOR_ARGS.into()),
                         })),
                         prop: js::MemberProp::Computed(js::ComputedPropName {
                             span: DUMMY_SP,
-                            expr: Box::new(js::Expr::Lit(js::Lit::Num(js::Number {
-                                span: DUMMY_SP,
-                                value: i as f64,
-                                raw: None,
-                            }))),
+                            expr: Box::new(js_num_lit(i)),
                         }),
                     }))),
                     definite: false,
@@ -595,12 +500,7 @@ impl ir::Case {
         let params: Vec<_> = pattern
             .params
             .iter()
-            .map(|p| {
-                js::Pat::Ident(js::BindingIdent {
-                    id: js::Ident::new(p.to_string().into(), DUMMY_SP, SyntaxContext::empty()),
-                    type_ann: None,
-                })
-            })
+            .map(|p| js::Pat::Ident(js::BindingIdent::from(js::Ident::from(p.to_string()))))
             .collect();
 
         let body_expr = body.to_js_expr()?;
@@ -621,10 +521,7 @@ impl ir::Case {
         });
 
         Ok(js::PropOrSpread::Prop(Box::new(js::Prop::KeyValue(js::KeyValueProp {
-            key: js::PropName::Ident(js::IdentName {
-                span: DUMMY_SP,
-                sym: method_name.to_string().into(),
-            }),
+            key: js::PropName::Ident(js::IdentName::from(method_name.to_string())),
             value: Box::new(arrow),
         }))))
     }
@@ -641,6 +538,19 @@ fn args_to_js_exprs(args: &[ir::Exp]) -> BackendResult<Vec<js::ExprOrSpread>> {
             arg.to_js_expr().map(|expr| js::ExprOrSpread { spread: None, expr: Box::new(expr) })
         })
         .collect()
+}
+
+fn js_str_lit(str: impl Into<js::Str>) -> js::Expr {
+    js::Expr::Lit(js::Lit::Str(str.into()))
+}
+
+fn js_num_lit(num: impl Into<js::Number>) -> js::Expr {
+    js::Expr::Lit(js::Lit::Num(num.into()))
+}
+
+fn js_bigint_lit(bigint: impl Into<js::BigIntValue>) -> js::Expr {
+    let bigint: js::BigIntValue = bigint.into();
+    js::Expr::Lit(js::Lit::BigInt(bigint.into()))
 }
 
 fn extern_call_to_js_expr(name: &str, args: Vec<js::Expr>) -> Option<Box<js::Expr>> {
@@ -685,8 +595,7 @@ fn extern_call_to_js_expr(name: &str, args: Vec<js::Expr>) -> Option<Box<js::Exp
             let (c, s) = take2(args);
             quote_expr!("$s.concat(String.fromCodePoint($c))", s: Expr = s, c: Expr = c)
         }
-        // This is a safe way to evaluate to undefined.
-        "unit" => quote_expr!("(void 0)"),
+        "unit" => js::Expr::undefined(DUMMY_SP),
         "return_io" => {
             let x = take1(args);
             quote_expr!("(() => $x)", x: Expr = x)

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -125,113 +125,11 @@ impl ir::Call {
     /// Handle builtin extern calls and pass the rest to [Self::to_js_function_call].
     fn to_js_extern_function_call(&self) -> BackendResult<js::Expr> {
         let Self { name, module_uri: _, args } = self;
-        let args = args_to_js_exprs(args)?;
+        let args = args_to_js_exprs(args)?.into_iter().map(|arg| *arg.expr).collect();
 
-        match name.to_string().as_str() {
-            // BigInt.asIntN(64, 〚x 〛 + 〚y 〛)
-            "add_i64" => Ok(js_binary_expr_i64(
-                js::BinaryOp::Add,
-                args[0].expr.clone(),
-                args[1].expr.clone(),
-            )),
-            // BigInt.asIntN(64, 〚x 〛 - 〚y 〛)
-            "sub_i64" => Ok(js_binary_expr_i64(
-                js::BinaryOp::Sub,
-                args[0].expr.clone(),
-                args[1].expr.clone(),
-            )),
-            // BigInt.asIntN(64, 〚x 〛 * 〚y 〛)
-            "mul_i64" => Ok(js_binary_expr_i64(
-                js::BinaryOp::Mul,
-                args[0].expr.clone(),
-                args[1].expr.clone(),
-            )),
-            // BigInt.asIntN(64, 〚x 〛 / 〚y 〛)
-            "div_i64" => Ok(js_binary_expr_i64(
-                js::BinaryOp::Div,
-                args[0].expr.clone(),
-                args[1].expr.clone(),
-            )),
-            // (〚x 〛 + 〚y 〛)
-            "add_f64" => {
-                Ok(js_binary_expr(js::BinaryOp::Add, args[0].expr.clone(), args[1].expr.clone()))
-            }
-            // (〚x 〛 - 〚y 〛)
-            "sub_f64" => {
-                Ok(js_binary_expr(js::BinaryOp::Sub, args[0].expr.clone(), args[1].expr.clone()))
-            }
-            // (〚x 〛 * 〚y 〛)
-            "mul_f64" => {
-                Ok(js_binary_expr(js::BinaryOp::Mul, args[0].expr.clone(), args[1].expr.clone()))
-            }
-            // (〚x 〛 / 〚y 〛)
-            "div_f64" => {
-                Ok(js_binary_expr(js::BinaryOp::Div, args[0].expr.clone(), args[1].expr.clone()))
-            }
-            // 〚x 〛.concat(〚y 〛)
-            "concat" => Ok(js::Expr::Call(js::CallExpr {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
-                    span: DUMMY_SP,
-                    obj: args[0].expr.clone(),
-                    prop: js::MemberProp::Ident(js::IdentName::from("concat")),
-                }))),
-                args: vec![js::ExprOrSpread { spread: None, expr: args[1].expr.clone() }],
-                type_args: None,
-            })),
-            // 〚s 〛.concat(String.fromCodePoint(〚c 〛))
-            "append_char" => Ok(js::Expr::Call(js::CallExpr {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
-                    span: DUMMY_SP,
-                    obj: args[1].expr.clone(),
-                    prop: js::MemberProp::Ident(js::IdentName::from("concat")),
-                }))),
-                args: vec![js::ExprOrSpread {
-                    spread: None,
-                    expr: Box::new(js::Expr::Call(js::CallExpr {
-                        span: DUMMY_SP,
-                        ctxt: SyntaxContext::empty(),
-                        callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
-                            span: DUMMY_SP,
-                            obj: Box::new(js::Expr::Ident(js::Ident::from("String"))),
-                            prop: js::MemberProp::Ident(js::IdentName::from("fromCodePoint")),
-                        }))),
-                        args: vec![js::ExprOrSpread { spread: None, expr: args[0].expr.clone() }],
-                        type_args: None,
-                    })),
-                }],
-                type_args: None,
-            })),
-            // void 0
-            // (This is a safe way to evaluate to undefined)
-            "unit" => Ok(*js::Expr::undefined(DUMMY_SP)),
-            // (() => 〚x 〛)
-            "return_io" => Ok(thunk_expr(*args[0].expr.clone())),
-            // (() => { console.log(〚s 〛); return void 0; })
-            "println" => Ok(thunk_block(vec![
-                js::Stmt::Expr(js::ExprStmt {
-                    span: DUMMY_SP,
-                    expr: Box::new(js::Expr::Call(js::CallExpr {
-                        span: DUMMY_SP,
-                        ctxt: SyntaxContext::empty(),
-                        callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
-                            span: DUMMY_SP,
-                            obj: Box::new(js::Expr::Ident(js::Ident::from("console"))),
-                            prop: js::MemberProp::Ident(js::IdentName::from("log")),
-                        }))),
-                        args: vec![js::ExprOrSpread { spread: None, expr: args[0].expr.clone() }],
-                        type_args: None,
-                    })),
-                }),
-                js::Stmt::Return(js::ReturnStmt {
-                    span: DUMMY_SP,
-                    arg: Some(js::Expr::undefined(DUMMY_SP)),
-                }),
-            ])),
-            _ => self.to_js_function_call(),
+        match extern_call_to_js_expr(name.to_string().as_str(), args) {
+            Some(expr) => Ok(*expr),
+            None => self.to_js_function_call(),
         }
     }
 }
@@ -749,32 +647,72 @@ fn args_to_js_exprs(args: &[ir::Exp]) -> BackendResult<Vec<js::ExprOrSpread>> {
         .collect()
 }
 
-fn js_binary_expr(op: js::BinaryOp, left: Box<js::Expr>, right: Box<js::Expr>) -> js::Expr {
-    js::Expr::Paren(js::ParenExpr {
-        span: DUMMY_SP,
-        expr: Box::new(js::Expr::Bin(js::BinExpr { span: DUMMY_SP, op, left, right })),
+fn extern_call_to_js_expr(name: &str, args: Vec<js::Expr>) -> Option<Box<js::Expr>> {
+    Some(match name {
+        "add_i64" => {
+            let (x, y) = take2(args);
+            quote_expr!("BigInt.asIntN(64, $x + $y)", x: Expr = x, y: Expr = y)
+        }
+        "sub_i64" => {
+            let (x, y) = take2(args);
+            quote_expr!("BigInt.asIntN(64, $x - $y)", x: Expr = x, y: Expr = y)
+        }
+        "mul_i64" => {
+            let (x, y) = take2(args);
+            quote_expr!("BigInt.asIntN(64, $x * $y)", x: Expr = x, y: Expr = y)
+        }
+        "div_i64" => {
+            let (x, y) = take2(args);
+            quote_expr!("BigInt.asIntN(64, $x / $y)", x: Expr = x, y: Expr = y)
+        }
+        "add_f64" => {
+            let (x, y) = take2(args);
+            quote_expr!("($x + $y)", x: Expr = x, y: Expr = y)
+        }
+        "sub_f64" => {
+            let (x, y) = take2(args);
+            quote_expr!("($x - $y)", x: Expr = x, y: Expr = y)
+        }
+        "mul_f64" => {
+            let (x, y) = take2(args);
+            quote_expr!("($x * $y)", x: Expr = x, y: Expr = y)
+        }
+        "div_f64" => {
+            let (x, y) = take2(args);
+            quote_expr!("($x / $y)", x: Expr = x, y: Expr = y)
+        }
+        "concat" => {
+            let (x, y) = take2(args);
+            quote_expr!("$x.concat($y)", x: Expr = x, y: Expr = y)
+        }
+        "append_char" => {
+            let (c, s) = take2(args);
+            quote_expr!("$s.concat(String.fromCodePoint($c))", s: Expr = s, c: Expr = c)
+        }
+        // This is a safe way to evaluate to undefined.
+        "unit" => quote_expr!("(void 0)"),
+        "return_io" => {
+            let x = take1(args);
+            quote_expr!("(() => $x)", x: Expr = x)
+        }
+        "println" => {
+            let s = take1(args);
+            quote_expr!("(() => { console.log($s); return void 0; })", s: Expr = s)
+        }
+        _ => return None,
     })
 }
 
-fn js_binary_expr_i64(op: js::BinaryOp, left: Box<js::Expr>, right: Box<js::Expr>) -> js::Expr {
-    js::Expr::Call(js::CallExpr {
-        span: DUMMY_SP,
-        ctxt: SyntaxContext::empty(),
-        callee: js::Callee::Expr(Box::new(js::Expr::Member(js::MemberExpr {
-            span: DUMMY_SP,
-            obj: Box::new(js::Expr::Ident(js::Ident::from("BigInt"))),
-            prop: js::MemberProp::Ident(js::IdentName::from("asIntN")),
-        }))),
-        args: vec![
-            js::ExprOrSpread {
-                spread: None,
-                expr: Box::new(js::Expr::Lit(js::Lit::Num(js::Number::from(64)))),
-            },
-            js::ExprOrSpread {
-                spread: None,
-                expr: Box::new(js::Expr::Bin(js::BinExpr { span: DUMMY_SP, op, left, right })),
-            },
-        ],
-        type_args: None,
-    })
+// Get the value of a Vec with *exactly* one element.
+fn take1(mut args: Vec<js::Expr>) -> js::Expr {
+    debug_assert_eq!(args.len(), 1);
+    args.swap_remove(0)
+}
+
+// Get the values of a Vec with *exactly* two elements.
+fn take2(mut args: Vec<js::Expr>) -> (js::Expr, js::Expr) {
+    debug_assert_eq!(args.len(), 2);
+    let y = args.swap_remove(1);
+    let x = args.swap_remove(0);
+    (x, y)
 }

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -1,7 +1,8 @@
 //! JavaScript code generation for IR expressions using SWC AST.
 
-use swc_common::{DUMMY_SP, SyntaxContext};
-use swc_ecma_ast as js;
+use swc_core::common::{DUMMY_SP, SyntaxContext};
+use swc_core::ecma::ast as js;
+use swc_core::quote_expr;
 
 use crate::ir;
 use crate::ir2js::traits::ToJSStmt;
@@ -448,7 +449,7 @@ impl ToJSExpr for ir::Panic {
 /// ((x) => 〚 body 〛)(〚 foo 〛)
 /// ```
 impl ToJSExpr for ir::LocalLet {
-    fn to_js_expr(&self) -> BackendResult<swc_ecma_ast::Expr> {
+    fn to_js_expr(&self) -> BackendResult<js::Expr> {
         let Self { name, bound, body } = self;
 
         let body_expr = body.to_js_expr()?;
@@ -499,7 +500,7 @@ impl ToJSExpr for ir::LocalLet {
 /// })
 /// ```
 impl ToJSExpr for ir::DoBlock {
-    fn to_js_expr(&self) -> BackendResult<swc_ecma_ast::Expr> {
+    fn to_js_expr(&self) -> BackendResult<js::Expr> {
         let Self { bindings, return_exp } = self;
 
         let mut js_bindings = Vec::with_capacity(bindings.len());
@@ -534,7 +535,7 @@ impl ToJSExpr for ir::DoBlock {
 /// const y = 〚 e2 〛();
 /// ```
 impl ToJSStmt for ir::DoBinding {
-    fn to_js_stmt(&self) -> BackendResult<swc_ecma_ast::Stmt> {
+    fn to_js_stmt(&self) -> BackendResult<js::Stmt> {
         let var_declarator = match self {
             ir::DoBinding::Let { name, bound } => js::VarDeclarator {
                 span: DUMMY_SP,
@@ -586,7 +587,7 @@ impl ToJSStmt for ir::DoBinding {
 /// "somestring"
 /// ```
 impl ToJSExpr for ir::Literal {
-    fn to_js_expr(&self) -> BackendResult<swc_ecma_ast::Expr> {
+    fn to_js_expr(&self) -> BackendResult<js::Expr> {
         match self {
             ir::Literal::I64(int) => {
                 Ok(js::Expr::Lit(js::Lit::BigInt(js::BigIntValue::from(*int).into())))

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -28,11 +28,7 @@ impl ToJSExpr for ir::Exp {
             ir::Exp::LocalLet(local_let) => local_let.to_js_expr(),
             ir::Exp::DoBlock(do_block) => do_block.to_js_expr(),
             ir::Exp::Literal(lit) => lit.to_js_expr(),
-            ir::Exp::ZST => Ok(js::Expr::Ident(js::Ident::new(
-                "undefined".into(),
-                DUMMY_SP,
-                SyntaxContext::empty(),
-            ))),
+            ir::Exp::ZST => Ok(paren_expr(*js::Expr::undefined(DUMMY_SP))),
         }
     }
 }

--- a/lang/backend/src/ir2js/mod.rs
+++ b/lang/backend/src/ir2js/mod.rs
@@ -3,10 +3,10 @@
 use std::io;
 use std::rc::Rc;
 
-use swc_common::SourceMap;
-use swc_ecma_ast as js;
-use swc_ecma_codegen::text_writer::JsWriter;
-use swc_ecma_codegen::{Config as CodegenConfig, Emitter};
+use swc_core::common::SourceMap;
+use swc_core::ecma::ast as js;
+use swc_core::ecma::codegen::text_writer::JsWriter;
+use swc_core::ecma::codegen::{Config as CodegenConfig, Emitter};
 
 mod decls;
 mod exprs;

--- a/lang/backend/src/ir2js/mod.rs
+++ b/lang/backend/src/ir2js/mod.rs
@@ -7,6 +7,7 @@ use swc_core::common::SourceMap;
 use swc_core::ecma::ast as js;
 use swc_core::ecma::codegen::text_writer::JsWriter;
 use swc_core::ecma::codegen::{Config as CodegenConfig, Emitter};
+use swc_core::quote;
 
 mod decls;
 mod exprs;
@@ -25,32 +26,34 @@ enum CallToMain {
 }
 
 impl CallToMain {
-    fn generated_call(&self) -> Option<&str> {
+    fn generated_call(&self) -> Option<js::Stmt> {
         match self {
             CallToMain::None => None,
-            CallToMain::RunIO => Some("main()()"),
-            CallToMain::DebugPrint => Some(
-                "console.log(JSON.stringify(main(), (k, v) => typeof v == \"bigint\" ? v.toString() : v))",
-            ),
+            CallToMain::RunIO => Some(quote!("main()()" as Stmt)),
+            CallToMain::DebugPrint => Some(quote!(
+                "console.log(JSON.stringify(main(), (k, v) => typeof v == \"bigint\" ? v.toString() : v))"
+                    as Stmt
+            )),
         }
     }
 }
 
 /// Convert an IR module to JavaScript
 pub fn ir_to_js<W: io::Write>(ir_module: &ir::Module, writer: W) -> BackendResult {
+    let mut js_module = ir_module.to_js_module()?;
+
     let call_to_main = ir_module.find_main().map_or(CallToMain::None, |main| {
         if main.is_main_with_io { CallToMain::RunIO } else { CallToMain::DebugPrint }
     });
-    let js_module = ir_module.to_js_module()?;
-    emit_js(&js_module, writer, call_to_main)
+    if let Some(call) = call_to_main.generated_call() {
+        js_module.body.push(js::ModuleItem::Stmt(call));
+    }
+
+    emit_js(&js_module, writer)
 }
 
 /// Emit a JavaScript module
-fn emit_js<W: io::Write>(
-    js_module: &js::Module,
-    mut writer: W,
-    call_to_main: CallToMain,
-) -> BackendResult {
+fn emit_js<W: io::Write>(js_module: &js::Module, mut writer: W) -> BackendResult {
     let config = CodegenConfig::default();
     let cm = Rc::new(SourceMap::default());
 
@@ -60,12 +63,6 @@ fn emit_js<W: io::Write>(
     emitter
         .emit_module(js_module)
         .map_err(|e| BackendError::CodegenError(format!("Failed to emit module: {}", e)))?;
-
-    if let Some(generated_call) = call_to_main.generated_call() {
-        write!(writer, "\n{generated_call}\n").map_err(|e| {
-            BackendError::CodegenError(format!("Failed to write call to main: {e}"))
-        })?;
-    }
 
     Ok(())
 }

--- a/lang/backend/src/ir2js/traits.rs
+++ b/lang/backend/src/ir2js/traits.rs
@@ -1,4 +1,4 @@
-use swc_ecma_ast as js;
+use swc_core::ecma::ast as js;
 
 use crate::result::BackendResult;
 

--- a/lang/backend/src/ir2js/util.rs
+++ b/lang/backend/src/ir2js/util.rs
@@ -1,5 +1,5 @@
-use swc_common::{DUMMY_SP, SyntaxContext};
-use swc_ecma_ast as js;
+use swc_core::common::{DUMMY_SP, SyntaxContext};
+use swc_core::ecma::ast as js;
 
 /// Wrap expression in parentheses.
 pub fn paren_expr(e: js::Expr) -> js::Expr {

--- a/lang/backend/src/ir2js/util.rs
+++ b/lang/backend/src/ir2js/util.rs
@@ -18,21 +18,6 @@ pub fn force_expr(e: js::Expr) -> js::Expr {
 }
 
 /// Wrap expression in a thunk
-pub fn thunk_expr(e: js::Expr) -> js::Expr {
-    let arr = js::Expr::Arrow(js::ArrowExpr {
-        span: DUMMY_SP,
-        ctxt: SyntaxContext::empty(),
-        params: vec![],
-        body: Box::new(js::BlockStmtOrExpr::Expr(Box::new(e))),
-        is_async: false,
-        is_generator: false,
-        type_params: None,
-        return_type: None,
-    });
-    paren_expr(arr)
-}
-
-/// Wrap expression in a thunk
 pub fn thunk_block(block: Vec<js::Stmt>) -> js::Expr {
     let arr = js::Expr::Arrow(js::ArrowExpr {
         span: DUMMY_SP,

--- a/lang/driver/src/dependency_graph.rs
+++ b/lang/driver/src/dependency_graph.rs
@@ -104,10 +104,9 @@ impl DependencyGraph {
 /// A `String` representing the file name or the full path if extraction fails.
 fn url_to_label(url: &Url) -> String {
     // Extract the file name from the path
-    if let Some(mut path_segments) = url.path_segments() {
-        if let Some(file_name) = path_segments.next_back() {
+    if let Some(mut path_segments) = url.path_segments()
+        && let Some(file_name) = path_segments.next_back() {
             return file_name.to_string();
         }
-    }
     url.path().to_string()
 }

--- a/lang/driver/src/dependency_graph.rs
+++ b/lang/driver/src/dependency_graph.rs
@@ -105,8 +105,9 @@ impl DependencyGraph {
 fn url_to_label(url: &Url) -> String {
     // Extract the file name from the path
     if let Some(mut path_segments) = url.path_segments()
-        && let Some(file_name) = path_segments.next_back() {
-            return file_name.to_string();
-        }
+        && let Some(file_name) = path_segments.next_back()
+    {
+        return file_name.to_string();
+    }
     url.path().to_string()
 }

--- a/lang/elaborator/src/typechecker/ctx.rs
+++ b/lang/elaborator/src/typechecker/ctx.rs
@@ -63,11 +63,12 @@ impl ContextSubstExt for Ctx {
                         let lvl = Lvl { fst, snd };
                         let mut binding = binding.subst(&mut levels.clone(), subst);
                         if binding.val.is_none()
-                            && let Some(val) = subst.map.get(&lvl) {
-                                binding.val = Some(ctx::values::BoundValue::PatternMatching {
-                                    val: Box::new(val.clone()),
-                                })
-                            }
+                            && let Some(val) = subst.map.get(&lvl)
+                        {
+                            binding.val = Some(ctx::values::BoundValue::PatternMatching {
+                                val: Box::new(val.clone()),
+                            })
+                        }
                         binding.typ = binding.typ.normalize(type_info_table, &mut env.clone())?;
                         Ok(Binder { name: name.clone(), content: binding })
                     })

--- a/lang/elaborator/src/typechecker/ctx.rs
+++ b/lang/elaborator/src/typechecker/ctx.rs
@@ -62,13 +62,12 @@ impl ContextSubstExt for Ctx {
                     .map(|(snd, Binder { name, content: binding })| {
                         let lvl = Lvl { fst, snd };
                         let mut binding = binding.subst(&mut levels.clone(), subst);
-                        if binding.val.is_none() {
-                            if let Some(val) = subst.map.get(&lvl) {
+                        if binding.val.is_none()
+                            && let Some(val) = subst.map.get(&lvl) {
                                 binding.val = Some(ctx::values::BoundValue::PatternMatching {
                                     val: Box::new(val.clone()),
                                 })
                             }
-                        }
                         binding.typ = binding.typ.normalize(type_info_table, &mut env.clone())?;
                         Ok(Binder { name: name.clone(), content: binding })
                     })

--- a/test/suites/success/023-comatches.js.expected
+++ b/test/suites/success/023-comatches.js.expected
@@ -24,6 +24,6 @@ function const_(__self) {
 }
 function IdType() {
     return {
-        ap: (a1)=>(undefined)
+        ap: (a1)=>((void 0))
     };
 }

--- a/test/suites/success/035-stlc-bool.js.expected
+++ b/test/suites/success/035-stlc-bool.js.expected
@@ -629,7 +629,7 @@ function subst_lemma(__self, ctx1, ctx2, t7, t8, by_e) {
                                                         tag: "LT",
                                                         args: []
                                                     }, cmp(x47, len(ctx1)), {
-                                                        ap: (cmp0)=>(undefined)
+                                                        ap: (cmp0)=>((void 0))
                                                     }, weaken_append(ctx2, ctx1, {
                                                         tag: "Var",
                                                         args: [
@@ -659,14 +659,14 @@ function subst_lemma(__self, ctx1, ctx2, t7, t8, by_e) {
                                                         tag: "EQ",
                                                         args: []
                                                     }, cmp(x47, len(ctx1)), {
-                                                        ap: (cmp1)=>(undefined)
+                                                        ap: (cmp1)=>((void 0))
                                                     }, weaken_append(append(ctx1, ctx2), {
                                                         tag: "Nil",
                                                         args: []
                                                     }, by_e, t8).ap(transport(ctx_lookup(ctx1, ctx2, t8, t7).ap(transport(h_eq, x47, len(ctx1), {
-                                                        ap: (x55)=>(undefined)
+                                                        ap: (x55)=>((void 0))
                                                     }, h_elem)), t7, t8, {
-                                                        ap: (t9)=>(undefined)
+                                                        ap: (t9)=>((void 0))
                                                     }, h_by)));
                                                 case "IsGT":
                                                     const x56 = __scrutinee.args[0];
@@ -677,7 +677,7 @@ function subst_lemma(__self, ctx1, ctx2, t7, t8, by_e) {
                                                         tag: "GT",
                                                         args: []
                                                     }, cmp(x47, len(ctx1)), {
-                                                        ap: (cmp2)=>(undefined)
+                                                        ap: (cmp2)=>((void 0))
                                                     }, {
                                                         tag: "TVar",
                                                         args: [
@@ -838,7 +838,7 @@ function weaken_append(__self, ctx, e15, t11) {
                         tag: "Nil",
                         args: []
                     }), {
-                        ap: (ctx0)=>(undefined)
+                        ap: (ctx0)=>((void 0))
                     }, h_e9))
             };
         case "Cons":
@@ -870,7 +870,7 @@ function weaken_append(__self, ctx, e15, t11) {
                             ts1
                         ]
                     }), {
-                        ap: (ctx3)=>(undefined)
+                        ap: (ctx3)=>((void 0))
                     }, weaken_append(ts1, append(ctx, {
                         tag: "Cons",
                         args: [
@@ -1329,7 +1329,7 @@ function elem_append_pred(__self, ctx11, t29, t30, x100) {
                                                 pred(x109)
                                             ]
                                         }, x109, {
-                                            ap: (x113)=>(undefined)
+                                            ap: (x113)=>((void 0))
                                         }, {
                                             tag: "There",
                                             args: [

--- a/test/suites/success/037-vect.js.expected
+++ b/test/suites/success/037-vect.js.expected
@@ -123,5 +123,4 @@ function example1(__self) {
             };
     }
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/045-i64.js.expected
+++ b/test/suites/success/045-i64.js.expected
@@ -1,5 +1,4 @@
 function main() {
     return ((x)=>(((y)=>(BigInt.asIntN(64, BigInt.asIntN(64, y / 2n) + x)))(BigInt.asIntN(64, 1n - x))))(BigInt.asIntN(64, 3n * 4n));
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/046-i64-overflow.js.expected
+++ b/test/suites/success/046-i64-overflow.js.expected
@@ -7,5 +7,4 @@ function MIN() {
 function main() {
     return BigInt.asIntN(64, MAX() + 1n);
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/047-f64.js.expected
+++ b/test/suites/success/047-f64.js.expected
@@ -1,5 +1,4 @@
 function main() {
     return ((x)=>(((y)=>(((y / 2) + x)))((1 - x))))((3 * 4));
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/048-string-char.js.expected
+++ b/test/suites/success/048-string-char.js.expected
@@ -1,5 +1,4 @@
 function main() {
     return "Hello".concat(", World").concat(String.fromCodePoint(33));
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/049-infix-calls.js.expected
+++ b/test/suites/success/049-infix-calls.js.expected
@@ -4,5 +4,4 @@ function keep_left(x, y) {
 function main() {
     return ((x0)=>(((y0)=>(y0))(BigInt.asIntN(64, keep_left(x0, 7n) + 1n))))(BigInt.asIntN(64, 1n + 2n));
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/Regr-341a.js.expected
+++ b/test/suites/success/Regr-341a.js.expected
@@ -5,11 +5,11 @@ function foo(x) {
 }
 function T() {
     return foo({
-        ap: (x0)=>(F().ap(undefined))
+        ap: (x0)=>(F().ap((void 0)))
     });
 }
 function F() {
     return {
-        ap: (x1)=>(undefined)
+        ap: (x1)=>((void 0))
     };
 }

--- a/test/suites/success/Regr-529.js.expected
+++ b/test/suites/success/Regr-529.js.expected
@@ -1,5 +1,5 @@
 function foo() {
     return {
         ap: (x1)=>(x1)
-    }.ap(undefined);
+    }.ap((void 0));
 }

--- a/test/suites/success/Regr-625a.js.expected
+++ b/test/suites/success/Regr-625a.js.expected
@@ -4,5 +4,4 @@ function bar() {
 function main() {
     return bar();
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/Regr-625a.js.expected
+++ b/test/suites/success/Regr-625a.js.expected
@@ -1,5 +1,5 @@
 function bar() {
-    return undefined;
+    return (void 0);
 }
 function main() {
     return bar();

--- a/test/suites/success/Regr-625b.js.expected
+++ b/test/suites/success/Regr-625b.js.expected
@@ -7,5 +7,4 @@ function foo() {
 function main() {
     return foo();
 }
-
-console.log(JSON.stringify(main(), (k, v) => typeof v == "bigint" ? v.toString() : v))
+console.log(JSON.stringify(main(), (k, v)=>typeof v == "bigint" ? v.toString() : v));

--- a/test/suites/success/Regr-625b.js.expected
+++ b/test/suites/success/Regr-625b.js.expected
@@ -2,7 +2,7 @@ function foo() {
     return ((b)=>({
             tag: "T",
             args: []
-        }))(undefined);
+        }))((void 0));
 }
 function main() {
     return foo();

--- a/web/Makefile
+++ b/web/Makefile
@@ -1,6 +1,6 @@
 deps:
 	@rustup target add wasm32-unknown-unknown
-	@cargo install -f wasm-bindgen-cli --version 0.2.104
+	@cargo install -f wasm-bindgen-cli --version 0.2.117
 	@npm install
 
 build: build-server build-app


### PR DESCRIPTION
- Use `swc_core` that re-exports `swc_*` crates
- Make use of `swc_core::quote!`
- Clean up some uses of the SWC API to increase readability
- Use `void 0` instead of `undefined` (which is a safer default, preferred by SWC)

Note: The lastest version of `swc_core` needs Rust 1.91. Therefore, I bumped MSRV and `wasm-bindgen-cli` and updated the nix flake.