### PR TITLE
Compile IO to async functions

### DIFF
--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -31,12 +31,12 @@ function $append_char(c, s) {
     return s.concat(String.fromCodePoint(c));
 }
 function $return_io(x) {
-    return function () {
+    return async function () {
         return x;
     };
 }
 function $print(s) {
-    return function () {
+    return async function () {
         process.stdout.write(s);
         return {
             tag: "MkUnit",
@@ -45,7 +45,7 @@ function $print(s) {
     };
 }
 function $read_file(path) {
-    return function () {
+    return async function () {
         try {
             const data = __fs.readFileSync(path, "utf8");
             return {
@@ -62,7 +62,7 @@ function $read_file(path) {
     };
 }
 function $args() {
-    return function () {
+    return async function () {
         let args = {
             tag: "Nil",
             args: [],

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -12,7 +12,7 @@ type Option<T> = { tag: "Some"; args: [T] } | { tag: "None"; args: [] };
 type List<T> = { tag: "Cons"; args: [T, List<T>] } | { tag: "Nil"; args: [] };
 
 // IO
-type IO<T> = () => T;
+type IO<T> = () => Promise<T>;
 
 function $add_i64(x: I64, y: I64): I64 {
   return BigInt.asIntN(64, x + y);
@@ -55,13 +55,13 @@ function $append_char(c: Char, s: String_): String_ {
 }
 
 function $return_io<T>(x: T): IO<T> {
-  return function () {
+  return async function () {
     return x;
   };
 }
 
 function $print(s: String_): IO<Unit> {
-  return function () {
+  return async function () {
     process.stdout.write(s);
     return {
       tag: "MkUnit",
@@ -71,7 +71,7 @@ function $print(s: String_): IO<Unit> {
 }
 
 function $read_file(path: String_): IO<Option<String_>> {
-  return function () {
+  return async function () {
     try {
       const data: String_ = __fs.readFileSync(path, "utf8");
       return {
@@ -88,7 +88,7 @@ function $read_file(path: String_): IO<Option<String_>> {
 }
 
 function $args(): IO<List<String_>> {
-  return function () {
+  return async function () {
     let args: List<String_> = {
       tag: "Nil",
       args: [],

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -2,7 +2,7 @@
 
 use swc_core::common::{DUMMY_SP, SyntaxContext};
 use swc_core::ecma::ast as js;
-use swc_core::quote_expr;
+use swc_core::{quote, quote_expr};
 
 use crate::ir;
 use crate::ir2js::traits::ToJSStmt;
@@ -249,7 +249,7 @@ impl ToJSExpr for ir::LocalMatch {
             cases,
         });
 
-        let thunk = thunk_block(vec![var_decl, switch_stmt]);
+        let thunk = thunk_block(vec![var_decl, switch_stmt], false);
         Ok(force_expr(thunk))
     }
 }
@@ -359,7 +359,7 @@ impl ToJSExpr for ir::DoBlock {
         let mut js_stmts = js_bindings;
         js_stmts.push(js_return_stmt);
 
-        Ok(thunk_block(js_stmts))
+        Ok(thunk_block(js_stmts, true))
     }
 }
 
@@ -378,30 +378,18 @@ impl ToJSExpr for ir::DoBlock {
 /// ```
 impl ToJSStmt for ir::DoBinding {
     fn to_js_stmt(&self) -> BackendResult<js::Stmt> {
-        let var_declarator = match self {
-            ir::DoBinding::Let { name, bound } => js::VarDeclarator {
-                span: DUMMY_SP,
-                name: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(name.to_string()))),
-                init: Some(Box::new(bound.to_js_expr()?)),
-                definite: false,
-            },
-            ir::DoBinding::Bind { name, bound } => js::VarDeclarator {
-                span: DUMMY_SP,
-                name: js::Pat::Ident(js::BindingIdent::from(js::Ident::from(name.to_string()))),
-                init: Some(Box::new(force_expr(bound.to_js_expr()?))),
-                definite: false,
-            },
-        };
-
-        let var_decl = js::VarDecl {
-            span: DUMMY_SP,
-            ctxt: SyntaxContext::empty(),
-            kind: js::VarDeclKind::Const,
-            declare: false,
-            decls: vec![var_declarator],
-        };
-
-        Ok(js::Stmt::Decl(js::Decl::Var(Box::new(var_decl))))
+        match self {
+            ir::DoBinding::Let { name, bound } => {
+                let x: js::Ident = name.to_string().into();
+                let e: js::Expr = bound.to_js_expr()?;
+                Ok(quote!("const $x = $e;" as Stmt, x: Ident = x, e: Expr = e))
+            }
+            ir::DoBinding::Bind { name, bound } => {
+                let x: js::Ident = name.to_string().into();
+                let e: js::Expr = bound.to_js_expr()?;
+                Ok(quote!("const $x = await $e();" as Stmt, x: Ident = x, e: Expr = e))
+            }
+        }
     }
 }
 

--- a/lang/backend/src/ir2js/util.rs
+++ b/lang/backend/src/ir2js/util.rs
@@ -18,7 +18,7 @@ pub fn force_expr(e: js::Expr) -> js::Expr {
 }
 
 /// Wrap expression in a thunk
-pub fn thunk_block(block: Vec<js::Stmt>) -> js::Expr {
+pub fn thunk_block(block: Vec<js::Stmt>, is_async: bool) -> js::Expr {
     let arr = js::Expr::Arrow(js::ArrowExpr {
         span: DUMMY_SP,
         ctxt: SyntaxContext::empty(),
@@ -28,7 +28,7 @@ pub fn thunk_block(block: Vec<js::Stmt>) -> js::Expr {
             ctxt: SyntaxContext::empty(),
             stmts: block,
         })),
-        is_async: false,
+        is_async,
         is_generator: false,
         type_params: None,
         return_type: None,


### PR DESCRIPTION
Compile Polarity's IO to async thunks in JS.
This allows us to make use of async APIs (like `readline`).