### PR TITLE
Fix JS translation of `return_io`

### DIFF
--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -598,7 +598,7 @@ fn extern_call_to_js_expr(name: &str, args: Vec<js::Expr>) -> Option<Box<js::Exp
         "unit" => js::Expr::undefined(DUMMY_SP),
         "return_io" => {
             let x = take1(args);
-            quote_expr!("(() => $x)", x: Expr = x)
+            quote_expr!("(() => { return $x; })", x: Expr = x)
         }
         "println" => {
             let s = take1(args);


### PR DESCRIPTION
Previously `return_io(_, x)` translated to `() => x`. This fails if `x` is an object literal because the braces are misinterpreted as block.