### PR TITLE
Prefix extern calls in JS

### DIFF
--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -1,41 +1,41 @@
 "use strict";
 const __fs = require("node:fs");
-function add_i64(x, y) {
+function $add_i64(x, y) {
     return BigInt.asIntN(64, x + y);
 }
-function sub_i64(x, y) {
+function $sub_i64(x, y) {
     return BigInt.asIntN(64, x - y);
 }
-function mul_i64(x, y) {
+function $mul_i64(x, y) {
     return BigInt.asIntN(64, x * y);
 }
-function div_i64(x, y) {
+function $div_i64(x, y) {
     return BigInt.asIntN(64, x / y);
 }
-function add_f64(x, y) {
+function $add_f64(x, y) {
     return x + y;
 }
-function sub_f64(x, y) {
+function $sub_f64(x, y) {
     return x - y;
 }
-function mul_f64(x, y) {
+function $mul_f64(x, y) {
     return x * y;
 }
-function div_f64(x, y) {
+function $div_f64(x, y) {
     return x / y;
 }
-function concat(s1, s2) {
+function $concat(s1, s2) {
     return s1.concat(s2);
 }
-function append_char(c, s) {
+function $append_char(c, s) {
     return s.concat(String.fromCodePoint(c));
 }
-function return_io(x) {
+function $return_io(x) {
     return function () {
         return x;
     };
 }
-function print(s) {
+function $print(s) {
     return function () {
         process.stdout.write(s);
         return {
@@ -44,7 +44,7 @@ function print(s) {
         };
     };
 }
-function read_file(path) {
+function $read_file(path) {
     return function () {
         try {
             const data = __fs.readFileSync(path, "utf8");
@@ -61,7 +61,7 @@ function read_file(path) {
         }
     };
 }
-function args() {
+function $args() {
     return function () {
         let args = {
             tag: "Nil",

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -14,53 +14,53 @@ type List<T> = { tag: "Cons"; args: [T, List<T>] } | { tag: "Nil"; args: [] };
 // IO
 type IO<T> = () => T;
 
-function add_i64(x: I64, y: I64): I64 {
+function $add_i64(x: I64, y: I64): I64 {
   return BigInt.asIntN(64, x + y);
 }
 
-function sub_i64(x: I64, y: I64): I64 {
+function $sub_i64(x: I64, y: I64): I64 {
   return BigInt.asIntN(64, x - y);
 }
 
-function mul_i64(x: I64, y: I64): I64 {
+function $mul_i64(x: I64, y: I64): I64 {
   return BigInt.asIntN(64, x * y);
 }
 
-function div_i64(x: I64, y: I64): I64 {
+function $div_i64(x: I64, y: I64): I64 {
   return BigInt.asIntN(64, x / y);
 }
 
-function add_f64(x: F64, y: F64): F64 {
+function $add_f64(x: F64, y: F64): F64 {
   return x + y;
 }
 
-function sub_f64(x: F64, y: F64): F64 {
+function $sub_f64(x: F64, y: F64): F64 {
   return x - y;
 }
 
-function mul_f64(x: F64, y: F64): F64 {
+function $mul_f64(x: F64, y: F64): F64 {
   return x * y;
 }
 
-function div_f64(x: F64, y: F64): F64 {
+function $div_f64(x: F64, y: F64): F64 {
   return x / y;
 }
 
-function concat(s1: String_, s2: String_): String_ {
+function $concat(s1: String_, s2: String_): String_ {
   return s1.concat(s2);
 }
 
-function append_char(c: Char, s: String_): String_ {
+function $append_char(c: Char, s: String_): String_ {
   return s.concat(String.fromCodePoint(c));
 }
 
-function return_io<T>(x: T): IO<T> {
+function $return_io<T>(x: T): IO<T> {
   return function () {
     return x;
   };
 }
 
-function print(s: String_): IO<Unit> {
+function $print(s: String_): IO<Unit> {
   return function () {
     process.stdout.write(s);
     return {
@@ -70,7 +70,7 @@ function print(s: String_): IO<Unit> {
   };
 }
 
-function read_file(path: String_): IO<Option<String_>> {
+function $read_file(path: String_): IO<Option<String_>> {
   return function () {
     try {
       const data: String_ = __fs.readFileSync(path, "utf8");
@@ -87,7 +87,7 @@ function read_file(path: String_): IO<Option<String_>> {
   };
 }
 
-function args(): IO<List<String_>> {
+function $args(): IO<List<String_>> {
   return function () {
     let args: List<String_> = {
       tag: "Nil",

--- a/lang/backend/src/ir/exprs.rs
+++ b/lang/backend/src/ir/exprs.rs
@@ -62,7 +62,7 @@ impl Rename for Exp {
             Exp::CtorCall(call) => call.rename(ctx),
             Exp::CodefCall(call) => call.rename(ctx),
             Exp::LetCall(call) => call.rename(ctx),
-            Exp::ExternCall(call) => call.rename(ctx),
+            Exp::ExternCall(call) => call.args.rename(ctx),
             Exp::DtorCall(dot_call) => dot_call.rename(ctx),
             Exp::DefCall(dot_call) => dot_call.rename(ctx),
             Exp::LocalMatch(local_match) => local_match.rename(ctx),

--- a/lang/backend/src/ir2js/exprs.rs
+++ b/lang/backend/src/ir2js/exprs.rs
@@ -19,7 +19,7 @@ impl ToJSExpr for ir::Exp {
             ir::Exp::CtorCall(call) => call.to_js_ctor_record(),
             ir::Exp::CodefCall(call) => call.to_js_function_call(),
             ir::Exp::LetCall(call) => call.to_js_function_call(),
-            ir::Exp::ExternCall(call) => call.to_js_function_call(),
+            ir::Exp::ExternCall(call) => call.to_js_extern_function_call(),
             ir::Exp::DtorCall(dot_call) => dot_call.to_js_record_member_call(),
             ir::Exp::DefCall(dot_call) => dot_call.to_js_function_call_with_self(),
             ir::Exp::LocalMatch(local_match) => local_match.to_js_expr(),
@@ -100,6 +100,30 @@ impl ir::Call {
             span: DUMMY_SP,
             ctxt: SyntaxContext::empty(),
             callee: js::Callee::Expr(Box::new(js::Expr::Ident(name.to_string().into()))),
+            args,
+            type_args: None,
+        }))
+    }
+
+    /// Input:
+    ///
+    /// ```text
+    /// f(x, y)
+    /// ```
+    ///
+    /// Output:
+    ///
+    /// ```js
+    /// $f(〚 x, y 〛)
+    /// ```
+    fn to_js_extern_function_call(&self) -> BackendResult<js::Expr> {
+        let Self { name, module_uri: _, args } = self;
+        let args = args_to_js_exprs(args)?;
+
+        Ok(js::Expr::Call(js::CallExpr {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            callee: js::Callee::Expr(Box::new(js::Expr::Ident(format!("${name}").into()))),
             args,
             type_args: None,
         }))


### PR DESCRIPTION
Since `extern` calls cannot be renamed, prefix them in JS with `$` to avoid name collisions.