### PR TITLE
Remove primitive unit type

### DIFF
--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -30,9 +30,6 @@ function concat(s1, s2) {
 function append_char(c, s) {
     return s.concat(String.fromCodePoint(c));
 }
-function unit() {
-    return void 0;
-}
 function return_io(x) {
     return function () {
         return x;
@@ -41,7 +38,10 @@ function return_io(x) {
 function println(s) {
     return function () {
         console.log(s);
-        return void 0;
+        return {
+            tag: "MkUnit",
+            args: [],
+        };
     };
 }
 function read_file(path) {

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -5,9 +5,9 @@ type I64 = bigint;
 type F64 = number;
 type String_ = string;
 type Char = number;
-type Unit = undefined;
 
 // data
+type Unit = { tag: "MkUnit"; args: [] };
 type Option<T> = { tag: "Some"; args: [T] } | { tag: "None"; args: [] };
 
 // IO
@@ -53,10 +53,6 @@ function append_char(c: Char, s: String_): String_ {
   return s.concat(String.fromCodePoint(c));
 }
 
-function unit(): Unit {
-  return void 0;
-}
-
 function return_io<T>(x: T): IO<T> {
   return function () {
     return x;
@@ -66,7 +62,10 @@ function return_io<T>(x: T): IO<T> {
 function println(s: String_): IO<Unit> {
   return function () {
     console.log(s);
-    return void 0;
+    return {
+      tag: "MkUnit",
+      args: [],
+    };
   };
 }
 

--- a/std/io/print.pol
+++ b/std/io/print.pol
@@ -1,6 +1,6 @@
 use "io.pol"
 use "../prim/string.pol"
-use "../prim/unit.pol"
+use "../data/unit.pol"
 
 /// Print a string to the console, appending a newline.
 extern println(s: String): IO(Unit)

--- a/std/prim/unit.pol
+++ b/std/prim/unit.pol
@@ -1,3 +1,0 @@
-/// An opaque unit type with a single constructor.
-extern Unit: Type
-extern unit: Unit


### PR DESCRIPTION
This removes the `extern Unit` type from the stdlib and replaces it (in `println`) with the `data Unit` type.