### PR TITLE
Rename `concat_string` and add infix operator

### DIFF
--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -24,7 +24,7 @@ function $mul_f64(x, y) {
 function $div_f64(x, y) {
     return x / y;
 }
-function $concat(s1, s2) {
+function $concat_string(s1, s2) {
     return s1.concat(s2);
 }
 function $append_char(c, s) {

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -46,7 +46,7 @@ function $div_f64(x: F64, y: F64): F64 {
   return x / y;
 }
 
-function $concat(s1: String_, s2: String_): String_ {
+function $concat_string(s1: String_, s2: String_): String_ {
   return s1.concat(s2);
 }
 

--- a/std/prim/string.pol
+++ b/std/prim/string.pol
@@ -4,7 +4,9 @@ use "./char.pol"
 extern String: Type
 
 /// Concatenation of two strings.
-extern concat(x y: String): String
+extern concat_string(x y: String): String
+
+infix _ ++ _ := concat_string(_, _)
 
 /// Appending a single unicode character to a string.
 extern append_char(c: Char, s: String): String

--- a/test/suites/success/048-string-char.ir.expected
+++ b/test/suites/success/048-string-char.ir.expected
@@ -1,1 +1,4 @@
-let main { append_char('!', concat("Hello", ", World")) }
+use "../../../std/prim/string.pol"
+use "../../../std/prim/char.pol"
+
+let main { append_char('!', concat_string("Hello", ", World")) }

--- a/test/suites/success/048-string-char.pol
+++ b/test/suites/success/048-string-char.pol
@@ -1,8 +1,6 @@
-extern Char: Type
-extern String: Type
-extern concat(x y: String): String
-extern append_char(c: Char, s: String): String
+use "../../../std/prim/string.pol"
+use "../../../std/prim/char.pol"
 
 let main: String {
-	append_char('!', concat("Hello", ", World"))
+	append_char('!', "Hello" ++ ", World")
 }


### PR DESCRIPTION
To avoid the naming clash with `List.concat`, rename the string extern `concat` to `concat_string`.
Also, add an infix operator `++` that desugars to `concat_string`.