### PR TITLE
Add support for CLI arguments

### DIFF
--- a/app/src/cli/run.rs
+++ b/app/src/cli/run.rs
@@ -19,6 +19,10 @@ pub struct Args {
     /// Only output the normal form of main and don't compile.
     #[clap(long, short)]
     normalize: bool,
+
+    /// Arguments to pass to the executed program.
+    #[clap(trailing_var_arg = true)]
+    args: Vec<String>,
 }
 
 pub async fn exec(cmd: Args, settings: &GlobalSettings) -> Result<(), Vec<miette::Report>> {
@@ -35,7 +39,7 @@ pub async fn exec(cmd: Args, settings: &GlobalSettings) -> Result<(), Vec<miette
         codegen::generate_ir(&mut db, &cmd.filepath).await?;
         let js_file = codegen::generate_js(&mut db, &cmd.filepath).await?;
 
-        run_node(&js_file).map_err(|err| vec![NodeFailed { err }.into()])?;
+        run_node(&js_file, &cmd.args).map_err(|err| vec![NodeFailed { err }.into()])?;
     }
 
     Ok(())
@@ -47,8 +51,8 @@ fn print_nf(nf: &polarity_lang_ast::Exp, colorize: ColorChoice) {
     println!();
 }
 
-fn run_node(path: &PathBuf) -> io::Result<()> {
-    let cmd = Command::new("node").arg(path).output()?;
+fn run_node(path: &PathBuf, args: &[String]) -> io::Result<()> {
+    let cmd = Command::new("node").arg(path).args(args).output()?;
     io::stdout().write_all(&cmd.stdout)?;
     io::stderr().write_all(&cmd.stderr)?;
     Ok(())

--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -61,3 +61,18 @@ function read_file(path) {
         }
     };
 }
+function args() {
+    return function () {
+        let args = {
+            tag: "Nil",
+            args: [],
+        };
+        for (const arg of process.argv.slice(2).reverse()) {
+            args = {
+                tag: "Cons",
+                args: [arg, args],
+            };
+        }
+        return args;
+    };
+}

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -9,6 +9,7 @@ type Unit = undefined;
 
 // data
 type Option<T> = { tag: "Some"; args: [T] } | { tag: "None"; args: [] };
+type List<T> = { tag: "Cons"; args: [T, List<T>] } | { tag: "Nil"; args: [] };
 
 // IO
 type IO<T> = () => T;
@@ -84,5 +85,23 @@ function read_file(path: String_): IO<Option<String_>> {
         args: [],
       };
     }
+  };
+}
+
+function args(): IO<List<String_>> {
+  return function () {
+    let args: List<String_> = {
+      tag: "Nil",
+      args: [],
+    };
+
+    for (const arg of process.argv.slice(2).reverse()) {
+      args = {
+        tag: "Cons",
+        args: [arg, args],
+      };
+    }
+
+    return args;
   };
 }

--- a/std/io/env.pol
+++ b/std/io/env.pol
@@ -1,0 +1,6 @@
+use "io.pol"
+use "../data/list.pol"
+use "../prim/string.pol"
+
+/// Collect command-line arguments.
+extern args: IO(List(String))


### PR DESCRIPTION
- Add `args` extern to stdlib and runtime that collects cli arguments into a `List(String)`
- Pass through arguments from `pol run`