### PR TITLE
Compile multiple modules

### DIFF
--- a/lang/backend/src/ir/decls.rs
+++ b/lang/backend/src/ir/decls.rs
@@ -116,12 +116,13 @@ impl Rename for Module {
             let_decls,
         } = self;
 
-        ctx.rename_binders(&mut toplevel_names, |ctx| {
-            def_decls.rename(ctx)?;
-            codef_decls.rename(ctx)?;
-            let_decls.rename(ctx)?;
-            Ok(())
-        })
+        ctx.rename_global_binders(&mut toplevel_names);
+
+        def_decls.rename(ctx)?;
+        codef_decls.rename(ctx)?;
+        let_decls.rename(ctx)?;
+
+        Ok(())
     }
 }
 
@@ -154,7 +155,7 @@ impl Rename for Def {
         let Def { name, params, cases } = self;
 
         ctx.rename_bound(name)?;
-        ctx.rename_binders(params, |ctx| {
+        ctx.rename_local_binders(params, |ctx| {
             cases.rename(ctx)?;
             Ok(())
         })?;
@@ -191,7 +192,7 @@ impl Rename for Codef {
         let Codef { name, params, cases } = self;
 
         ctx.rename_bound(name)?;
-        ctx.rename_binders(params, |ctx| cases.rename(ctx))?;
+        ctx.rename_local_binders(params, |ctx| cases.rename(ctx))?;
 
         Ok(())
     }
@@ -235,7 +236,7 @@ impl Rename for Let {
         let Let { name, params, body, is_main_with_io: _ } = self;
 
         ctx.rename_bound(name)?;
-        ctx.rename_binders(params, |ctx| body.rename(ctx))?;
+        ctx.rename_local_binders(params, |ctx| body.rename(ctx))?;
 
         Ok(())
     }

--- a/lang/backend/src/ir/exprs.rs
+++ b/lang/backend/src/ir/exprs.rs
@@ -295,7 +295,7 @@ impl Rename for LocalLet {
     fn rename(&mut self, ctx: &mut RenameCtx) -> RenameResult {
         let LocalLet { name, bound, body } = self;
         bound.rename(ctx)?;
-        ctx.rename_binder(name, |ctx| body.rename(ctx))?;
+        ctx.rename_local_binder(name, |ctx| body.rename(ctx))?;
         Ok(())
     }
 }
@@ -351,11 +351,11 @@ fn rename_do_block(
         Some((binding, bindings)) => match binding {
             DoBinding::Let { name, bound } => {
                 bound.rename(ctx)?;
-                ctx.rename_binder(name, |ctx| rename_do_block(bindings, return_exp, ctx))
+                ctx.rename_local_binder(name, |ctx| rename_do_block(bindings, return_exp, ctx))
             }
             DoBinding::Bind { name, bound } => {
                 bound.rename(ctx)?;
-                ctx.rename_binder(name, |ctx| rename_do_block(bindings, return_exp, ctx))
+                ctx.rename_local_binder(name, |ctx| rename_do_block(bindings, return_exp, ctx))
             }
         },
     }
@@ -403,7 +403,7 @@ impl Rename for Case {
         let Case { pattern, body } = self;
         let Pattern { is_copattern: _, name, module_uri: _, params } = pattern;
         ctx.rename_bound(name)?;
-        ctx.rename_binders(params, |ctx| body.rename(ctx))?;
+        ctx.rename_local_binders(params, |ctx| body.rename(ctx))?;
         Ok(())
     }
 }

--- a/lang/backend/src/ir/rename.rs
+++ b/lang/backend/src/ir/rename.rs
@@ -31,13 +31,8 @@ pub enum RenameError {
     EmptyBindings,
 }
 
-pub fn rename_ir(ir: &mut Module, backend: Backend) -> BackendResult {
-    let mut ctx = RenameCtx::new(backend);
-    ir.rename(&mut ctx).map_err(Into::into)
-}
-
-pub fn rename_ir_for_js(ir: &mut Module) -> BackendResult {
-    rename_ir(ir, Backend::Javascript)
+pub fn rename_ir(ir: &mut Module, ctx: &mut RenameCtx) -> BackendResult {
+    ir.rename(ctx).map_err(Into::into)
 }
 
 #[derive(Debug, Clone)]

--- a/lang/backend/src/ir/rename.rs
+++ b/lang/backend/src/ir/rename.rs
@@ -54,7 +54,20 @@ impl RenameCtx {
         Self { active_bindings: Vec::new(), inactive_bindings: Vec::new(), backend }
     }
 
-    pub fn rename_binder<F>(&mut self, ident: &mut Ident, f: F) -> RenameResult
+    pub fn rename_global_binder(&mut self, ident: &mut Ident) {
+        let original = ident.clone();
+        self.rename_to_valid_identifier(&mut ident.name);
+        self.disambiguate_ident(ident);
+        self.active_bindings.push(Binding { original, renamed: ident.clone() });
+    }
+
+    pub fn rename_global_binders(&mut self, idents: &mut [Ident]) {
+        for ident in idents {
+            self.rename_global_binder(ident);
+        }
+    }
+
+    pub fn rename_local_binder<F>(&mut self, ident: &mut Ident, f: F) -> RenameResult
     where
         F: FnOnce(&mut RenameCtx) -> RenameResult,
     {
@@ -69,13 +82,15 @@ impl RenameCtx {
         Ok(())
     }
 
-    pub fn rename_binders<F>(&mut self, idents: &mut [Ident], f: F) -> RenameResult
+    pub fn rename_local_binders<F>(&mut self, idents: &mut [Ident], f: F) -> RenameResult
     where
         F: FnOnce(&mut RenameCtx) -> RenameResult,
     {
         match idents.split_first_mut() {
             None => f(self),
-            Some((x, xs)) => self.rename_binder(x, |extended| extended.rename_binders(xs, f)),
+            Some((x, xs)) => {
+                self.rename_local_binder(x, |extended| extended.rename_local_binders(xs, f))
+            }
         }
     }
 

--- a/lang/backend/src/ir2js/mod.rs
+++ b/lang/backend/src/ir2js/mod.rs
@@ -39,7 +39,7 @@ impl CallToMain {
 }
 
 /// Convert an IR module to JavaScript
-pub fn ir_to_js<W: io::Write>(ir_module: &ir::Module, writer: W) -> BackendResult {
+pub fn ir_to_js<W: io::Write>(ir_module: &ir::Module, writer: &mut W) -> BackendResult {
     let mut js_module = ir_module.to_js_module()?;
 
     let call_to_main = ir_module.find_main().map_or(CallToMain::None, |main| {

--- a/lang/backend/src/lib.rs
+++ b/lang/backend/src/lib.rs
@@ -3,7 +3,7 @@ pub mod ir;
 pub mod ir2js;
 pub mod result;
 
-pub use ir::rename::{rename_ir, rename_ir_for_js};
+pub use ir::rename::{RenameCtx, rename_ir};
 pub use ir2js::ir_to_js;
 
 #[derive(Debug, Clone, Copy)]

--- a/lang/driver/src/database.rs
+++ b/lang/driver/src/database.rs
@@ -538,11 +538,17 @@ impl Database {
     }
 
     /// Compile to JavaScript
-    pub async fn js<W: io::Write>(&mut self, uri: &Url, output: W) -> AppResult<()> {
-        let mut ir = Arc::unwrap_or_clone(self.ir(uri).await?);
+    pub async fn js<W: io::Write>(&mut self, uri: &Url, mut output: W) -> AppResult<()> {
+        self.build_dependency_dag().await?;
+        let modules: Vec<Url> = self.deps.topological_sort(uri).into_iter().cloned().collect();
         let mut ctx = polarity_lang_backend::RenameCtx::new(Backend::Javascript);
-        polarity_lang_backend::rename_ir(&mut ir, &mut ctx).map_err(AppError::Backend)?;
-        polarity_lang_backend::ir_to_js(&ir, output).map_err(AppError::Backend)?;
+
+        for module in &modules {
+            let mut module = Arc::unwrap_or_clone(self.ir(module).await?);
+            polarity_lang_backend::rename_ir(&mut module, &mut ctx).map_err(AppError::Backend)?;
+            polarity_lang_backend::ir_to_js(&module, &mut output).map_err(AppError::Backend)?;
+        }
+
         Ok(())
     }
 

--- a/lang/driver/src/database.rs
+++ b/lang/driver/src/database.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use lsp_types::HoverContents;
 use polarity_lang_ast::rename::Rename;
+use polarity_lang_backend::Backend;
 use polarity_lang_miette_util::ToMiette;
 use polarity_lang_miette_util::codespan::Span;
 use url::Url;
@@ -539,7 +540,8 @@ impl Database {
     /// Compile to JavaScript
     pub async fn js<W: io::Write>(&mut self, uri: &Url, output: W) -> AppResult<()> {
         let mut ir = Arc::unwrap_or_clone(self.ir(uri).await?);
-        polarity_lang_backend::rename_ir_for_js(&mut ir).map_err(AppError::Backend)?;
+        let mut ctx = polarity_lang_backend::RenameCtx::new(Backend::Javascript);
+        polarity_lang_backend::rename_ir(&mut ir, &mut ctx).map_err(AppError::Backend)?;
         polarity_lang_backend::ir_to_js(&ir, output).map_err(AppError::Backend)?;
         Ok(())
     }

--- a/lang/driver/src/dependency_graph.rs
+++ b/lang/driver/src/dependency_graph.rs
@@ -41,6 +41,34 @@ impl DependencyGraph {
         closure
     }
 
+    pub fn topological_sort<'a>(&'a self, uri: &'a Url) -> Vec<&'a Url> {
+        fn visit<'a>(
+            graph: &'a DependencyGraph,
+            node: &'a Url,
+            visited: &mut HashSet<&'a Url>,
+            order: &mut Vec<&'a Url>,
+        ) {
+            if !visited.insert(node) {
+                return;
+            }
+
+            if let Some(deps) = graph.get(node) {
+                for dep in deps {
+                    visit(graph, dep, visited, order);
+                }
+            }
+
+            order.push(node);
+        }
+
+        let mut visited = HashSet::default();
+        let mut order = Vec::new();
+
+        visit(self, uri, &mut visited, &mut order);
+
+        order
+    }
+
     /// Prints the dependency graph as an indented tree.
     ///
     /// Each module is printed with its dependencies indented below it.


### PR DESCRIPTION
This adds support for multiple modules in the JS backend.

The renaming pass uniquifies names across all modules, then everything is compiled into a single JS file.