### PR TITLE
Replace `println` extern with `print`

### DIFF
--- a/examples/hello_world.pol
+++ b/examples/hello_world.pol
@@ -1,8 +1,7 @@
-extern String: Type
-extern Unit: Type
-
-extern IO(a: Type): Type
-extern println(s: String): IO(Unit)
+use "../std/prim/string.pol"
+use "../std/data/unit.pol"
+use "../std/io/io.pol"
+use "../std/io/print.pol"
 
 let main: IO(Unit) {
     println("Hello, World!")

--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -35,9 +35,9 @@ function return_io(x) {
         return x;
     };
 }
-function println(s) {
+function print(s) {
     return function () {
-        console.log(s);
+        process.stdout.write(s);
         return {
             tag: "MkUnit",
             args: [],

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -60,9 +60,9 @@ function return_io<T>(x: T): IO<T> {
   };
 }
 
-function println(s: String_): IO<Unit> {
+function print(s: String_): IO<Unit> {
   return function () {
-    console.log(s);
+    process.stdout.write(s);
     return {
       tag: "MkUnit",
       args: [],

--- a/lang/backend/runtime/tsconfig.json
+++ b/lang/backend/runtime/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
+    "lib": ["esnext"],
     "types": ["node"],
     "strict": true,
     "outDir": "dist"

--- a/std/io/print.pol
+++ b/std/io/print.pol
@@ -1,6 +1,12 @@
 use "io.pol"
 use "../prim/string.pol"
+use "../prim/char.pol"
 use "../data/unit.pol"
 
+/// Print a string to the console.
+extern print(s: String): IO(Unit)
+
 /// Print a string to the console, appending a newline.
-extern println(s: String): IO(Unit)
+let println(s: String): IO(Unit) {
+    print(append_char('\n', s))
+}


### PR DESCRIPTION
Update the stdlib/runtime to feature `extern print` instead of `extern println`.
Add `let println` as wrapper around `print`.