### PR TITLE
Compile to ECMAScript Module

### DIFF
--- a/lang/backend/runtime/dist/runtime.js
+++ b/lang/backend/runtime/dist/runtime.js
@@ -1,5 +1,4 @@
-"use strict";
-const __fs = require("node:fs");
+import * as __fs from "node:fs";
 function $add_i64(x, y) {
     return BigInt.asIntN(64, x + y);
 }

--- a/lang/backend/runtime/runtime.ts
+++ b/lang/backend/runtime/runtime.ts
@@ -1,4 +1,4 @@
-const __fs = require("node:fs");
+import * as __fs from "node:fs";
 
 // primitives
 type I64 = bigint;

--- a/lang/backend/src/ir2js/mod.rs
+++ b/lang/backend/src/ir2js/mod.rs
@@ -32,7 +32,7 @@ impl CallToMain {
     fn generated_call(&self) -> Option<js::Stmt> {
         match self {
             CallToMain::None => None,
-            CallToMain::RunIO => Some(quote!("main()()" as Stmt)),
+            CallToMain::RunIO => Some(quote!("await main()();" as Stmt)),
             CallToMain::DebugPrint => Some(quote!(
                 "console.log(JSON.stringify(main(), (k, v) => typeof v == \"bigint\" ? v.toString() : v))"
                     as Stmt


### PR DESCRIPTION
Previously, we compiled to Node.js using CommonJS modules.
Modern ESM brings features like top-level `await` and stricter naming rules.