### PR TITLE
Enable JS tests for programs with imports

### DIFF
--- a/test/test-runner/src/phases.rs
+++ b/test/test-runner/src/phases.rs
@@ -445,13 +445,6 @@ impl Phase for Node {
     }
 
     async fn run(db: &mut Database, uri: &Url) -> AppResult<Self::Out> {
-        let ir = db.ir(uri).await?;
-
-        // TODO: multiple modules are not yet implemented for the backend
-        if !ir.use_decls.is_empty() {
-            return Ok(String::from("NOT YET IMPLEMENTED"));
-        }
-
         let mut file = tempfile::NamedTempFile::new().unwrap();
         db.js(uri, &mut file).await?;
 


### PR DESCRIPTION
We disabled the node test phase for programs with `use` declarations.
Now that we added compilation for multiple modules, this PR removes the restriction.